### PR TITLE
  feat: seed document taxonomy per language, tui installer autodetect language (deutsch, english)

### DIFF
--- a/docs/creating-stacklets.md
+++ b/docs/creating-stacklets.md
@@ -34,6 +34,7 @@ Values in `{braces}` are resolved from `stack.toml` and runtime state:
 
 | Variable | Source |
 |---|---|
+| `{language}` | `[core].language` (falls back to `[ai].language`, then `en`) |
 | `{timezone}` | `[core].timezone` |
 | `{data_dir}` | `[core].data_dir` |
 | `{domain}` | `[core].domain` |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -91,6 +91,8 @@ Document archive with OCR. Receipts, letters, contracts, tax documents. Search a
 
 The archivist bot creates a **Documents** room in your chat. Send it a photo of a receipt and it files it automatically. AI classifies and tags documents when the AI stacklet is running. Type `show 42` to read a document's content, or search by typing any term.
 
+On first setup, famstack seeds Paperless with common document categories and types in your configured language. The LLM picks from these when classifying, so tags stay consistent. See [`stacklets/docs/taxonomy.toml`](../stacklets/docs/taxonomy.toml) for the full list.
+
 **Port:** 42020
 **Data:** `~/famstack-data/docs/paperless/` (documents, media), `~/famstack-data/docs/postgres/` (database), `~/famstack-data/docs/consume/` (inbox folder)
 
@@ -162,6 +164,7 @@ The single config file. Everything flows from here.
 domain   = ""                    # empty = port mode (recommended to start)
 data_dir = "~/famstack-data"     # where all data lives
 timezone = "Europe/Berlin"
+language = "de"                  # "de" or "en" — used for document tags, UI
 
 [ai]
 default = "mlx-community/Qwen3.5-9B-MLX-4bit"   # change to match your RAM
@@ -171,6 +174,7 @@ language = "en"                                    # "de" for German voice/trans
 Key things to know:
 - **domain**: leave empty to start. Services are reachable via `hostname:port`. Set a domain later for pretty URLs like `photos.home.internal` (requires wildcard DNS on your router).
 - **data_dir**: where databases, uploads, and media live. Back this up. It's outside the git repo.
+- **language**: the installer detects this from your timezone. Controls which language document categories are seeded in (German or English). Change it and run `./stack restart docs` to seed missing tags.
 - **AI model**: the installer picks one for your RAM tier. The alternatives are listed as comments in `stack.toml`. Switch by uncommenting a different line and running `./stack setup ai`.
 
 ### users.toml

--- a/docs/stack-reference.md
+++ b/docs/stack-reference.md
@@ -143,6 +143,7 @@ Available template variables:
 |---|---|
 | `{data_dir}` | `stack.toml` → `[core].data_dir` |
 | `{domain}` | `stack.toml` → `[core].domain` |
+| `{language}` | `stack.toml` → `[core].language` (falls back to `[ai].language`, then `en`) |
 | `{timezone}` | `stack.toml` → `[core].timezone` |
 | `{stacklet_id}` | The stacklet's own `id` field |
 | `{admin_username}` | Tech admin username (`stackadmin`) |
@@ -795,6 +796,7 @@ One file, committed to the repo. User edits it directly.
 domain   = ""                    # empty = port mode
 data_dir = "~/famstack-data"
 timezone = "Europe/Berlin"
+language = "de"                  # document tags, UI language (de, en)
 
 [updates]
 schedule = "0 0 3 * * *"        # Watchtower cron (3am nightly)

--- a/lib/stack/installer.py
+++ b/lib/stack/installer.py
@@ -295,6 +295,7 @@ def write_stack_toml(config):
 domain = ""
 data_dir = "{data_dir}"
 timezone = "{tz}"
+language = "{language}"
 
 [updates]
 schedule = "0 0 3 * * *"

--- a/lib/stack/installer_v2.py
+++ b/lib/stack/installer_v2.py
@@ -85,6 +85,18 @@ def detect_timezone():
     return "UTC"
 
 
+# Map timezone to primary language. Only de and en for now --
+# taxonomy.yaml only has these two. Add more as we add translations.
+_TZ_LANGUAGE = {
+    "Europe/Berlin": "de", "Europe/Vienna": "de", "Europe/Zurich": "de",
+}
+
+
+def detect_language(timezone: str) -> str:
+    """Guess the household language from timezone. Defaults to English."""
+    return _TZ_LANGUAGE.get(timezone, "en")
+
+
 # (min_ram_gb, model_id, label)
 MODEL_TIERS = [
     (48, "mlx-community/Qwen3.5-35B-A3B-8bit", "48 GB+ RAM — best quality"),
@@ -229,7 +241,7 @@ def _model_comments(chosen: str) -> str:
     return "\n".join(lines)
 
 
-def write_stack_toml(family_name, server_name, timezone):
+def write_stack_toml(family_name, server_name, timezone, language="en"):
     """Write a minimal stack.toml — just enough for messages."""
     default_model = detect_default_model()
     model_block = _model_comments(default_model)
@@ -243,6 +255,7 @@ stack_owner = "{family_name}"
 domain = ""
 data_dir = "~/famstack-data"
 timezone = "{timezone}"
+language = "{language}"
 
 [updates]
 schedule = "0 0 3 * * *"
@@ -409,9 +422,10 @@ def wizard():
     nl()
 
     timezone = detect_timezone()
+    language = detect_language(timezone)
 
     with Spinner("Writing stack.toml"):
-        write_stack_toml(family_name, server_name, timezone)
+        write_stack_toml(family_name, server_name, timezone, language)
 
     with Spinner("Writing users.toml"):
         write_users_toml(users)

--- a/lib/stack/stack.py
+++ b/lib/stack/stack.py
@@ -157,6 +157,7 @@ class Stack:
             # Core config
             "data_dir":              str(self.data),
             "domain":                self._cfg("core", "domain"),
+            "language":              self._cfg("core", "language", self._cfg("ai", "language", "en")),
             "timezone":              self._cfg("core", "timezone", "UTC"),
             # AI service URLs — host-side for CLI, docker-side for containers
             "ai_openai_url":         ai_openai_url,

--- a/stacklets/docs/hooks/on_install_success.py
+++ b/stacklets/docs/hooks/on_install_success.py
@@ -3,10 +3,10 @@
 Runs once after Paperless-ngx is healthy:
 1. Obtains an API token and stores it in secrets.toml
 2. Creates admin-role user accounts as superusers
-3. Seeds person tags from users.toml
+3. Seeds person tags and document taxonomy
 
-Person tags are also seeded on every `stack up docs` via on_start.py
-so they stay in sync with users.toml changes.
+Also seeded on every `stack up docs` via on_start_ready.py
+so they stay in sync with users.toml and taxonomy.yaml changes.
 """
 
 import json
@@ -15,10 +15,7 @@ from pathlib import Path
 
 # seed.py lives one level up from hooks/
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from seed import seed_person_tags
-
-PAPERLESS_URL = "http://localhost:42020"
-
+from seed import seed_person_tags, seed_taxonomy
 
 def run(ctx):
     env = ctx.env
@@ -26,6 +23,8 @@ def run(ctx):
     step = ctx.step
     http_post = ctx.http_post
     http_get = ctx.http_get
+
+    PAPERLESS_URL = env.get("PAPERLESS_URL", "http://localhost:42020")
 
     # Verify existing token still works (a previous destroy + up cycle
     # creates a fresh database, invalidating the old token in secrets.toml)
@@ -68,8 +67,8 @@ def run(ctx):
     # ── Create admin-role users as superusers ────────────────────────
     _create_admin_users(ctx, existing_token)
 
-    # ── Seed person tags from users.toml ─────────────────────────────
-    _seed_person_tags(ctx, existing_token)
+    # ── Seed person tags + category taxonomy ───────────────────────────
+    _seed_taxonomy(ctx, existing_token)
 
 
 def _create_admin_users(ctx, token):
@@ -120,6 +119,9 @@ def _create_admin_users(ctx, token):
             ctx.step(f"Could not create Docs admin {uid}: {err}")
 
 
-def _seed_person_tags(ctx, token):
-    """Seed person tags from users.toml. See seed.py for details."""
-    seed_person_tags(PAPERLESS_URL, token, ctx.users, step=ctx.step)
+def _seed_taxonomy(ctx, token):
+    """Seed person tags and document taxonomy. See seed.py for details."""
+    url = ctx.env.get("PAPERLESS_URL", "http://localhost:42020")
+    seed_person_tags(url, token, ctx.users, step=ctx.step)
+    language = ctx.env.get("LANGUAGE", "en")
+    seed_taxonomy(url, token, language, step=ctx.step)

--- a/stacklets/docs/hooks/on_start_ready.py
+++ b/stacklets/docs/hooks/on_start_ready.py
@@ -1,17 +1,16 @@
-"""Docs on_start_ready — seed person tags after Paperless is healthy.
+"""Docs on_start_ready — seed person tags and taxonomy after Paperless is healthy.
 
 Runs on every `stack up docs`, after health checks pass. Ensures
-person tags in Paperless stay in sync with users.toml. Idempotent --
-skips existing tags, creates new ones for users added since last run.
+person tags and category taxonomy stay in sync. Idempotent -- skips
+existing entries, creates new ones for users or categories added
+since last run.
 """
 
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from seed import seed_person_tags
-
-PAPERLESS_URL = "http://localhost:42020"
+from seed import seed_person_tags, seed_taxonomy
 
 
 def run(ctx):
@@ -19,8 +18,9 @@ def run(ctx):
     if not token:
         return
 
-    users = ctx.users
-    if not users:
-        return
+    url = ctx.env.get("PAPERLESS_URL", "http://localhost:42020")
 
-    seed_person_tags(PAPERLESS_URL, token, users, step=ctx.step)
+    seed_person_tags(url, token, ctx.users or [], step=ctx.step)
+
+    language = ctx.env.get("LANGUAGE", "en")
+    seed_taxonomy(url, token, language, step=ctx.step)

--- a/stacklets/docs/seed.py
+++ b/stacklets/docs/seed.py
@@ -1,22 +1,90 @@
-"""Seed Paperless-ngx with person tags from users.toml.
+"""Seed Paperless-ngx with person tags and document taxonomy.
 
-Idempotent -- safe to run on every `stack up docs`. Skips tags that
-already exist. Creates "Person: X" tags for each family member so
-the Archivist can associate documents with people.
+Idempotent -- safe to run on every `stack up docs`. Skips entries that
+already exist. Seeds two things:
+
+1. Person tags from users.toml:
 
     users.toml              Paperless tags
     ──────────              ──────────────
     name = "Homer"    ->    "Person: Homer"  (blue)
     name = "Marge"    ->    "Person: Marge"  (blue)
-    name = "Bart"     ->    "Person: Bart"   (blue)
 
-Topic tags and correspondents are NOT seeded. They grow organically
-from the Archivist's LLM classifications in the document's language.
+2. Category tags and document types from taxonomy.yaml:
+
+    taxonomy.yaml           Paperless tags / types
+    ─────────────           ──────────────────────
+    de.tags.Versicherung -> tag "Versicherung"    (green)
+    de.types.Rechnung    -> doc type "Rechnung"
+
+stdlib only -- no framework dependencies so hooks can import this directly.
 """
 
 import json
+from pathlib import Path
 
 PERSON_TAG_COLOR = "#2196f3"
+CATEGORY_TAG_COLOR = "#4caf50"
+TAXONOMY_PATH = Path(__file__).parent / "taxonomy.toml"
+
+
+def _load_taxonomy(language: str) -> dict:
+    """Load taxonomy for the given language from taxonomy.toml.
+
+    Falls back to English if the requested language isn't defined.
+    Returns {"tags": [...], "types": [...]}.
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        from stack._compat import tomllib
+
+    if not TAXONOMY_PATH.exists():
+        return {"tags": [], "types": []}
+
+    with open(TAXONOMY_PATH, "rb") as f:
+        data = tomllib.load(f)
+
+    lang_key = language[:2].lower()
+    section = data.get(lang_key, data.get("en", {}))
+
+    return {
+        "tags": section.get("tags", []),
+        "types": section.get("types", []),
+    }
+
+
+def _fetch_existing(paperless_url: str, headers: dict, endpoint: str) -> set:
+    """Fetch existing entity names from a Paperless API endpoint."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(
+            f"{paperless_url}/api/{endpoint}/?page_size=1000",
+            headers=headers,
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return {t["name"] for t in data.get("results", [])}
+    except Exception:
+        return set()
+
+
+def _create_entity(paperless_url: str, headers: dict, endpoint: str, body: dict) -> bool:
+    """Create a single entity via Paperless API. Returns True on success."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(
+            f"{paperless_url}/api/{endpoint}/",
+            data=json.dumps(body).encode(),
+            headers={**headers, "Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 201
+    except Exception:
+        return False
 
 
 def seed_person_tags(paperless_url: str, token: str, users: list[dict], step=None):
@@ -31,29 +99,14 @@ def seed_person_tags(paperless_url: str, token: str, users: list[dict], step=Non
     Returns:
         list of tag names that were created (empty if all existed)
     """
-    import urllib.request
-
     if not users or not token:
         return []
 
     headers = {"Authorization": f"Token {token}"}
-
-    # Fetch existing tags once
-    existing_tags = set()
-    try:
-        req = urllib.request.Request(
-            f"{paperless_url}/api/tags/?page_size=1000",
-            headers=headers,
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            existing_tags = {t["name"] for t in data.get("results", [])}
-    except Exception:
-        pass
+    existing_tags = _fetch_existing(paperless_url, headers, "tags")
 
     created = []
     for user in users:
-        # First name only: "Homer J. Simpson" -> "Homer"
         name = user.get("name", "").split()[0]
         if not name:
             continue
@@ -62,26 +115,66 @@ def seed_person_tags(paperless_url: str, token: str, users: list[dict], step=Non
         if tag_name in existing_tags:
             continue
 
-        try:
-            body = json.dumps({
-                "name": tag_name,
-                "color": PERSON_TAG_COLOR,
-                "matching_algorithm": 0,
-            }).encode()
-            req = urllib.request.Request(
-                f"{paperless_url}/api/tags/",
-                data=body,
-                headers={**headers, "Content-Type": "application/json"},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                if resp.status == 201:
-                    created.append(tag_name)
-        except Exception as e:
-            if step:
-                step(f"Could not create tag {tag_name}: {e}")
+        if _create_entity(paperless_url, headers, "tags", {
+            "name": tag_name,
+            "color": PERSON_TAG_COLOR,
+            "matching_algorithm": 0,
+        }):
+            created.append(tag_name)
+        elif step:
+            step(f"Could not create tag {tag_name}")
 
     if created and step:
         step(f"Seeded {len(created)} person tag(s): {', '.join(created)}")
 
     return created
+
+
+def seed_taxonomy(paperless_url: str, token: str, language: str = "en", step=None):
+    """Seed category tags and document types from taxonomy.yaml.
+
+    Args:
+        paperless_url: Paperless base URL
+        token: Paperless API token
+        language: language code (e.g. "de", "en")
+        step: optional callback for progress messages
+
+    Returns:
+        dict with "tags" and "types" lists of created names
+    """
+    if not token:
+        return {"tags": [], "types": []}
+
+    taxonomy = _load_taxonomy(language)
+    headers = {"Authorization": f"Token {token}"}
+
+    existing_tags = _fetch_existing(paperless_url, headers, "tags")
+    existing_types = _fetch_existing(paperless_url, headers, "document_types")
+
+    created_tags = []
+    for tag_name in taxonomy["tags"]:
+        if tag_name in existing_tags:
+            continue
+        if _create_entity(paperless_url, headers, "tags", {
+            "name": tag_name,
+            "color": CATEGORY_TAG_COLOR,
+            "matching_algorithm": 0,
+        }):
+            created_tags.append(tag_name)
+
+    created_types = []
+    for type_name in taxonomy["types"]:
+        if type_name in existing_types:
+            continue
+        if _create_entity(paperless_url, headers, "document_types", {
+            "name": type_name,
+            "matching_algorithm": 0,
+        }):
+            created_types.append(type_name)
+
+    if created_tags and step:
+        step(f"Seeded {len(created_tags)} category tag(s)")
+    if created_types and step:
+        step(f"Seeded {len(created_types)} document type(s)")
+
+    return {"tags": created_tags, "types": created_types}

--- a/stacklets/docs/stacklet.toml
+++ b/stacklets/docs/stacklet.toml
@@ -45,6 +45,7 @@ DB_NAME              = "paperless"
 ADMIN_USER           = "{admin_username}"
 ADMIN_PASSWORD       = "{admin_password}"
 PAPERLESS_URL        = "{url}"
+LANGUAGE             = "{language}"
 
 [health]
 url    = "http://localhost:42020/api/"

--- a/stacklets/docs/taxonomy.toml
+++ b/stacklets/docs/taxonomy.toml
@@ -1,0 +1,111 @@
+# taxonomy.toml — initial document categories and types for Paperless-ngx
+#
+# Seeded on first setup and every `stack up docs`. Idempotent — existing
+# tags are skipped. The LLM prompt includes these as "existing topic tags"
+# so it picks from the list instead of inventing inconsistent names.
+#
+# Organized by what goes into a family's filing cabinet. Not too granular
+# (Housing covers rent, mortgage, utilities), not too broad (Finance is
+# separate from Taxes because you search for them differently).
+
+[de]
+tags = [
+    "Versicherung",        # health, car, home, liability, life
+    "Finanzen",            # bank statements, retirement, accounts
+    "Investments",         # stocks, funds, portfolios, dividends
+    "Einkommen",           # salary, freelance income, side jobs
+    "Steuern",             # returns, assessments, deductions
+    "Finanzamt",           # tax office correspondence, Steuerbescheid
+    "Gesundheit",          # doctors, prescriptions, lab results
+    "Schule",              # report cards, enrollment, school letters
+    "Kinder",              # daycare, activities, allowances, Kindergeld
+    "Ehe",                 # marriage certificate, divorce, joint documents
+    "Fahrzeug",            # registration, inspections, repairs, fuel
+    "Wohnen",              # rent, mortgage, renovations, maintenance
+    "Immobilien",          # property purchase, Grundbuch, Makler
+    "Nebenkosten",         # electricity, water, gas, heating
+    "Arbeit",              # contracts, pay slips, references
+    "Recht",               # legal contracts, notary, court
+    "Behörden",            # ID, permits, registrations, Meldebescheinigung
+    "Mitgliedschaft",      # clubs, associations, memberships
+    "Abonnement",          # streaming, software, magazines
+    "Einkauf",             # general shopping, warranties, returns
+    "Elektronik",          # computers, phones, gadgets, tech purchases
+    "Lebensmittel",        # groceries, supermarket receipts
+    "Reise",               # bookings, tickets, travel insurance
+    "Haustiere",           # vet, registration, insurance
+    "Telekommunikation",   # phone, internet, mobile contracts
+    "Rezepte",             # family recipes, grandma's classics, cooking and baking
+    "Erinnerungen",        # kids' artwork, letters, postcards, milestone docs
+    "Urkunden",            # birth/death certificates, passports, wills, Vollmacht
+    "Rente",               # state pension, Riester, company pension, Altersvorsorge
+    "Spenden",             # charity donations, tax-deductible receipts
+    "Garantie",            # warranty cards, proof of purchase for claims
+    "Impfungen",           # vaccination records, allergy passes, blood type
+    "Zugangsdaten",        # WiFi passwords, serial numbers, access codes
+]
+types = [
+    "Rechnung",
+    "Quittung",
+    "Vertrag",
+    "Brief",
+    "Bescheinigung",
+    "Kontoauszug",
+    "Bescheid",
+    "Kündigung",
+    "Police",
+    "Bedienungsanleitung",
+    "Protokoll",
+    "Buchung",
+]
+
+[en]
+tags = [
+    "Insurance",           # health, car, home, liability, life
+    "Finance",             # bank statements, retirement, accounts
+    "Investments",         # stocks, funds, portfolios, dividends
+    "Income",              # salary, freelance income, side jobs
+    "Taxes",               # returns, assessments, deductions
+    "Tax Office",          # IRS/HMRC correspondence, tax notices
+    "Medical",             # doctors, prescriptions, lab results
+    "School",              # report cards, enrollment, school letters
+    "Children",            # daycare, activities, allowances, child benefit
+    "Marriage",            # marriage certificate, divorce, joint documents
+    "Vehicle",             # registration, inspections, repairs, fuel
+    "Housing",             # rent, mortgage, renovations, maintenance
+    "Property",            # property purchase, deed, real estate agent
+    "Utilities",           # electricity, water, gas, heating
+    "Employment",          # contracts, pay slips, references
+    "Legal",               # contracts, notary, court
+    "Government",          # ID, permits, registrations
+    "Membership",          # clubs, associations, memberships
+    "Subscription",        # streaming, software, magazines
+    "Shopping",            # general shopping, warranties, returns
+    "Electronics",         # computers, phones, gadgets, tech purchases
+    "Groceries",           # supermarket receipts
+    "Travel",              # bookings, tickets, travel insurance
+    "Pets",                # vet, registration, insurance
+    "Telecom",             # phone, internet, mobile contracts
+    "Recipes",             # family recipes, grandma's classics, cooking and baking
+    "Memories",            # kids' artwork, letters, postcards, milestone docs
+    "Personal Records",    # birth/death certificates, passports, wills, power of attorney
+    "Pension",             # state pension, 401k, company pension, retirement
+    "Donations",           # charity donations, tax-deductible receipts
+    "Warranty",            # warranty cards, proof of purchase for claims
+    "Vaccinations",        # vaccination records, allergy passes, blood type
+    "Credentials",         # WiFi passwords, serial numbers, access codes
+]
+types = [
+    "Invoice",
+    "Receipt",
+    "Contract",
+    "Letter",
+    "Certificate",
+    "Statement",
+    "Notice",
+    "Cancellation",
+    "Policy",
+    "Manual",
+    "Protocol",
+    "Booking",
+]

--- a/tests/stacklets/test_docs_seed.py
+++ b/tests/stacklets/test_docs_seed.py
@@ -1,0 +1,78 @@
+"""Taxonomy seeding specification for the Docs stacklet.
+
+Tests the taxonomy loading and seed logic. Uses the actual
+taxonomy.toml file to verify it parses correctly.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "stacklets" / "docs"))
+
+from seed import _load_taxonomy, TAXONOMY_PATH
+
+
+class TestLoadTaxonomy:
+
+    def test_taxonomy_file_exists(self):
+        assert TAXONOMY_PATH.exists(), "taxonomy.yaml must exist"
+
+    def test_german_tags_loaded(self):
+        t = _load_taxonomy("de")
+        assert "Versicherung" in t["tags"]
+        assert "Steuern" in t["tags"]
+        assert "Wohnen" in t["tags"]
+        assert "Nebenkosten" in t["tags"]
+
+    def test_german_types_loaded(self):
+        t = _load_taxonomy("de")
+        assert "Rechnung" in t["types"]
+        assert "Vertrag" in t["types"]
+        assert "Bescheinigung" in t["types"]
+
+    def test_english_tags_loaded(self):
+        t = _load_taxonomy("en")
+        assert "Insurance" in t["tags"]
+        assert "Taxes" in t["tags"]
+        assert "Housing" in t["tags"]
+        assert "Utilities" in t["tags"]
+
+    def test_english_types_loaded(self):
+        t = _load_taxonomy("en")
+        assert "Invoice" in t["types"]
+        assert "Contract" in t["types"]
+        assert "Certificate" in t["types"]
+
+    def test_unknown_language_falls_back_to_english(self):
+        t = _load_taxonomy("fr")
+        assert "Insurance" in t["tags"]
+
+    def test_language_prefix_matching(self):
+        # "de-DE" should match "de"
+        t = _load_taxonomy("de-DE")
+        assert "Versicherung" in t["tags"]
+
+    def test_german_tag_count(self):
+        t = _load_taxonomy("de")
+        assert len(t["tags"]) >= 15, f"Expected 15+ tags, got {len(t['tags'])}"
+
+    def test_english_tag_count(self):
+        t = _load_taxonomy("en")
+        assert len(t["tags"]) >= 15, f"Expected 15+ tags, got {len(t['tags'])}"
+
+    def test_no_inline_comments_in_values(self):
+        """Inline YAML comments must be stripped during parsing."""
+        for lang in ("de", "en"):
+            t = _load_taxonomy(lang)
+            for tag in t["tags"]:
+                assert "#" not in tag, f"Comment leaked into tag: {tag}"
+            for typ in t["types"]:
+                assert "#" not in typ, f"Comment leaked into type: {typ}"
+
+    def test_no_empty_values(self):
+        for lang in ("de", "en"):
+            t = _load_taxonomy(lang)
+            for tag in t["tags"]:
+                assert tag.strip(), "Empty tag found"
+            for typ in t["types"]:
+                assert typ.strip(), "Empty type found"


### PR DESCRIPTION
  - taxonomy.yaml with 33 tags + 12 document types per language (de/en)
  - seed_taxonomy() seeds categories and types on every `stack up docs`
  - {language} template variable from [core].language
  - Installer detects language from timezone (Europe/Berlin -> de)
  - Removed hardcoded PAPERLESS_URL from hooks