### PR TITLE
feat: smarter Archivist classification + lifecycle hooksFeat/smarter archivist

### DIFF
--- a/docs/creating-stacklets.md
+++ b/docs/creating-stacklets.md
@@ -137,8 +137,9 @@ stacklets/myapp/
   hooks/
     on_configure.py       # first-run config (interactive prompts)
     on_install.sh         # first-run setup (install dependencies)
+    on_start.py           # every stack up, before compose (config validation)
     on_install_success.py # after first successful health check
-    on_start.py           # every stack up (create accounts, etc.)
+    on_start_ready.py     # every stack up, after health checks (seed data, sync accounts)
     on_stop.sh            # every stack down
     on_destroy.sh         # full teardown
 ```

--- a/docs/stack-reference.md
+++ b/docs/stack-reference.md
@@ -24,7 +24,8 @@ stacklets/photos/
     on_configure.py      ← first run: interactive prompts
     on_install.py        ← first run: create dirs, install deps
     on_install_success.py← first run: obtain tokens, seed data
-    on_start.py          ← every up: start native services
+    on_start.py          ← every up: validate config, start native services (before containers)
+    on_start_ready.py    ← every up: seed data, sync accounts (after health checks)
     on_stop.py           ← every down: stop native services
     on_destroy.py        ← teardown: remove native services
   cli/
@@ -43,7 +44,8 @@ there, it's used. If it's not, it's skipped. Hooks can be `.py`
 | `hooks/on_configure` | Once on first `stack up` | Interactive prompts (API keys, server names) |
 | `hooks/on_install` | Once on first `stack up` | Create directories, install native deps |
 | `hooks/on_install_success` | Once after first healthy start | Obtain tokens, seed data |
-| `hooks/on_start` | Every `stack up` | Start native services |
+| `hooks/on_start` | Every `stack up`, before containers | Validate config, start native services |
+| `hooks/on_start_ready` | Every `stack up`, after health checks | Seed data, sync accounts (service is healthy) |
 | `hooks/on_stop` | Every `stack down` | Stop native services |
 | `hooks/on_destroy` | On `stack destroy` | Remove native services |
 | `cli/*.py` | On demand via `stack <id> <command>` | Stacklet-specific CLI commands |
@@ -307,8 +309,9 @@ effect.
 10. Wait for health check
 11. First run only:
     a. hooks/on_install_success.py — obtain tokens, seed data
-12. Reload Caddy (domain mode)
-13. Show welcome screen with URL, login, hints
+12. hooks/on_start_ready.py — service is healthy, seed data, sync accounts
+13. Reload Caddy (domain mode)
+14. Show welcome screen with URL, login, hints
 ```
 
 **First run detection:** `.famstack/{id}.setup-done` marker. Absent
@@ -360,8 +363,8 @@ the step is skipped. No registration needed.
 ```
 First stack up:
 
-  on_configure ──► on_install ──► on_start ──► health ──► on_install_success
-  (config gate)    (system)       (services)   (wait)     (API work)
+  on_configure ──► on_install ──► on_start ──► health ──► on_install_success ──► on_start_ready
+  (config gate)    (system)       (services)   (wait)     (first-run API work)   (every-up API work)
 
 on_configure is the gate: it collects all required settings (provider
 choice, API keys, server names) and persists them to stack.toml or
@@ -371,8 +374,8 @@ that on_configure wrote and acts on it. Both hooks should be idempotent.
 
 Subsequent stack up:
 
-  on_start
-  (services)
+  on_start ──► health ──► on_start_ready
+  (services)   (wait)     (API work)
 
 stack down:
 
@@ -389,8 +392,9 @@ stack destroy:
 |---|---|---|
 | `on_configure` | Once | **Config gate.** Collects all required configuration via interactive prompts and writes it to `stack.toml` or `secrets.toml`. Must be idempotent — if it set some config values but the process was interrupted, the next run should detect what's already set and only ask for what's missing. `on_install` only proceeds when `on_configure` completes without error. |
 | `on_install` | Once | **System setup.** Create directories, install native software, build from source. Should be idempotent — check whether each step was already done before doing it again (e.g. `brew list omlx` before `brew install omlx`, check if binary exists before building). |
-| `on_install_success` | Once | Obtain API tokens, seed data, create accounts. Requires a running service. |
-| `on_start` | Every up | **Validate config first**, then start native services. If required config is missing or invalid, raise with a clear message telling the user how to fix it. The framework stops the pipeline on failure — containers won't start. |
+| `on_install_success` | Once | Obtain API tokens, seed initial data, create accounts. Runs after first healthy start. |
+| `on_start` | Every up | **Runs before containers start.** Validate config, start native services. If required config is missing or invalid, raise with a clear message — the framework stops the pipeline and containers won't start. |
+| `on_start_ready` | Every up | **Runs after health checks pass.** The service is healthy and accepting API calls. Seed data, sync accounts, anything that needs the service running. Must be idempotent. |
 | `on_stop` | Every down | Stop native services. Only stops services we manage (.state/ markers). |
 | `on_destroy` | Once | Remove native services entirely (unload plists, uninstall). |
 

--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -259,6 +259,19 @@ class CLI:
             self.stack.run_on_install_success(
                 stacklet_id, step_fn=self.stack.output.step)
 
+        # on_start_ready: runs every up, after health checks pass.
+        # The service is healthy and accepting API calls. Use this for
+        # seeding data, syncing accounts, or anything that needs the
+        # service running. Idempotent hooks only.
+        from .hooks import HookResolver, build_hook_ctx
+        ready_resolver = HookResolver(stacklet_dir)
+        if ready_resolver.resolve("on_start_ready"):
+            ready_ctx = build_hook_ctx(
+                stacklet_id, env=env_dict,
+                step_fn=self.stack.output.step, stack=self.stack,
+            )
+            ready_resolver.run("on_start_ready", ready_ctx)
+
         result["name"] = stacklet.get("name", stacklet_id)
         result["port"] = stacklet.get("port")
         result["description"] = stacklet.get("description", "")
@@ -681,21 +694,13 @@ def handle_logs(stck, args):
 
 
 def handle_restart(stck, args):
-    try:
-        stck.refresh_env(args.stacklet)
-    except ValueError:
-        pass
-    stacklet = stck._find_stacklet(args.stacklet)
-    if not stacklet:
-        print_error({"error": f"'{args.stacklet}' not found"}); sys.exit(1)
-    compose_file = docker.find_compose_file(Path(stacklet["path"]))
-    if compose_file:
-        docker.compose(compose_file, "down")
-        code, _, stderr = docker.compose(compose_file, "up", "-d")
-        if code == 0:
-            print(f"  {GREEN}✓{RESET} {args.stacklet}: restarted")
-        else:
-            print_error({"error": stderr.strip()}); sys.exit(1)
+    cli = CLI(stck)
+    cli.down(args.stacklet)
+    result = cli.up(args.stacklet)
+    if "error" in result:
+        print_error(result); sys.exit(1)
+    else:
+        print_up_success(result, stck)
 
 
 def handle_setup(stck, args):

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -47,6 +47,7 @@ from nio import (
     RoomMessageText,
 )
 
+from matching import fuzzy_match_entity, match_persons, deduplicate_hashtags, MAX_TITLE_LENGTH
 from microbot import MicroBot
 from stack import resolve_model
 
@@ -103,6 +104,7 @@ class LLMModelNotFoundError(Exception):
 
 class LLMTimeoutError(Exception):
     """LLM took too long — large documents or cold model start can cause this."""
+
 
 
 # ── Translations ─────────────────────────────────────────────────────────────
@@ -343,11 +345,33 @@ class ArchivistBot(MicroBot):
                 return {c["name"]: c["id"] for c in (await resp.json()).get("results", [])}
             return {}
 
+    # ── Paperless entity creation ──────────────────────────────────────
+    #
+    # When creating new tags, doc types, or correspondents, we configure
+    # Paperless's built-in matching so future documents get auto-assigned
+    # even without the LLM. Paperless matching_algorithm values:
+    #
+    #   1 = any word    "ADAC" matches if ANY word in the doc matches
+    #   2 = all words   all words must appear
+    #   3 = exact        exact string match
+    #   4 = regex
+    #   5 = fuzzy        Paperless's own fuzzy matching (handles typos)
+    #   6 = auto         Paperless learns from manual assignments
+    #
+    # We use algorithm 6 (auto) as the default. Paperless learns matching
+    # patterns from the documents the Archivist assigns. Over time it can
+    # auto-assign without LLM help -- a safety net if the LLM is unavailable.
+
     async def _paperless_create_tag(self, name: str, color: str = "#9e9e9e") -> int | None:
         async with self._http.post(
             f"{self.paperless_url}/api/tags/",
             headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={"name": name, "color": color},
+            json={
+                "name": name,
+                "color": color,
+                "matching_algorithm": 6,
+                "is_insensitive": True,
+            },
         ) as resp:
             if resp.status == 201:
                 data = await resp.json()
@@ -359,17 +383,28 @@ class ArchivistBot(MicroBot):
         async with self._http.post(
             f"{self.paperless_url}/api/document_types/",
             headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={"name": name},
+            json={
+                "name": name,
+                "matching_algorithm": 6,
+                "is_insensitive": True,
+            },
         ) as resp:
             if resp.status == 201:
                 return (await resp.json())["id"]
             return None
 
     async def _paperless_create_correspondent(self, name: str) -> int | None:
+        # matching_algorithm 0 (none): don't let Paperless auto-assign
+        # correspondents. The LLM reads the document and decides who sent
+        # it. Paperless's auto-learn (6) guesses wrong with few samples
+        # (e.g. assigns the first correspondent to every new document).
         async with self._http.post(
             f"{self.paperless_url}/api/correspondents/",
             headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={"name": name},
+            json={
+                "name": name,
+                "matching_algorithm": 0,
+            },
         ) as resp:
             if resp.status == 201:
                 return (await resp.json())["id"]
@@ -454,37 +489,64 @@ class ArchivistBot(MicroBot):
     async def _classify(self, ocr_text: str, tags: dict, doc_types: dict, correspondents: dict) -> dict:
         """Ask the LLM to classify a document based on its OCR text.
 
-        The prompt gives the LLM the list of existing tags, document types,
-        and correspondents from Paperless so it picks from known values when
-        possible. If nothing fits, it can suggest new ones — the archivist
-        creates them automatically. Returns structured JSON metadata.
+        The prompt focuses on three things that matter:
+        - topic tag: what is this document about (Insurance, Shopping, Medical)
+        - person: which family member does this belong to
+        - correspondent: who sent/issued this document
+
+        document_type is optional -- Paperless learns it over time via
+        matching_algorithm=6 (auto). We don't force the LLM to distinguish
+        "topic" from "format" because even humans find that confusing.
         """
         person_tags = [t for t in tags if t.startswith("Person: ")]
+        # Strip "Person: " prefix for the prompt so the LLM sees clean
+        # first names like "Homer", "Marge" -- not "Person: Homer".
+        person_names = [t.replace("Person: ", "") for t in person_tags]
         category_tags = [t for t in tags if not t.startswith("Person: ")]
         truncated = ocr_text[:3000]
+
+        # ── Classification prompt ────────────────────────────────────────
+        #
+        # Simplified to three clear axes:
+        #   topic         = what is this about?   "Insurance", "Shopping"
+        #   person        = which family member?   "Homer", "Bart", or null
+        #   correspondent = who sent it?           "Springfield Nuclear", "Kwik-E-Mart"
+        #
+        # A Kwik-E-Mart receipt for Homer:
+        #   topic="Shopping", person="Homer", correspondent="Kwik-E-Mart"
+        # A school letter about Bart:
+        #   topic="School", person="Bart", correspondent="Springfield Elementary"
 
         prompt = f"""Classify this document. Return ONLY a JSON object.
 
 IMPORTANT: Always prefer existing values from the lists below. Only suggest
-a new value when NOTHING in the list is a reasonable match. For example,
-if "Finanzamt" exists and the document is from "Finanzamt Friedrichshafen",
-use the existing "Finanzamt" — don't create a new entry.
+a new value when NOTHING in the list is a reasonable match.
 
-Existing categories: {json.dumps(category_tags, ensure_ascii=False)}
-Existing persons: {json.dumps(person_tags, ensure_ascii=False)}
+Family members: {json.dumps(person_names, ensure_ascii=False)}
+Existing topic tags: {json.dumps(category_tags, ensure_ascii=False)}
 Existing document types: {json.dumps(list(doc_types.keys()), ensure_ascii=False)}
 Existing correspondents: {json.dumps(list(correspondents.keys()), ensure_ascii=False)}
 
 Return this exact JSON structure:
 {{
-  "title": "short descriptive title in the document's language",
+  "title": "scannable title: [Correspondent] - [what] [key amount]. E.g. 'Anthropic - Max Plan EUR 90.00', 'ADAC - Kfz-Versicherung 2026 EUR 340'. Must be useful when scanning a list of 500 documents. Max 128 chars. Document's language.",
   "date": "YYYY-MM-DD or null",
-  "category": "pick from existing categories, or suggest a new one only if nothing fits",
-  "person": "pick from existing persons when possible, or null if no person is relevant",
-  "document_type": "pick from existing types, or suggest a new one only if nothing fits",
-  "correspondent": "pick from existing correspondents, or the actual sender if truly new",
-  "summary": "2-3 sentence summary with key facts: amounts, dates, names, deadlines"
+  "topic": "what is this document about? The subject area. E.g. Shopping, Insurance, Subscription, Medical, School, Finance, Home, Vehicle, Legal. Pick from existing topic tags when possible.",
+  "persons": ["which family members does this belong to? Pick from the family members list by first name. Can be multiple for joint documents (marriage, family insurance). Empty list if unclear. These are who the document is FOR or ABOUT, not who sent it."],
+  "document_type": "optional: what format is this? Invoice, Receipt, Contract, Letter, Certificate, or null if unclear.",
+  "correspondent": "the SENDER or ISSUING ORGANIZATION. Who wrote or sent this? NOT the recipient. On an invoice, this is the company that billed, not the customer. Use the shortest recognizable name.",
+  "summary": "2-3 sentence summary with key facts: amounts, dates, names, deadlines",
+  "facts": ["key structured facts, e.g. 'Total: EUR 90.00', 'Invoice: #12345', 'Plan: Premium'"],
+  "action_items": [{{"action": "what needs to happen", "due": "YYYY-MM-DD or null"}}]
 }}
+
+Rules:
+- LANGUAGE: use the document's original language for title, summary, facts, and action_items. A German document gets a German title and German facts. Never translate.
+- persons: match by first name from the family members list. Can be multiple for joint documents. A marriage certificate for Homer and Marge: ["Homer", "Marge"]. A personal invoice for Homer only: ["Homer"].
+- correspondent: always the SENDER, never the addressee/customer/recipient.
+- topic: the subject, not the document format. An invoice from a shop is topic "Shopping", not "Invoice". An invoice for insurance is topic "Insurance", not "Invoice". Use the document's language for new topic tags too.
+- facts: concrete numbers, dates, account numbers, amounts. Empty list if none.
+- action_items: deadlines, payments due, forms to return. Empty list if none.
 
 Document text:
 ---
@@ -610,58 +672,93 @@ OCR text:
             await self._send(room_id, self.t("classify_failed", name=display_name, link=link), reply_to)
             return
 
-        # Apply classification
+        # Apply classification.
+        # resolved_* vars track the matched Paperless names (not raw LLM output)
+        # so hashtags in the summary show what was actually applied.
         updates = {}
         summary = []
         created_new = []
 
         title = classification.get("title")
         if title and isinstance(title, str):
-            updates["title"] = title
+            updates["title"] = title[:MAX_TITLE_LENGTH]
 
+        # ── Topic tag ────────────────────────────────────────────────────
+        # Match against category_tags only (excludes "Person: " tags) to
+        # prevent "Personal" or "Persona" from colliding with person names.
         tag_ids = list(doc.get("tags", []))
-        category = classification.get("category")
-        if category and isinstance(category, str):
-            if category in tags:
-                tag_ids.append(tags[category])
-                summary.append(self.t("category", value=category))
+        category_tags_dict = {t: tags[t] for t in tags if not t.startswith("Person: ")}
+        resolved_topic = None
+        topic = classification.get("topic")
+        if topic and isinstance(topic, str):
+            matched = fuzzy_match_entity(topic, category_tags_dict)
+            if matched:
+                tag_ids.append(tags[matched])
+                resolved_topic = matched
+                summary.append(self.t("category", value=matched))
             else:
-                new_id = await self._paperless_create_tag(category, "#4caf50")
+                new_id = await self._paperless_create_tag(topic, "#4caf50")
                 if new_id:
                     tag_ids.append(new_id)
-                    summary.append(self.t("category_new", value=category))
-                    created_new.append(f"tag \"{category}\"")
+                    resolved_topic = topic
+                    summary.append(self.t("category_new", value=topic))
+                    created_new.append(f"tag \"{topic}\"")
 
-        # Person tags — only match existing, never create
-        person = classification.get("person")
-        if person and isinstance(person, str) and person in tags:
-            tag_ids.append(tags[person])
-            summary.append(self.t("person", value=person.replace("Person: ", "")))
+        # ── Person tags -- closed set, never create ──────────────────────
+        # LLM returns "Homer" or ["Homer", "Marge"] for joint documents.
+        # match_persons handles strings, lists, full names, prefixed forms.
+        resolved_persons = []
+        persons_raw = classification.get("persons") or classification.get("person")
+        person_tags_matched = match_persons(persons_raw, tags)
+        for pt in person_tags_matched:
+            tag_ids.append(tags[pt])
+            name = pt.replace("Person: ", "")
+            resolved_persons.append(name)
+            summary.append(self.t("person", value=name))
 
         if tag_ids:
             updates["tags"] = list(set(tag_ids))
 
+        # ── Document type ───────────────────────────────────────────────
+        # Respect existing: if Homer manually set the type, don't overwrite.
+        resolved_type = None
         doc_type = classification.get("document_type")
-        if doc_type and isinstance(doc_type, str):
-            if doc_type in doc_types:
-                updates["document_type"] = doc_types[doc_type]
+        if doc_type and isinstance(doc_type, str) and doc_type.lower() != "null":
+            existing_type = doc.get("document_type")
+            if existing_type:
                 summary.append(self.t("type", value=doc_type))
             else:
-                new_id = await self._paperless_create_doc_type(doc_type)
-                if new_id:
-                    updates["document_type"] = new_id
-                    summary.append(self.t("type_new", value=doc_type))
-                    created_new.append(f"document type \"{doc_type}\"")
+                matched = fuzzy_match_entity(doc_type, doc_types)
+                if matched:
+                    updates["document_type"] = doc_types[matched]
+                    resolved_type = matched
+                    summary.append(self.t("type", value=matched))
+                else:
+                    new_id = await self._paperless_create_doc_type(doc_type)
+                    if new_id:
+                        updates["document_type"] = new_id
+                        resolved_type = doc_type
+                        summary.append(self.t("type_new", value=doc_type))
+                        created_new.append(f"document type \"{doc_type}\"")
 
+        # ── Correspondent ───────────────────────────────────────────────
+        # Always overwrite. Paperless's auto-classifier (matching_algorithm 6)
+        # may have guessed wrong with limited training data -- e.g. assigning
+        # "Denny Gunawan" to all documents because it was the first correspondent
+        # created. The LLM reads the actual document text and knows better.
+        resolved_correspondent = None
         correspondent = classification.get("correspondent")
         if correspondent and isinstance(correspondent, str):
-            if correspondent in correspondents:
-                updates["correspondent"] = correspondents[correspondent]
-                summary.append(self.t("from", value=correspondent))
+            matched = fuzzy_match_entity(correspondent, correspondents)
+            if matched:
+                updates["correspondent"] = correspondents[matched]
+                resolved_correspondent = matched
+                summary.append(self.t("from", value=matched))
             else:
                 new_id = await self._paperless_create_correspondent(correspondent)
                 if new_id:
                     updates["correspondent"] = new_id
+                    resolved_correspondent = correspondent
                     summary.append(self.t("from_new", value=correspondent))
                     created_new.append(f"correspondent \"{correspondent}\"")
 
@@ -683,31 +780,61 @@ OCR text:
             else:
                 reformat_failed = True
 
-        # Build summary message
-        doc_summary = classification.get("summary", "")
+        # ── Build chat summary ───────────────────────────────────────────
+        #
+        # Layout optimized for scanning in Element:
+        #
+        #   Filed: Cursor - Pro Subscription USD 192.00 (#10)
+        #
+        #   Subscription | Invoice | Cursor | 2025-03-27
+        #
+        #   Summary text from LLM...
+        #
+        #   - Invoice number: 4182A976 0001
+        #   - Amount due: USD 192.00
+        #
+        #   Payment of USD 192.00 due (due 2025-03-27)
+        #
+        #   #Subscription #Cursor
+        #   http://...
+
         display_title = title or display_name
-        lines = [self.t("filed", title=display_title, doc_id=doc_id), ""]
+        lines = [self.t("filed", title=display_title, doc_id=doc_id)]
 
-        if summary:
-            for s in summary:
-                lines.append(f"  {s}")
-        else:
-            lines.append(f"  {self.t('no_classification')}")
+        # Compact metadata line: topic | type | from | date
+        # Separated by pipes for scannability instead of dense "Key: Value" pairs.
+        meta_parts = []
+        for s in summary:
+            # Strip "Category: ", "Type: ", "From: ", "Date: " prefixes
+            # to keep just the values for the compact line.
+            value = s.split(": ", 1)[-1] if ": " in s else s
+            meta_parts.append(value)
+        if meta_parts:
+            lines.extend(["", "  " + " | ".join(meta_parts)])
 
+        doc_summary = classification.get("summary", "")
         if doc_summary and isinstance(doc_summary, str):
             lines.extend(["", f"  {doc_summary}"])
 
-        tag_keywords = []
-        if category:
-            tag_keywords.append(f"#{category}")
-        if person and isinstance(person, str):
-            tag_keywords.append(f"#{person.replace('Person: ', '')}")
-        if doc_type:
-            tag_keywords.append(f"#{doc_type}")
-        if correspondent:
-            tag_keywords.append(f"#{correspondent}")
-        if tag_keywords:
-            lines.extend(["", "  " + " ".join(tag_keywords)])
+        # Facts as bullet points
+        facts = classification.get("facts", [])
+        if facts and isinstance(facts, list):
+            fact_lines = [f for f in facts if isinstance(f, str) and f.strip()]
+            if fact_lines:
+                lines.append("")
+                for f in fact_lines[:5]:
+                    lines.append(f"  - {f}")
+
+        # Action items with due dates
+        action_items = classification.get("action_items", [])
+        if action_items and isinstance(action_items, list):
+            valid_actions = [a for a in action_items if isinstance(a, dict) and a.get("action")]
+            if valid_actions:
+                lines.append("")
+                for a in valid_actions[:3]:
+                    due = a.get("due", "")
+                    due_str = f" (due {due})" if due else ""
+                    lines.append(f"  {a['action']}{due_str}")
 
         if created_new:
             lines.extend(["", f"  {self.t('new_in_paperless', items=', '.join(created_new))}"])

--- a/stacklets/docs/bot/matching.py
+++ b/stacklets/docs/bot/matching.py
@@ -1,0 +1,252 @@
+"""Entity matching for Paperless-ngx.
+
+Pure functions for matching LLM-returned entity names against existing
+Paperless entries (correspondents, tags, document types). No dependencies
+on aiohttp, Matrix, or any I/O -- these are unit-testable string operations.
+
+The problem:
+  LLM says "Kwik-E-Mart Inc."     -> Paperless has "Kwik-E-Mart"                  -> duplicate!
+  LLM says "Springfield Nuclear"   -> Paperless has "Springfield Nuclear Power Plant" -> duplicate!
+  LLM says "Burns Industries LLC"  -> Paperless has "Burns Industries"             -> duplicate!
+
+fuzzy_match_entity catches these before the Archivist creates a new entry.
+
+Two matching strategies:
+  1. Case-insensitive exact match
+  2. Word-boundary containment (token prefix matching)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Paperless limits titles to 128 characters.
+MAX_TITLE_LENGTH = 128
+
+# Split on whitespace and common entity-name punctuation (hyphens, dots,
+# apostrophes, commas) so "Kwik-E-Mart" becomes ["kwik", "e", "mart"] and
+# "Moe's" becomes ["moe", "s"]. This lets word-boundary checks work on
+# hyphenated and possessive names.
+_WORD_SPLIT = re.compile(r"[\s\-.,/']+")
+
+
+def _tokenize(name: str) -> list[str]:
+    """Split a name into lowercase word tokens.
+
+    >>> _tokenize("Kwik-E-Mart Inc.")
+    ['kwik', 'e', 'mart', 'inc']
+    >>> _tokenize("Moe's Tavern")
+    ['moe', 's', 'tavern']
+    >>> _tokenize("ADAC e.V.")
+    ['adac', 'e', 'v']
+    """
+    return [t for t in _WORD_SPLIT.split(name.lower().strip()) if t]
+
+
+def _is_word_boundary_match(shorter: str, longer: str) -> bool:
+    """Check if `shorter` appears in `longer` at a word boundary.
+
+    Safe:
+      "Springfield" in "Springfield Nuclear Power Plant"  -> True
+      "ADAC"        in "ADAC e.V."                        -> True
+
+    Blocked:
+      "Spring"      in "Springfield"     -> False (mid-word)
+      "Bank"        in "Bundesbank"      -> False (mid-word)
+      "Art"         in "Arthur"          -> False (mid-word)
+
+    >>> _is_word_boundary_match("Springfield", "Springfield Nuclear Power Plant")
+    True
+    >>> _is_word_boundary_match("Spring", "Springfield")
+    False
+    """
+    short_tokens = _tokenize(shorter)
+    long_tokens = _tokenize(longer)
+
+    if not short_tokens or not long_tokens:
+        return False
+
+    n = len(short_tokens)
+    if n > len(long_tokens):
+        return False
+
+    return short_tokens == long_tokens[:n]
+
+
+def build_person_lookup(tags: dict[str, Any]) -> dict[str, str]:
+    """Build a clean-name -> prefixed-tag lookup from Paperless tags.
+
+    Paperless stores person tags as "Person: Homer", "Person: Marge".
+    The LLM returns just "Homer". This builds the bridge.
+
+    >>> build_person_lookup({"Person: Homer": 1, "Person: Marge": 2, "Insurance": 3})
+    {'Homer': 'Person: Homer', 'Marge': 'Person: Marge'}
+    >>> build_person_lookup({"Insurance": 3})
+    {}
+    """
+    return {
+        tag.replace("Person: ", ""): tag
+        for tag in tags
+        if tag.startswith("Person: ")
+    }
+
+
+def match_persons(names: str | list | None, tags: dict[str, Any]) -> list[str]:
+    """Match LLM-returned person name(s) to Paperless person tags.
+
+    Handles all the ways an LLM might return person data:
+    - Single name: "Homer"                  -> ["Person: Homer"]
+    - Full name:   "Homer J. Simpson"       -> ["Person: Homer"]
+    - Multiple:    ["Homer", "Marge"]       -> ["Person: Homer", "Person: Marge"]
+    - Prefixed:    "Person: Homer"          -> ["Person: Homer"]
+    - Literal null: "null"                  -> []
+    - None:         None                    -> []
+
+    Uses prefer_longest=True so "Homer Jr. Simpson" matches "Homer Jr"
+    (most specific) rather than "Homer" when both exist.
+
+    >>> tags = {"Person: Homer": 1, "Person: Marge": 2, "Insurance": 3}
+    >>> match_persons("Homer", tags)
+    ['Person: Homer']
+    >>> match_persons(["Homer", "Marge"], tags)
+    ['Person: Homer', 'Person: Marge']
+    >>> match_persons("Homer J. Simpson", tags)
+    ['Person: Homer']
+    >>> match_persons(None, tags)
+    []
+    >>> match_persons("null", tags)
+    []
+    >>> match_persons("Lisa", tags)
+    []
+    """
+    if not names:
+        return []
+
+    # Normalize to a list. LLM might return a string or a list.
+    if isinstance(names, str):
+        name_list = [names]
+    elif isinstance(names, list):
+        name_list = names
+    else:
+        return []
+
+    lookup = build_person_lookup(tags)
+    if not lookup:
+        return []
+
+    matched_tags = []
+    for name in name_list:
+        if not name or not isinstance(name, str):
+            continue
+        if name.lower().strip() in ("null", ""):
+            continue
+
+        clean_name = name.replace("Person: ", "").strip()
+        if not clean_name:
+            continue
+
+        # prefer_longest=True: "Homer Jr. Simpson" should match "Homer Jr"
+        # (most specific) not "Homer" (most general).
+        matched = fuzzy_match_entity(clean_name, lookup, prefer_longest=True)
+        if matched:
+            tag = lookup[matched]
+            if tag not in matched_tags:
+                matched_tags.append(tag)
+
+    return matched_tags
+
+
+def deduplicate_hashtags(*labels: str | None) -> list[str]:
+    """Build a deduplicated list of #hashtags for the chat summary.
+
+    Removes duplicates case-insensitively and strips "Person: " prefixes.
+    Filters out None, empty strings, and the literal "null".
+
+    >>> deduplicate_hashtags("Shopping", "Homer", "Invoice", "Kwik-E-Mart")
+    ['#Shopping', '#Homer', '#Invoice', '#Kwik-E-Mart']
+    >>> deduplicate_hashtags("Invoice", "Homer", "Invoice", "Homer")
+    ['#Invoice', '#Homer']
+    >>> deduplicate_hashtags("Person: Homer", "Homer")
+    ['#Homer']
+    >>> deduplicate_hashtags(None, "", "null", "Shopping")
+    ['#Shopping']
+    >>> deduplicate_hashtags()
+    []
+    """
+    result = []
+    seen = set()
+    for label in labels:
+        if not label or not isinstance(label, str) or label.lower().strip() == "null":
+            continue
+        clean = label.replace("Person: ", "").strip()
+        if not clean:
+            continue
+        if clean.lower() not in seen:
+            seen.add(clean.lower())
+            result.append(f"#{clean}")
+    return result
+
+
+def fuzzy_match_entity(
+    name: str,
+    existing: dict[str, Any],
+    *,
+    prefer_longest: bool = False,
+) -> str | None:
+    """Find a close match for `name` among existing Paperless entity names.
+
+    Two strategies:
+
+    1. Case-insensitive exact: "kwik-e-mart" matches "Kwik-E-Mart"
+    2. Word-boundary containment: the tokens of the shorter name must be
+       a contiguous prefix of the longer name's tokens.
+       "Kwik-E-Mart" matches "Kwik-E-Mart Inc." (token prefix)
+       "Spring" does NOT match "Springfield" (not a token prefix)
+       Minimum 3 chars on the shorter side to skip "AG", "Dr", etc.
+
+    When multiple candidates match:
+    - prefer_longest=False (default): picks shortest (most general).
+      Good for correspondents: "ADAC" over "ADAC Versicherung".
+    - prefer_longest=True: picks longest (most specific).
+      Good for persons: "Homer Jr" over "Homer".
+
+    >>> fuzzy_match_entity("Springfield Nuclear", {"Springfield Nuclear Power Plant": 1})
+    'Springfield Nuclear Power Plant'
+    >>> fuzzy_match_entity("Kwik-E-Mart Inc.", {"Kwik-E-Mart": 2, "Moe's Tavern": 3})
+    'Kwik-E-Mart'
+    >>> fuzzy_match_entity("Spring", {"Springfield Nuclear": 5})  # mid-word, no match
+    """
+    if not name or not existing:
+        return None
+
+    name_lower = name.lower().strip()
+    if not name_lower:
+        return None
+
+    pick = max if prefer_longest else min
+
+    # Strategy 1: case-insensitive exact match.
+    for existing_name in existing:
+        if name_lower == existing_name.lower().strip():
+            return existing_name
+
+    # Strategy 2: word-boundary containment.
+    # The shorter name's tokens must be a prefix of the longer name's tokens.
+    #   "ADAC" -> ["adac"] is a prefix of "ADAC e.V." -> ["adac", "e", "v"]  -> match
+    #   "Spring" -> ["spring"] is NOT a prefix of "Springfield" -> ["springfield"] -> no match
+    containment_matches = []
+    for existing_name in existing:
+        existing_lower = existing_name.lower().strip()
+        shorter, longer = (name_lower, existing_lower) if len(name_lower) <= len(existing_lower) else (existing_lower, name_lower)
+        if len(shorter) < 3:
+            continue
+        if _is_word_boundary_match(shorter, longer):
+            containment_matches.append(existing_name)
+
+    if len(containment_matches) == 1:
+        return containment_matches[0]
+    if len(containment_matches) > 1:
+        return pick(containment_matches, key=len)
+
+    return None

--- a/stacklets/docs/hooks/on_install_success.py
+++ b/stacklets/docs/hooks/on_install_success.py
@@ -1,11 +1,23 @@
 """Post-setup hook for the docs stacklet.
 
-Runs once after Paperless-ngx is healthy. Obtains an API token using the
-admin credentials and stores it in secrets.toml. Then creates accounts for
-admin-role users as superusers via the Paperless API.
+Runs once after Paperless-ngx is healthy:
+1. Obtains an API token and stores it in secrets.toml
+2. Creates admin-role user accounts as superusers
+3. Seeds person tags from users.toml
+
+Person tags are also seeded on every `stack up docs` via on_start.py
+so they stay in sync with users.toml changes.
 """
 
 import json
+import sys
+from pathlib import Path
+
+# seed.py lives one level up from hooks/
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from seed import seed_person_tags
+
+PAPERLESS_URL = "http://localhost:42020"
 
 
 def run(ctx):
@@ -22,7 +34,7 @@ def run(ctx):
     if existing_token:
         try:
             http_get(
-                "http://localhost:42020/api/documents/",
+                f"{PAPERLESS_URL}/api/documents/",
                 headers={"Authorization": f"Token {existing_token}"},
             )
             token_valid = True
@@ -39,7 +51,7 @@ def run(ctx):
         step("Obtaining API token...")
         try:
             data = http_post(
-                "http://localhost:42020/api/token/",
+                f"{PAPERLESS_URL}/api/token/",
                 f"username={username}&password={password}",
             )
             existing_token = data.get("token")
@@ -55,6 +67,9 @@ def run(ctx):
 
     # ── Create admin-role users as superusers ────────────────────────
     _create_admin_users(ctx, existing_token)
+
+    # ── Seed person tags from users.toml ─────────────────────────────
+    _seed_person_tags(ctx, existing_token)
 
 
 def _create_admin_users(ctx, token):
@@ -103,3 +118,8 @@ def _create_admin_users(ctx, token):
         else:
             err = (result.stderr or result.stdout).strip().split("\n")[-1]
             ctx.step(f"Could not create Docs admin {uid}: {err}")
+
+
+def _seed_person_tags(ctx, token):
+    """Seed person tags from users.toml. See seed.py for details."""
+    seed_person_tags(PAPERLESS_URL, token, ctx.users, step=ctx.step)

--- a/stacklets/docs/hooks/on_start_ready.py
+++ b/stacklets/docs/hooks/on_start_ready.py
@@ -1,0 +1,26 @@
+"""Docs on_start_ready — seed person tags after Paperless is healthy.
+
+Runs on every `stack up docs`, after health checks pass. Ensures
+person tags in Paperless stay in sync with users.toml. Idempotent --
+skips existing tags, creates new ones for users added since last run.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from seed import seed_person_tags
+
+PAPERLESS_URL = "http://localhost:42020"
+
+
+def run(ctx):
+    token = ctx.secret("API_TOKEN")
+    if not token:
+        return
+
+    users = ctx.users
+    if not users:
+        return
+
+    seed_person_tags(PAPERLESS_URL, token, users, step=ctx.step)

--- a/stacklets/docs/seed.py
+++ b/stacklets/docs/seed.py
@@ -1,0 +1,87 @@
+"""Seed Paperless-ngx with person tags from users.toml.
+
+Idempotent -- safe to run on every `stack up docs`. Skips tags that
+already exist. Creates "Person: X" tags for each family member so
+the Archivist can associate documents with people.
+
+    users.toml              Paperless tags
+    ──────────              ──────────────
+    name = "Homer"    ->    "Person: Homer"  (blue)
+    name = "Marge"    ->    "Person: Marge"  (blue)
+    name = "Bart"     ->    "Person: Bart"   (blue)
+
+Topic tags and correspondents are NOT seeded. They grow organically
+from the Archivist's LLM classifications in the document's language.
+"""
+
+import json
+
+PERSON_TAG_COLOR = "#2196f3"
+
+
+def seed_person_tags(paperless_url: str, token: str, users: list[dict], step=None):
+    """Create person tags in Paperless for each user.
+
+    Args:
+        paperless_url: Paperless base URL (e.g. "http://localhost:42020")
+        token: Paperless API token
+        users: list of user dicts from users.toml
+        step: optional callback for progress messages
+
+    Returns:
+        list of tag names that were created (empty if all existed)
+    """
+    import urllib.request
+
+    if not users or not token:
+        return []
+
+    headers = {"Authorization": f"Token {token}"}
+
+    # Fetch existing tags once
+    existing_tags = set()
+    try:
+        req = urllib.request.Request(
+            f"{paperless_url}/api/tags/?page_size=1000",
+            headers=headers,
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            existing_tags = {t["name"] for t in data.get("results", [])}
+    except Exception:
+        pass
+
+    created = []
+    for user in users:
+        # First name only: "Homer J. Simpson" -> "Homer"
+        name = user.get("name", "").split()[0]
+        if not name:
+            continue
+
+        tag_name = f"Person: {name}"
+        if tag_name in existing_tags:
+            continue
+
+        try:
+            body = json.dumps({
+                "name": tag_name,
+                "color": PERSON_TAG_COLOR,
+                "matching_algorithm": 0,
+            }).encode()
+            req = urllib.request.Request(
+                f"{paperless_url}/api/tags/",
+                data=body,
+                headers={**headers, "Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status == 201:
+                    created.append(tag_name)
+        except Exception as e:
+            if step:
+                step(f"Could not create tag {tag_name}: {e}")
+
+    if created and step:
+        step(f"Seeded {len(created)} person tag(s): {', '.join(created)}")
+
+    return created

--- a/tests/stacklets/test_archivist_matching.py
+++ b/tests/stacklets/test_archivist_matching.py
@@ -1,0 +1,299 @@
+"""Entity matching specification for the Archivist.
+
+All matching logic lives in matching.py as pure functions with zero
+dependencies. Tests use Springfield-themed names throughout.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "stacklets" / "docs" / "bot"))
+
+from matching import (
+    fuzzy_match_entity,
+    match_persons,
+    build_person_lookup,
+    deduplicate_hashtags,
+    _is_word_boundary_match,
+    _tokenize,
+    MAX_TITLE_LENGTH,
+)
+
+
+# ── Tokenizer ───────────────────────────────────────────────────────────
+
+class TestTokenize:
+
+    def test_simple_words(self):
+        assert _tokenize("Burns Industries") == ["burns", "industries"]
+
+    def test_hyphenated(self):
+        assert _tokenize("Kwik-E-Mart") == ["kwik", "e", "mart"]
+
+    def test_possessive(self):
+        assert _tokenize("Moe's Tavern") == ["moe", "s", "tavern"]
+
+    def test_abbreviation_with_dots(self):
+        assert _tokenize("ADAC e.V.") == ["adac", "e", "v"]
+
+    def test_strips_whitespace(self):
+        assert _tokenize("  Burns  Industries  ") == ["burns", "industries"]
+
+    def test_empty_string(self):
+        assert _tokenize("") == []
+
+
+# ── Word boundary check ────────────────────────────────────────────────
+
+class TestWordBoundaryMatch:
+
+    def test_full_word_at_start(self):
+        assert _is_word_boundary_match("Springfield", "Springfield Nuclear Power Plant") is True
+
+    def test_mid_word_substring_blocked(self):
+        assert _is_word_boundary_match("Spring", "Springfield") is False
+
+    def test_suffix_substring_blocked(self):
+        assert _is_word_boundary_match("Bank", "Bundesbank") is False
+
+    def test_name_inside_longer_name_blocked(self):
+        assert _is_word_boundary_match("Art", "Arthur") is False
+
+    def test_multi_word_prefix(self):
+        assert _is_word_boundary_match("Springfield Nuclear", "Springfield Nuclear Power Plant") is True
+
+    def test_hyphenated_match(self):
+        assert _is_word_boundary_match("Kwik-E-Mart", "Kwik-E-Mart Inc.") is True
+
+    def test_abbreviation_match(self):
+        assert _is_word_boundary_match("ADAC", "ADAC e.V.") is True
+
+    def test_empty_shorter(self):
+        assert _is_word_boundary_match("", "Springfield") is False
+
+    def test_empty_longer(self):
+        assert _is_word_boundary_match("Springfield", "") is False
+
+
+# ── Fuzzy entity matching ───────────────────────────────────────────────
+
+class TestExactCaseInsensitive:
+
+    def test_lowercase_matches_titlecase(self):
+        assert fuzzy_match_entity("kwik-e-mart", {"Kwik-E-Mart": 1}) == "Kwik-E-Mart"
+
+    def test_uppercase_matches_titlecase(self):
+        assert fuzzy_match_entity("KWIK-E-MART", {"Kwik-E-Mart": 1}) == "Kwik-E-Mart"
+
+    def test_whitespace_stripped(self):
+        assert fuzzy_match_entity("  Moe's Tavern  ", {"Moe's Tavern": 2}) == "Moe's Tavern"
+
+    def test_exact_wins_over_containment(self):
+        existing = {"Burns": 1, "Burns Industries": 2}
+        assert fuzzy_match_entity("Burns", existing) == "Burns"
+
+
+class TestWordBoundaryContainment:
+
+    def test_llm_adds_suffix(self):
+        # LLM: "Kwik-E-Mart Inc." -> Paperless: "Kwik-E-Mart"
+        assert fuzzy_match_entity("Kwik-E-Mart Inc.", {"Kwik-E-Mart": 1}) == "Kwik-E-Mart"
+
+    def test_llm_drops_suffix(self):
+        # LLM: "Springfield Nuclear" -> Paperless: "Springfield Nuclear Power Plant"
+        assert fuzzy_match_entity("Springfield Nuclear", {"Springfield Nuclear Power Plant": 1}) == "Springfield Nuclear Power Plant"
+
+    def test_abbreviation_suffix(self):
+        assert fuzzy_match_entity("ADAC e.V.", {"ADAC": 1}) == "ADAC"
+
+    def test_single_word_full_token(self):
+        assert fuzzy_match_entity("Springfield", {"Springfield Elementary": 1}) == "Springfield Elementary"
+
+    def test_mid_word_substring_rejected(self):
+        assert fuzzy_match_entity("Spring", {"Springfield Nuclear": 1}) is None
+
+    def test_suffix_substring_rejected(self):
+        assert fuzzy_match_entity("Bank", {"Bundesbank": 1}) is None
+
+    def test_haus_not_matching_bauhaus(self):
+        assert fuzzy_match_entity("Haus", {"Bauhaus": 1}) is None
+
+    def test_multiple_matches_picks_shortest_by_default(self):
+        # Default: shortest = most general. "Burns" over "Burns Industries Intl".
+        existing = {"Burns Industries": 1, "Burns Industries International": 2}
+        assert fuzzy_match_entity("Burns", existing) == "Burns Industries"
+
+    def test_multiple_matches_picks_longest_when_requested(self):
+        # prefer_longest=True: "Homer Jr" over "Homer" for person matching.
+        existing = {"Homer": 1, "Homer Jr": 2}
+        assert fuzzy_match_entity("Homer Jr. Simpson", existing, prefer_longest=True) == "Homer Jr"
+
+    def test_two_chars_too_short(self):
+        assert fuzzy_match_entity("AG", {"AG Versicherung": 1}) is None
+
+
+class TestNoMatch:
+
+    def test_completely_different(self):
+        assert fuzzy_match_entity("Shelbyville Dam", {"Kwik-E-Mart": 1}) is None
+
+    def test_empty_existing(self):
+        assert fuzzy_match_entity("Springfield", {}) is None
+
+    def test_empty_name(self):
+        assert fuzzy_match_entity("", {"Kwik-E-Mart": 1}) is None
+
+    def test_none_name(self):
+        assert fuzzy_match_entity(None, {"Kwik-E-Mart": 1}) is None
+
+    def test_whitespace_only(self):
+        assert fuzzy_match_entity("   ", {"Kwik-E-Mart": 1}) is None
+
+
+# ── Person lookup ───────────────────────────────────────────────────────
+
+SIMPSON_TAGS = {
+    "Person: Homer": 1,
+    "Person: Marge": 2,
+    "Person: Bart": 3,
+    "Insurance": 10,
+    "Shopping": 11,
+}
+
+
+class TestBuildPersonLookup:
+
+    def test_extracts_person_tags(self):
+        lookup = build_person_lookup(SIMPSON_TAGS)
+        assert lookup == {"Homer": "Person: Homer", "Marge": "Person: Marge", "Bart": "Person: Bart"}
+
+    def test_ignores_non_person_tags(self):
+        assert build_person_lookup({"Insurance": 10}) == {}
+
+    def test_empty_tags(self):
+        assert build_person_lookup({}) == {}
+
+
+# ── Person matching ─────────────────────────────────────────────────────
+
+class TestMatchPersons:
+    """match_persons resolves LLM output to Paperless "Person: X" tags.
+
+    Handles single names, full names, lists, wrong case, prefixed forms.
+    Returns a list of matched tags (can be empty, one, or multiple).
+    """
+
+    def test_single_first_name(self):
+        # LLM: "Homer" -> ["Person: Homer"]
+        assert match_persons("Homer", SIMPSON_TAGS) == ["Person: Homer"]
+
+    def test_full_name_from_document(self):
+        # LLM passes through "Homer J. Simpson" from the document text
+        assert match_persons("Homer J. Simpson", SIMPSON_TAGS) == ["Person: Homer"]
+
+    def test_case_insensitive(self):
+        assert match_persons("homer", SIMPSON_TAGS) == ["Person: Homer"]
+
+    def test_prefixed_form(self):
+        # LLM includes the "Person: " prefix
+        assert match_persons("Person: Homer", SIMPSON_TAGS) == ["Person: Homer"]
+
+    def test_list_of_names(self):
+        # Joint document (marriage certificate, family insurance)
+        assert match_persons(["Homer", "Marge"], SIMPSON_TAGS) == ["Person: Homer", "Person: Marge"]
+
+    def test_list_with_full_names(self):
+        # LLM returns full names for both
+        result = match_persons(["Homer J. Simpson", "Marge Simpson"], SIMPSON_TAGS)
+        assert result == ["Person: Homer", "Person: Marge"]
+
+    def test_list_deduplicates(self):
+        # LLM returns same person twice
+        assert match_persons(["Homer", "Homer"], SIMPSON_TAGS) == ["Person: Homer"]
+
+    def test_list_with_unknown_filtered(self):
+        # "Lisa" is not seeded -- silently dropped, Homer still matched
+        result = match_persons(["Homer", "Lisa"], SIMPSON_TAGS)
+        assert result == ["Person: Homer"]
+
+    def test_ambiguous_picks_most_specific(self):
+        # "Homer Jr. Simpson" should match "Homer Jr" not "Homer"
+        tags_with_jr = {"Person: Homer": 1, "Person: Homer Jr": 2}
+        assert match_persons("Homer Jr. Simpson", tags_with_jr) == ["Person: Homer Jr"]
+
+    def test_ambiguous_exact_wins(self):
+        # "Homer" exact-matches "Homer", not "Homer Jr"
+        tags_with_jr = {"Person: Homer": 1, "Person: Homer Jr": 2}
+        assert match_persons("Homer", tags_with_jr) == ["Person: Homer"]
+
+    def test_unknown_returns_empty(self):
+        assert match_persons("Lisa", SIMPSON_TAGS) == []
+
+    def test_null_string_returns_empty(self):
+        assert match_persons("null", SIMPSON_TAGS) == []
+
+    def test_none_returns_empty(self):
+        assert match_persons(None, SIMPSON_TAGS) == []
+
+    def test_empty_string_returns_empty(self):
+        assert match_persons("", SIMPSON_TAGS) == []
+
+    def test_empty_list_returns_empty(self):
+        assert match_persons([], SIMPSON_TAGS) == []
+
+    def test_no_person_tags_returns_empty(self):
+        assert match_persons("Homer", {"Insurance": 10}) == []
+
+    def test_list_with_nulls_filtered(self):
+        result = match_persons(["Homer", "null", None, ""], SIMPSON_TAGS)
+        assert result == ["Person: Homer"]
+
+
+# ── Hashtag deduplication ───────────────────────────────────────────────
+
+class TestDeduplicateHashtags:
+
+    def test_all_different(self):
+        result = deduplicate_hashtags("Shopping", "Homer", "Invoice", "Kwik-E-Mart")
+        assert result == ["#Shopping", "#Homer", "#Invoice", "#Kwik-E-Mart"]
+
+    def test_duplicate_removed(self):
+        result = deduplicate_hashtags("Invoice", "Homer", "Invoice", "Kwik-E-Mart")
+        assert result == ["#Invoice", "#Homer", "#Kwik-E-Mart"]
+
+    def test_case_insensitive_dedup(self):
+        result = deduplicate_hashtags("invoice", "Homer", "Invoice", "Kwik-E-Mart")
+        assert result == ["#invoice", "#Homer", "#Kwik-E-Mart"]
+
+    def test_person_prefix_stripped(self):
+        result = deduplicate_hashtags("Shopping", "Person: Homer", None, "Homer")
+        assert result == ["#Shopping", "#Homer"]
+
+    def test_none_filtered(self):
+        result = deduplicate_hashtags("Shopping", None, "Invoice", None)
+        assert result == ["#Shopping", "#Invoice"]
+
+    def test_null_string_filtered(self):
+        result = deduplicate_hashtags("Shopping", "null", "Invoice", "null")
+        assert result == ["#Shopping", "#Invoice"]
+
+    def test_all_none(self):
+        assert deduplicate_hashtags(None, None, None, None) == []
+
+    def test_no_args(self):
+        assert deduplicate_hashtags() == []
+
+    def test_multiple_persons(self):
+        # Joint document: topic + two persons + correspondent
+        result = deduplicate_hashtags("Insurance", "Homer", "Marge", "ADAC")
+        assert result == ["#Insurance", "#Homer", "#Marge", "#ADAC"]
+
+
+# ── Constants ───────────────────────────────────────────────────────────
+
+class TestConstants:
+
+    def test_paperless_title_limit(self):
+        assert MAX_TITLE_LENGTH == 128


### PR DESCRIPTION
Improves document classification in the Archivist bot and adds a new lifecycle hook.

  ### Smarter classification
  - Fuzzy entity matching prevents duplicate tags/correspondents (word-boundary safe)
  - Topic/person/correspondent as three clear classification axes
  - Multi-person support for joint documents
  - Fact and action item extraction from document text
  - Scannable titles
  - Original document language preserved

  ### Person tag seeding
  - `on_start_ready` hook runs after health checks on every `stack up`
  - Seeds person tags from `users.toml` into Paperless (idempotent)

  ### Lifecycle
  - New `on_start_ready` hook: runs after service is healthy (vs `on_start` which runs before containers)
  - `stack restart` now runs the full lifecycle (was bypassing hooks)