### PR TITLE
feat(docs): CLI: inspect, reclassify, and mirror filed documents

### DIFF
--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -1082,10 +1082,12 @@ def main():
         handle_install(stck, None)
         return
 
-    # --json: machine-readable output for read-only queries (list, env)
+    # --json: machine-readable output for the bare `stack` / status / list /
+    # env paths. The flag is *detected* here but left in argv — stacklet CLI
+    # plugins (stack docs classify --json, ...) are free to define --json
+    # as their own option. parser.parse_known_args() below is tolerant of
+    # unknown flags, so leaving --json in doesn't disrupt top-level parsing.
     json_mode = "--json" in sys.argv
-    while "--json" in sys.argv:
-        sys.argv.remove("--json")
 
     parser = argparse.ArgumentParser(
         prog="stack", add_help=False,

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -27,7 +27,6 @@ and the sync loop — this file focuses purely on document processing logic.
 
 import asyncio
 import io
-import json
 import os
 import re
 import time
@@ -48,11 +47,16 @@ from nio import (
 )
 
 from git_mirror import GitMirror
-from matching import (
-    _is_empty, fuzzy_match_entity, match_persons, match_topics,
-    build_document_event, deduplicate_hashtags, MAX_TITLE_LENGTH,
-)
+from matching import build_document_event
 from microbot import MicroBot
+from pipeline import (
+    Classifier,
+    EnrichResult,
+    PaperlessAPI,
+    PaperlessDuplicateError,
+    enrich_document,
+    reformat_document,
+)
 from stack import resolve_model
 
 
@@ -78,6 +82,29 @@ def _timed(operation: str):
         elapsed = time.monotonic() - t0
         logger.info("[archivist] {} completed in {:.1f}s", operation, elapsed)
 
+def _llm_error_for_chat(
+    pipeline_error: tuple[str, str] | None,
+    *, name: str, openai_url: str, link: str,
+) -> tuple[str, dict] | None:
+    """Map a pipeline llm_error tuple to (translation-key, format-kwargs).
+
+    The pipeline speaks in transport terms ("unavailable", "model_missing",
+    "timeout"); the chat reply needs translation keys that already know
+    how to render the document's name and a link back to Paperless.
+    Returns None when there was no error.
+    """
+    if not pipeline_error:
+        return None
+    kind, detail = pipeline_error
+    if kind == "unavailable":
+        return ("llm_unavailable", {"name": name, "url": openai_url, "link": link})
+    if kind == "model_missing":
+        return ("llm_model_missing", {"name": name, "model": detail, "link": link})
+    if kind == "timeout":
+        return ("llm_timeout", {"name": name, "link": link})
+    return None
+
+
 # ── Constants ────────────────────────────────────────────────────────────────
 
 SUPPORTED_MSGTYPES = {"m.file", "m.image"}
@@ -96,34 +123,6 @@ GOOGLE_DOC_PATTERNS = {
     re.compile(r'https://docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)'): "spreadsheets",
     re.compile(r'https://docs\.google\.com/presentation/d/([a-zA-Z0-9_-]+)'): "presentation",
 }
-
-
-# ── LLM Errors ───────────────────────────────────────────────────────────────
-
-class LLMUnavailableError(Exception):
-    """LLM service is not reachable — oMLX/Ollama might not be running."""
-
-class LLMModelNotFoundError(Exception):
-    """The configured model is not loaded on the LLM server."""
-
-class LLMTimeoutError(Exception):
-    """LLM took too long — large documents or cold model start can cause this."""
-
-
-# ── Paperless Errors ─────────────────────────────────────────────────────────
-
-class PaperlessDuplicateError(Exception):
-    """Paperless rejected the upload as a content-hash duplicate of an
-    already-filed doc. Carries the original's id + title so the chat
-    reply can point the user at what's already there."""
-    def __init__(self, doc_id: int | None, title: str | None):
-        self.doc_id = doc_id
-        self.title = title
-        super().__init__(f"duplicate of #{doc_id}: {title}")
-
-
-_DUPLICATE_RE = re.compile(r"duplicate of\s+(.+?)\s+\(#(\d+)\)", re.IGNORECASE)
-
 
 
 # ── Translations ─────────────────────────────────────────────────────────────
@@ -210,6 +209,8 @@ class ArchivistBot(MicroBot):
         self.mirror_org = settings.get("mirror_org", "family")
         self._scan_sessions: dict[str, dict] = {}
         self._http: aiohttp.ClientSession | None = None
+        self._paperless: PaperlessAPI | None = None
+        self._classifier: Classifier | None = None
         self._mirror: GitMirror | None = None
         self._paperless_version: str = ""
 
@@ -234,6 +235,10 @@ class ArchivistBot(MicroBot):
             logger.warning("[archivist] {}", e)
 
         self._http = aiohttp.ClientSession()
+        self._paperless = PaperlessAPI(self._http, self.paperless_url, self.paperless_token)
+        self._classifier = Classifier(
+            self._http, self.openai_url, self.openai_key, bot_name=self.name,
+        )
         try:
             if self.mirror_to_git:
                 self._init_mirror()
@@ -378,371 +383,6 @@ class ArchivistBot(MicroBot):
                 logger.error("[archivist] Download failed (HTTP {}): {}", resp.status, body)
                 return None
 
-    # ── Paperless API ────────────────────────────────────────────────────
-
-    def _paperless_headers(self) -> dict:
-        return {"Authorization": f"Token {self.paperless_token}"}
-
-    async def _paperless_upload(self, filename: str, data: bytes,
-                                 content_type: str | None = None) -> str | None:
-        """Upload a file to Paperless. Returns the task id on success.
-
-        When `content_type` is given it's set on the multipart field —
-        important for text-like files where aiohttp's default of
-        application/octet-stream stops Paperless from matching a parser
-        and the server returns 400 with no useful chat message. On
-        failure we log the response body (truncated) so the next 400
-        isn't a mystery.
-        """
-        form = aiohttp.FormData()
-        field_kwargs: dict = {"filename": filename}
-        if content_type:
-            field_kwargs["content_type"] = content_type
-        form.add_field("document", data, **field_kwargs)
-        try:
-            async with self._http.post(
-                f"{self.paperless_url}/api/documents/post_document/",
-                headers=self._paperless_headers(), data=form,
-            ) as resp:
-                if resp.status == 200:
-                    task_id = (await resp.text()).strip().strip('"')
-                    logger.info("[archivist] Uploaded {} → task {}", filename, task_id)
-                    return task_id
-                body = (await resp.text())[:400]
-                logger.error("[archivist] Upload failed (HTTP {}): {} — body: {}",
-                             resp.status, filename, body)
-                return None
-        except (aiohttp.ClientConnectionError, aiohttp.ClientError, OSError) as e:
-            logger.error("[archivist] Paperless unreachable: {}", e)
-            return None
-
-    async def _paperless_wait_task(self, task_id: str, timeout: int = 120) -> int | None:
-        """Poll Paperless for task completion. Raises PaperlessDuplicateError
-        when Paperless rejects the upload as a duplicate; returns None for
-        every other FAILURE / timeout / transport error so the caller can
-        render the generic `ocr_failed` message."""
-        import time
-        start = time.time()
-        while time.time() - start < timeout:
-            try:
-                async with self._http.get(
-                    f"{self.paperless_url}/api/tasks/?task_id={task_id}",
-                    headers=self._paperless_headers(),
-                ) as resp:
-                    if resp.status == 200:
-                        tasks = await resp.json()
-                        if tasks:
-                            task = tasks[0] if isinstance(tasks, list) else tasks
-                            status = task.get("status", "")
-                            if status == "SUCCESS":
-                                doc_id = task.get("related_document")
-                                return int(doc_id) if doc_id else None
-                            elif status == "FAILURE":
-                                result = task.get("result") or ""
-                                logger.error("[archivist] Task failed: {}", result)
-                                match = _DUPLICATE_RE.search(result)
-                                if match:
-                                    title = match.group(1).strip()
-                                    dup_id = int(match.group(2))
-                                    raise PaperlessDuplicateError(dup_id, title)
-                                return None
-            except (aiohttp.ClientConnectionError, aiohttp.ClientError, OSError) as e:
-                logger.error("[archivist] Paperless unreachable while waiting for task: {}", e)
-                return None
-            await asyncio.sleep(3)
-        logger.error("[archivist] Task {} timed out", task_id)
-        return None
-
-    async def _paperless_get_doc(self, doc_id: int) -> dict | None:
-        async with self._http.get(
-            f"{self.paperless_url}/api/documents/{doc_id}/",
-            headers=self._paperless_headers(),
-        ) as resp:
-            return await resp.json() if resp.status == 200 else None
-
-    async def _paperless_get_tags(self) -> dict:
-        async with self._http.get(
-            f"{self.paperless_url}/api/tags/?page_size=1000",
-            headers=self._paperless_headers(),
-        ) as resp:
-            if resp.status == 200:
-                return {t["name"]: t["id"] for t in (await resp.json()).get("results", [])}
-            return {}
-
-    async def _paperless_get_doc_types(self) -> dict:
-        async with self._http.get(
-            f"{self.paperless_url}/api/document_types/?page_size=1000",
-            headers=self._paperless_headers(),
-        ) as resp:
-            if resp.status == 200:
-                return {t["name"]: t["id"] for t in (await resp.json()).get("results", [])}
-            return {}
-
-    async def _paperless_get_correspondents(self) -> dict:
-        async with self._http.get(
-            f"{self.paperless_url}/api/correspondents/?page_size=1000",
-            headers=self._paperless_headers(),
-        ) as resp:
-            if resp.status == 200:
-                return {c["name"]: c["id"] for c in (await resp.json()).get("results", [])}
-            return {}
-
-    # ── Paperless entity creation ──────────────────────────────────────
-    #
-    # All entities use matching_algorithm=0 (disabled). The LLM classifies
-    # every document; Paperless just stores what the LLM decides.
-    #
-    # Why not auto-learn (algorithm 6)?
-    #
-    # Paperless auto-assigns during document consumption -- BEFORE the LLM
-    # runs. With algorithm 6, Paperless learns from the first few LLM-assigned
-    # documents, then starts pre-assigning based on that tiny sample:
-    #
-    #   1. LLM tags three invoices as "Shopping"
-    #   2. Paperless learns: "Shopping" = common tag
-    #   3. Paperless auto-assigns "Shopping" to every new document at ingest
-    #   4. LLM adds the correct tag, but "Shopping" is already there too
-    #   5. Result: every document gets "Shopping" regardless of content
-    #
-    # Same failure mode hit correspondents: "Denny Gunawan" (first correspondent
-    # created) got auto-assigned to all subsequent documents.
-    #
-    # Algorithm 0 means: Paperless never guesses. The LLM reads the actual
-    # document text and makes the call. If the LLM is unavailable, documents
-    # get filed without tags -- the user can classify manually in the UI.
-
-    async def _paperless_create_tag(self, name: str, color: str = "#9e9e9e") -> int | None:
-        async with self._http.post(
-            f"{self.paperless_url}/api/tags/",
-            headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={
-                "name": name,
-                "color": color,
-                "matching_algorithm": 0,
-                "is_insensitive": True,
-            },
-        ) as resp:
-            if resp.status == 201:
-                data = await resp.json()
-                logger.info("[archivist] Created tag: {} (id={})", name, data["id"])
-                return data["id"]
-            return None
-
-    async def _paperless_create_doc_type(self, name: str) -> int | None:
-        async with self._http.post(
-            f"{self.paperless_url}/api/document_types/",
-            headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={
-                "name": name,
-                "matching_algorithm": 0,
-                "is_insensitive": True,
-            },
-        ) as resp:
-            if resp.status == 201:
-                return (await resp.json())["id"]
-            return None
-
-    async def _paperless_create_correspondent(self, name: str) -> int | None:
-        # matching_algorithm 0 (none): don't let Paperless auto-assign
-        # correspondents. The LLM reads the document and decides who sent
-        # it. Paperless's auto-learn (6) guesses wrong with few samples
-        # (e.g. assigns the first correspondent to every new document).
-        async with self._http.post(
-            f"{self.paperless_url}/api/correspondents/",
-            headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json={
-                "name": name,
-                "matching_algorithm": 0,
-            },
-        ) as resp:
-            if resp.status == 201:
-                return (await resp.json())["id"]
-            return None
-
-    async def _paperless_update_doc(self, doc_id: int, updates: dict) -> bool:
-        async with self._http.patch(
-            f"{self.paperless_url}/api/documents/{doc_id}/",
-            headers={**self._paperless_headers(), "Content-Type": "application/json"},
-            json=updates,
-        ) as resp:
-            return resp.status == 200
-
-    async def _paperless_search(self, query: str, limit: int = 5) -> list[dict]:
-        async with self._http.get(
-            f"{self.paperless_url}/api/documents/",
-            headers=self._paperless_headers(),
-            params={"query": query, "page_size": limit, "ordering": "-created"},
-        ) as resp:
-            if resp.status == 200:
-                return (await resp.json()).get("results", [])
-            return []
-
-    # ── LLM (OpenAI-compatible API) ──────────────────────────────────────
-
-    async def _llm_request(self, task: str, prompt: str, json_mode: bool = False) -> str:
-        """Send a prompt to the LLM and return the response text.
-
-        The task name (e.g. "classifier", "reformat") is resolved to a
-        concrete model via resolve_model("archivist/{task}"). This walks:
-          1. [ai.models] archivist.classifier — task-specific
-          2. [ai.models] archivist            — bot-level
-          3. [ai] default                     — global fallback
-
-        Uses the OpenAI-compatible chat completions API — works with oMLX,
-        Ollama, LM Studio, or any provider that serves /v1/chat/completions.
-        """
-        model = resolve_model(f"{self.name}/{task}")
-
-        headers = {"Content-Type": "application/json"}
-        if self.openai_key:
-            headers["Authorization"] = f"Bearer {self.openai_key}"
-
-        body = {
-            "model": model,
-            "messages": [{"role": "user", "content": prompt}],
-        }
-        if json_mode:
-            body["response_format"] = {"type": "json_object"}
-
-        url = self.openai_url.rstrip("/")
-        if not url:
-            raise LLMUnavailableError("No AI endpoint configured — set up AI with 'stack up ai'")
-        if not url.endswith("/chat/completions"):
-            url = url.rstrip("/") + "/chat/completions"
-
-        with _timed(f"LLM {task} (model={model})"):
-            try:
-                async with self._http.post(
-                    url, headers=headers, json=body,
-                    timeout=aiohttp.ClientTimeout(total=300),
-                ) as resp:
-                    if resp.status == 200:
-                        result = await resp.json()
-                        return result["choices"][0]["message"]["content"]
-                    elif resp.status == 401:
-                        raise LLMUnavailableError("Authentication failed — check [ai].openai_key in stack.toml")
-                    elif resp.status == 404:
-                        body_text = await resp.text()
-                        if "not found" in body_text.lower():
-                            raise LLMModelNotFoundError(f"{model} — is it loaded in oMLX?")
-                        raise LLMUnavailableError(f"HTTP 404: {body_text[:200]}")
-                    else:
-                        raise LLMUnavailableError(f"HTTP {resp.status}")
-            except asyncio.TimeoutError:
-                raise LLMTimeoutError(f"{model} — model may still be loading, try again")
-            except (LLMUnavailableError, LLMModelNotFoundError, LLMTimeoutError):
-                raise
-            except Exception as e:
-                raise LLMUnavailableError(f"{e}")
-
-    async def _classify(self, ocr_text: str, tags: dict, doc_types: dict, correspondents: dict) -> dict:
-        """Ask the LLM to classify a document based on its OCR text.
-
-        Returns structured JSON with:
-        - topics: subject areas (1-2 tags, e.g. ["Insurance", "Medical"])
-        - persons: which family members this belongs to
-        - correspondent: who sent/issued this document
-        - document_type: optional format (Invoice, Receipt, etc.)
-        """
-        person_tags = [t for t in tags if t.startswith("Person: ")]
-        # Strip "Person: " prefix for the prompt so the LLM sees clean
-        # first names like "Homer", "Marge" -- not "Person: Homer".
-        person_names = [t.replace("Person: ", "") for t in person_tags]
-        category_tags = [t for t in tags if not t.startswith("Person: ")]
-        truncated = ocr_text[:3000]
-
-        # ── Classification prompt ────────────────────────────────────────
-        #
-        # Simplified to three clear axes:
-        #   topic         = what is this about?   "Insurance", "Shopping"
-        #   person        = which family member?   "Homer", "Bart", or null
-        #   correspondent = who sent it?           "Springfield Nuclear", "Kwik-E-Mart"
-        #
-        # A Kwik-E-Mart receipt for Homer:
-        #   topic="Shopping", person="Homer", correspondent="Kwik-E-Mart"
-        # A school letter about Bart:
-        #   topics=["School"], person="Bart", correspondent="Springfield Elementary"
-        # A health insurance invoice for Homer:
-        #   topics=["Insurance", "Medical"], person="Homer", correspondent="AOK"
-
-        prompt = f"""Classify this document. Return ONLY a JSON object.
-
-IMPORTANT: Always prefer existing values from the lists below. Only suggest
-a new value when NOTHING in the list is a reasonable match.
-
-Family members: {json.dumps(person_names, ensure_ascii=False)}
-Existing topic tags: {json.dumps(category_tags, ensure_ascii=False)}
-Existing document types: {json.dumps(list(doc_types.keys()), ensure_ascii=False)}
-Existing correspondents: {json.dumps(list(correspondents.keys()), ensure_ascii=False)}
-
-Return this exact JSON structure:
-{{
-  "title": "scannable title: [Correspondent] - [what] [key amount]. E.g. 'Anthropic - Max Plan EUR 90.00', 'ADAC - Kfz-Versicherung 2026 EUR 340'. Must be useful when scanning a list of 500 documents. Max 128 chars. Document's language.",
-  "date": "YYYY-MM-DD or null",
-  "topics": ["what is this document about? One or two subject areas. E.g. ['Insurance'], ['Insurance', 'Vehicle'], ['Shopping']. A health insurance bill is ['Insurance', 'Medical']. A car repair invoice is ['Vehicle']. Pick from existing topic tags when possible. Usually one topic, two only when the document genuinely spans two areas."],
-  "persons": ["which family members does this belong to? Pick from the family members list by first name. Can be multiple for joint documents (marriage, family insurance). Empty list if unclear. These are who the document is FOR or ABOUT, not who sent it."],
-  "document_type": "optional: what format is this? Invoice, Receipt, Contract, Letter, Certificate, or null if unclear.",
-  "correspondent": "the SENDER or ISSUING ORGANIZATION, or null if unclear. Who wrote or sent this? NOT the recipient. On an invoice, this is the company that billed, not the customer. Use the shortest recognizable name. null is better than guessing.",
-  "summary": "2-3 sentence summary with key facts: amounts, dates, names, deadlines",
-  "facts": ["key structured facts, e.g. 'Total: EUR 90.00', 'Invoice: #12345', 'Plan: Premium'"],
-  "action_items": [{{"action": "what needs to happen", "due": "YYYY-MM-DD or null"}}]
-}}
-
-Rules:
-- LANGUAGE: use the document's original language for title, summary, facts, and action_items. A German document gets a German title and German facts. Never translate.
-- topics: the subject area(s), not the document format. An invoice from a shop is ["Shopping"], not ["Invoice"]. An invoice for insurance is ["Insurance"]. A health insurance claim is ["Insurance", "Medical"]. Use the document's language for new topic tags too. Most documents have one topic; use two only when clearly spanning two areas.
-- persons: match by first name from the family members list. Can be multiple for joint documents. A marriage certificate for Homer and Marge: ["Homer", "Marge"]. A personal invoice for Homer only: ["Homer"].
-- correspondent: always the SENDER, never the addressee/customer/recipient. Use null if the sender is not clearly identifiable. Do not guess from fragments.
-- facts: concrete numbers, dates, account numbers, amounts. Empty list if none.
-- action_items: deadlines, payments due, forms to return. Empty list if none.
-
-Document text:
----
-{truncated}
----"""
-
-        response = await self._llm_request("classifier", prompt, json_mode=True)
-        try:
-            return json.loads(response) if response else {}
-        except json.JSONDecodeError:
-            logger.warning("[archivist] LLM returned invalid JSON: {}", response[:200])
-            return {}
-
-    async def _reformat(self, ocr_text: str) -> str | None:
-        """Reformat raw OCR text into clean, readable Markdown.
-
-        OCR output is often messy: broken lines, garbled characters, no
-        structure. The LLM fixes artifacts while preserving all factual
-        content. The reformatted text replaces the original in Paperless,
-        making documents actually readable. Non-critical — if it fails,
-        the original OCR text is kept.
-        """
-        prompt = f"""Reformat this OCR-scanned document into clean, well-structured Markdown.
-
-Rules:
-- Fix OCR artifacts, broken lines, and garbled text
-- Correct obvious OCR errors in names and words
-- Preserve ALL factual content: numbers, dates, names, amounts, addresses
-- Structure with appropriate headings, lists, and tables
-- Do NOT summarize, translate, or add any content not in the original
-- NEVER guess or invent values — mark unreadable text as [unreadable]
-- If something is unreadable garbage (TSE signatures, hash strings), omit it
-- Keep the document language as-is
-- Output ONLY the formatted markdown, nothing else
-
-OCR text:
----
-{ocr_text[:6000]}
----"""
-
-        try:
-            result = await self._llm_request("reformat", prompt)
-            if result and len(result.strip()) > 20:
-                return result.strip()
-            return None
-        except (LLMUnavailableError, LLMTimeoutError):
-            return None
-
     # ── Document processing pipeline ─────────────────────────────────────
 
     async def _process_document(
@@ -781,13 +421,13 @@ OCR text:
         else:
             upload_filename, upload_type = filename, None
 
-        task_id = await self._paperless_upload(upload_filename, file_data, content_type=upload_type)
+        task_id = await self._paperless.upload(upload_filename, file_data, content_type=upload_type)
         if not task_id:
             await self._send(room_id, self.t("upload_failed", name=display_name), reply_to)
             return
 
         try:
-            doc_id = await self._paperless_wait_task(task_id)
+            doc_id = await self._paperless.wait_task(task_id)
         except PaperlessDuplicateError as e:
             await self._send(room_id, self._duplicate_reply(display_name, e), reply_to)
             return
@@ -801,7 +441,7 @@ OCR text:
         # the richness of the mirror entry rather than dropping it entirely.
 
         link = f"{self.paperless_public_url}/documents/{doc_id}/details" if self.paperless_public_url else ""
-        doc = await self._paperless_get_doc(doc_id)
+        doc = await self._paperless.get_doc(doc_id)
 
         if not doc:
             # Paperless accepted the upload but we can't read the doc back.
@@ -817,120 +457,29 @@ OCR text:
         ocr_text = doc.get("content", "") or ""
         has_text = len(ocr_text.strip()) >= 10
 
-        # ── Enrichment state ─────────────────────────────────────────────
-        # Populated when classification succeeds, untouched otherwise so
-        # the mirror and chat-reply branches read the same outcome.
-        classification: dict = {}
-        llm_error: tuple[str, dict] | None = None
-        resolved_topics: list[str] = []
-        resolved_persons: list[str] = []
-        resolved_correspondent: str | None = None
-        resolved_type: str | None = None
-        summary: list[str] = []
-        created_new: list[str] = []
-        updates: dict = {}
-        title: str | None = None
-
-        # ── Classify (only if enabled and we have text) ──────────────────
+        # ── Enrich via the shared pipeline ───────────────────────────────
+        # Pipeline hands back structured data; this function renders it for
+        # Matrix. When classification is disabled or the doc has no text,
+        # we skip the LLM call entirely by handing back an empty result.
         if self.classify_enabled and has_text:
-            tags = await self._paperless_get_tags()
-            doc_types = await self._paperless_get_doc_types()
-            correspondents = await self._paperless_get_correspondents()
+            result = await enrich_document(
+                paperless=self._paperless,
+                classifier=self._classifier,
+                doc=doc,
+            )
+        else:
+            result = EnrichResult()
 
-            try:
-                classification = await self._classify(ocr_text, tags, doc_types, correspondents)
-            except LLMUnavailableError:
-                llm_error = ("llm_unavailable",
-                             {"name": display_name, "url": self.openai_url, "link": link})
-            except LLMModelNotFoundError as e:
-                llm_error = ("llm_model_missing",
-                             {"name": display_name, "model": str(e), "link": link})
-            except LLMTimeoutError:
-                llm_error = ("llm_timeout",
-                             {"name": display_name, "link": link})
-
-        # ── Apply classification to Paperless (if we got one) ────────────
-        if classification:
-            title = classification.get("title")
-            if title and isinstance(title, str):
-                updates["title"] = title[:MAX_TITLE_LENGTH]
-
-            # Topic tags — LLM returns 1-2 topics; match_topics splits
-            # against existing tags (ignoring "Person: " ones) and flags
-            # the rest for creation.
-            tag_ids = list(doc.get("tags", []))
-            category_tags_dict = {t: tags[t] for t in tags if not t.startswith("Person: ")}
-            topics_raw = classification.get("topics") or classification.get("topic")
-            matched_topics, new_topics = match_topics(topics_raw, category_tags_dict)
-            for mt in matched_topics:
-                tag_ids.append(tags[mt])
-                resolved_topics.append(mt)
-                summary.append(self.t("category", value=mt))
-            for nt in new_topics:
-                new_id = await self._paperless_create_tag(nt, "#4caf50")
-                if new_id:
-                    tag_ids.append(new_id)
-                    resolved_topics.append(nt)
-                    summary.append(self.t("category_new", value=nt))
-                    created_new.append(f"tag \"{nt}\"")
-
-            # Person tags — closed set, never create. match_persons handles
-            # strings, lists, full names, and "Person: X" prefixes.
-            persons_raw = classification.get("persons") or classification.get("person")
-            person_tags_matched = match_persons(persons_raw, tags)
-            for pt in person_tags_matched:
-                tag_ids.append(tags[pt])
-                name = pt.replace("Person: ", "")
-                resolved_persons.append(name)
-                summary.append(self.t("person", value=name))
-
-            if tag_ids:
-                updates["tags"] = list(set(tag_ids))
-
-            # Document type — respect a manual type; otherwise apply/create.
-            doc_type = classification.get("document_type")
-            if not _is_empty(doc_type):
-                existing_type = doc.get("document_type")
-                if existing_type:
-                    summary.append(self.t("type", value=doc_type))
-                else:
-                    matched = fuzzy_match_entity(doc_type, doc_types)
-                    if matched:
-                        updates["document_type"] = doc_types[matched]
-                        resolved_type = matched
-                        summary.append(self.t("type", value=matched))
-                    else:
-                        new_id = await self._paperless_create_doc_type(doc_type)
-                        if new_id:
-                            updates["document_type"] = new_id
-                            resolved_type = doc_type
-                            summary.append(self.t("type_new", value=doc_type))
-                            created_new.append(f"document type \"{doc_type}\"")
-
-            # Correspondent — always overwrite Paperless's auto-classifier
-            # guess; the LLM has read the actual text and knows better.
-            correspondent = classification.get("correspondent")
-            if not _is_empty(correspondent):
-                matched = fuzzy_match_entity(correspondent, correspondents)
-                if matched:
-                    updates["correspondent"] = correspondents[matched]
-                    resolved_correspondent = matched
-                    summary.append(self.t("from", value=matched))
-                else:
-                    new_id = await self._paperless_create_correspondent(correspondent)
-                    if new_id:
-                        updates["correspondent"] = new_id
-                        resolved_correspondent = correspondent
-                        summary.append(self.t("from_new", value=correspondent))
-                        created_new.append(f"correspondent \"{correspondent}\"")
-
-            date = classification.get("date")
-            if date and isinstance(date, str) and re.match(r'^\d{4}-\d{2}-\d{2}$', date):
-                updates["created"] = date
-                summary.append(self.t("date", value=date))
-
-            if updates:
-                await self._paperless_update_doc(doc_id, updates)
+        classification = result.classification
+        resolved_topics = result.resolved_topics
+        resolved_persons = result.resolved_persons
+        resolved_correspondent = result.resolved_correspondent
+        resolved_type = result.resolved_type
+        created_new = result.created_new
+        llm_error = _llm_error_for_chat(
+            result.llm_error,
+            name=display_name, openai_url=self.openai_url, link=link,
+        )
 
         # ── Reformat (only when we had a classification, and only for
         #               non-text files — a .md is already clean, reformatting
@@ -939,10 +488,13 @@ OCR text:
         reformat_failed = False
         formatted: str | None = None
         if classification and self.reformat_enabled and not is_text:
-            formatted = await self._reformat(ocr_text)
-            if formatted:
-                await self._paperless_update_doc(doc_id, {"content": formatted})
-            else:
+            formatted = await reformat_document(
+                paperless=self._paperless,
+                classifier=self._classifier,
+                doc_id=doc_id,
+                ocr_text=ocr_text,
+            )
+            if not formatted:
                 reformat_failed = True
 
         # ── Mirror to Forgejo (always, when configured) ─────────────────
@@ -1024,14 +576,24 @@ OCR text:
             #
             #   http://...
 
+            title = classification.get("title")
             display_title = title or display_name
             lines = [self.t("filed", title=display_title, doc_id=doc_id)]
 
-            # Compact metadata line: topic | type | from | date
-            meta_parts = []
-            for s in summary:
-                value = s.split(": ", 1)[-1] if ": " in s else s
-                meta_parts.append(value)
+            # Compact metadata line: topic(s) | person(s) | type | from | date.
+            # Built from EnrichResult.resolved_* so the values on screen match
+            # exactly what was written to Paperless — no translation-key
+            # round-trip needed.
+            meta_parts: list[str] = []
+            meta_parts.extend(resolved_topics)
+            meta_parts.extend(resolved_persons)
+            if resolved_type:
+                meta_parts.append(resolved_type)
+            if resolved_correspondent:
+                meta_parts.append(resolved_correspondent)
+            date_applied = result.updates_applied.get("created")
+            if date_applied:
+                meta_parts.append(date_applied)
             if meta_parts:
                 lines.extend(["", "  " + " | ".join(meta_parts)])
 
@@ -1068,8 +630,13 @@ OCR text:
 
             await self._send(room_id, "\n".join(lines), reply_to)
 
+        processed_parts = [*resolved_topics, *resolved_persons]
+        if resolved_type:
+            processed_parts.append(resolved_type)
+        if resolved_correspondent:
+            processed_parts.append(resolved_correspondent)
         logger.info("[archivist] Processed: {} → doc {} [{}]",
-                     filename, doc_id, ", ".join(summary) or "no-classification")
+                     filename, doc_id, ", ".join(processed_parts) or "no-classification")
 
         # ── Structured event — always, once Paperless has the doc ───────
         # Element ignores unknown event types, so the event rides next to
@@ -1276,7 +843,7 @@ OCR text:
     # ── Search ───────────────────────────────────────────────────────────
 
     async def _handle_search(self, room_id: str, query: str, reply_to: str | None = None):
-        results = await self._paperless_search(query)
+        results = await self._paperless.search(query)
         if not results:
             await self._send(room_id, self.t("search_no_results", query=query), reply_to)
             return
@@ -1295,7 +862,7 @@ OCR text:
 
     async def _handle_show(self, room_id: str, doc_id: int, reply_to: str | None = None):
         """Fetch a document's content from Paperless and return it as Markdown."""
-        doc = await self._paperless_get_doc(doc_id)
+        doc = await self._paperless.get_doc(doc_id)
         if not doc:
             await self._send(room_id, f"Document #{doc_id} not found.", reply_to)
             return

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -15,6 +15,14 @@ Commands:
     show <id> [--content]       pretty-print Paperless state
     classify <id> [--json]      dry classify — LLM JSON output, no writes
     reformat <id> [--raw]       dry reformat — clean markdown, no writes
+    reclassify <id> [<id>...]   re-run the pipeline + apply to Paperless.
+                                reformat + mirror default to bot.toml's
+                                [settings] — flags below only override.
+                                flags: --[no-]reformat --[no-]mirror --dry-run
+    mirror <id> [<id>...]       push docs to the Forgejo mirror using their
+                                current Paperless state (no LLM). Useful for
+                                backfilling after enabling mirror_to_git.
+                                flags: --dry-run
 """
 
 from __future__ import annotations
@@ -30,7 +38,13 @@ sys.path.insert(0, "/app")  # stack.resolve_model, stack.prompt
 
 import aiohttp
 
-from pipeline import Classifier, PaperlessAPI
+from pipeline import (
+    Classifier,
+    EnrichResult,
+    PaperlessAPI,
+    enrich_document,
+    reformat_document,
+)
 
 
 def _err(msg: str) -> None:
@@ -47,6 +61,8 @@ async def main(argv: list[str]) -> int:
         "show": _show,
         "classify": _classify,
         "reformat": _reformat,
+        "reclassify": _reclassify,
+        "mirror": _mirror_cmd,
     }
     fn = handlers.get(cmd)
     if not fn:
@@ -263,6 +279,510 @@ def _print_reformat_result(formatted: str | None, source_chars: int) -> None:
     print(formatted)
     print(f"\n  {DIM}{'─' * 60}{RESET}")
     print(f"  {DIM}--dry-run: no changes made to Paperless.{RESET}\n")
+
+
+# ── reclassify ──────────────────────────────────────────────────────────
+
+async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
+                      argv: list[str]) -> int:
+    dry_run = "--dry-run" in argv
+
+    # Defaults come from the archivist's bot.toml so the CLI behaves the
+    # same way the bot does for a new upload. Explicit flags override.
+    settings = _read_bot_toml_settings()
+    reformat = settings.get("reformat", True)
+    if "--no-reformat" in argv:
+        reformat = False
+    elif "--reformat" in argv:
+        reformat = True
+    mirror_enabled = settings.get("mirror_to_git", False)
+    if "--no-mirror" in argv:
+        mirror_enabled = False
+    elif "--mirror" in argv:
+        mirror_enabled = True
+
+    flag_tokens = {"--dry-run", "--reformat", "--no-reformat",
+                   "--mirror", "--no-mirror"}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
+    if not positional:
+        _err("Usage: reclassify <id> [<id>...] [--[no-]reformat] [--[no-]mirror] [--dry-run]")
+        return 2
+
+    doc_ids: list[int] = []
+    for p in positional:
+        parsed = _parse_doc_id(p)
+        if parsed is None:
+            return 2
+        doc_ids.append(parsed)
+
+    mirror = _build_mirror_like_bot() if mirror_enabled else None
+    if mirror_enabled and mirror is None:
+        _err("Mirror enabled but required env (CODE_URL / admin creds) is missing. "
+             "Bring up `code` or pass --no-mirror.")
+        return 1
+
+    successes = 0
+    failures = 0
+    for doc_id in doc_ids:
+        ok = await _reclassify_one(
+            paperless, classifier, mirror,
+            doc_id=doc_id, reformat=reformat, dry_run=dry_run,
+        )
+        if ok:
+            successes += 1
+        else:
+            failures += 1
+
+    _print_reclassify_summary(successes, failures, dry_run=dry_run)
+    return 0 if failures == 0 else 1
+
+
+async def _reclassify_one(
+    paperless: PaperlessAPI, classifier: Classifier, mirror,
+    *, doc_id: int, reformat: bool, dry_run: bool,
+) -> bool:
+    """Re-enrich one Paperless doc. Returns True on success, False on any failure."""
+    doc = await paperless.get_doc(doc_id)
+    if not doc:
+        _err(f"Document #{doc_id} not found")
+        return False
+
+    tags = await paperless.get_tags()
+    doc_types = await paperless.get_doc_types()
+    correspondents = await paperless.get_correspondents()
+    before = _snapshot_doc(doc, tags, doc_types, correspondents)
+
+    pipeline_paperless = _DryRunPaperless(paperless) if dry_run else paperless
+    result = await enrich_document(
+        paperless=pipeline_paperless, classifier=classifier, doc=doc,
+    )
+    if result.llm_error:
+        kind, detail = result.llm_error
+        _err(f"#{doc_id}: LLM {kind} — {detail}")
+        return False
+    if not result.classification:
+        _err(f"#{doc_id}: classifier returned nothing")
+        return False
+
+    # Reformat — only meaningful on binary-origin docs; Paperless doesn't
+    # distinguish, so we always offer it as opt-in and trust the user.
+    formatted: str | None = None
+    if reformat:
+        ocr_text = (doc.get("content") or "").strip()
+        if dry_run:
+            formatted = await classifier.reformat(ocr_text)
+            if formatted and len(formatted) <= 20:
+                formatted = None
+        else:
+            formatted = await reformat_document(
+                paperless=paperless, classifier=classifier,
+                doc_id=doc_id, ocr_text=ocr_text,
+            )
+
+    # Mirror — refetch to get the post-PATCH state; skip for dry-run.
+    mirror_path: str | None = None
+    if mirror and not dry_run:
+        refreshed = await paperless.get_doc(doc_id) or doc
+        mirror_path = await _publish_mirror(
+            mirror, refreshed, result, formatted=formatted,
+        )
+
+    _print_reclassify_diff(
+        doc_id=doc_id, before=before, result=result,
+        reformatted=bool(formatted), mirror_path=mirror_path,
+        mirror_enabled=mirror is not None, dry_run=dry_run,
+    )
+    return True
+
+
+# ── reclassify: no-op writer for --dry-run ──────────────────────────────
+
+class _DryRunPaperless:
+    """Read-through wrapper that stubs every write so `enrich_document`
+    computes its plan without touching Paperless.
+
+    Reads delegate to the real PaperlessAPI. Writes return synthetic ids
+    (so `tag_ids.append(new_id)` still works downstream) and True for
+    updates. Safe to pass wherever pipeline expects a PaperlessAPI.
+    """
+
+    def __init__(self, real: PaperlessAPI):
+        self._real = real
+        self._fake_id = 10_000_000
+
+    async def get_doc(self, doc_id): return await self._real.get_doc(doc_id)
+    async def get_tags(self): return await self._real.get_tags()
+    async def get_doc_types(self): return await self._real.get_doc_types()
+    async def get_correspondents(self): return await self._real.get_correspondents()
+
+    async def update_doc(self, *a, **kw): return True
+
+    async def create_tag(self, *a, **kw):
+        self._fake_id += 1
+        return self._fake_id
+
+    async def create_doc_type(self, *a, **kw):
+        self._fake_id += 1
+        return self._fake_id
+
+    async def create_correspondent(self, *a, **kw):
+        self._fake_id += 1
+        return self._fake_id
+
+
+# ── reclassify: mirror bootstrap ────────────────────────────────────────
+
+def _read_bot_toml_settings() -> dict:
+    """Read [settings] from the archivist's bot.toml (same file the bot reads)."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        from stack._compat import tomllib
+    path = Path("/stacklets/docs/bot/bot.toml")
+    if not path.exists():
+        return {}
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    return data.get("settings", {})
+
+
+def _mirror_enabled_in_bot_toml() -> bool:
+    return bool(_read_bot_toml_settings().get("mirror_to_git", False))
+
+
+def _build_mirror_like_bot():
+    """Build a GitMirror exactly like the archivist bot's `_init_mirror`.
+
+    Reuses the bot's creds file at /data/docs/bot/forgejo-creds.json so
+    the CLI and the bot authenticate as the same Forgejo user. Returns
+    None when required env is missing (typically code stacklet down).
+    """
+    code_url = os.environ.get("CODE_URL", "")
+    admin_user = os.environ.get("MATRIX_ADMIN_USER", "")
+    admin_password = os.environ.get("MATRIX_ADMIN_PASSWORD", "")
+    admin_ids = os.environ.get("STACK_ADMIN_USER_IDS", "")
+    if not (code_url and admin_user and admin_password):
+        return None
+
+    admin_usernames: list[str] = []
+    for raw in admin_ids.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        name = raw.lstrip("@").split(":", 1)[0]
+        if name and name != admin_user:
+            admin_usernames.append(name)
+
+    from git_mirror import GitMirror
+    settings = _read_bot_toml_settings()
+    return GitMirror(
+        code_url=code_url,
+        admin_user=admin_user,
+        admin_password=admin_password,
+        admin_usernames=admin_usernames,
+        data_dir=Path("/data/docs/bot"),
+        org_name=settings.get("mirror_org", "family"),
+    )
+
+
+async def _publish_mirror(
+    mirror, doc: dict, result: EnrichResult,
+    *, formatted: str | None,
+) -> str | None:
+    """Publish a mirror entry for the re-enriched doc. Returns path or None."""
+    from stack import resolve_model
+
+    ocr_text = doc.get("content") or ""
+    if formatted:
+        body_text = formatted
+        processing = "ai_formatted"
+        try:
+            model = resolve_model("archivist-bot/reformat")
+        except ValueError:
+            model = None
+    else:
+        body_text = ocr_text
+        processing = "ocr"
+        model = None
+
+    enriched = dict(result.classification) if result.classification else {}
+    enriched["topics"] = result.resolved_topics
+    enriched["persons"] = result.resolved_persons
+    enriched["correspondent"] = result.resolved_correspondent
+    enriched["document_type"] = result.resolved_type
+    paperless_tags = [
+        *result.resolved_topics,
+        *(f"Person: {p}" for p in result.resolved_persons),
+    ]
+
+    paperless_url = (os.environ.get("PAPERLESS_PUBLIC_URL")
+                     or os.environ.get("PAPERLESS_URL", ""))
+    try:
+        ok = await mirror.publish(
+            paperless_id=doc["id"],
+            classification=enriched,
+            body_text=body_text,
+            processing=processing,
+            model=model,
+            paperless_url=paperless_url,
+            tags=paperless_tags,
+            fallback_title=doc.get("title"),
+        )
+    except Exception as e:
+        _err(f"#{doc['id']}: mirror publish failed — {e}")
+        return None
+    return mirror._cache.get(doc["id"]) if ok else None
+
+
+# ── reclassify: state snapshot + diff rendering ─────────────────────────
+
+def _snapshot_doc(doc: dict, tags: dict, doc_types: dict,
+                  correspondents: dict) -> dict:
+    """Capture the human-readable state of a doc as a flat dict."""
+    tag_name = {tid: name for name, tid in tags.items()}
+    type_name = {tid: name for name, tid in doc_types.items()}
+    corr_name = {tid: name for name, tid in correspondents.items()}
+
+    current_tags = [tag_name.get(t, f"#{t}") for t in (doc.get("tags") or [])]
+    topics = sorted(t for t in current_tags if not t.startswith("Person: "))
+    persons = sorted(t.replace("Person: ", "") for t in current_tags
+                     if t.startswith("Person: "))
+
+    return {
+        "title": doc.get("title") or "",
+        "topics": topics,
+        "persons": persons,
+        "correspondent": corr_name.get(doc.get("correspondent")),
+        "document_type": type_name.get(doc.get("document_type")),
+        "date": (doc.get("created") or "")[:10],
+    }
+
+
+def _print_reclassify_diff(*, doc_id: int, before: dict, result: EnrichResult,
+                            reformatted: bool, mirror_path: str | None,
+                            mirror_enabled: bool, dry_run: bool) -> None:
+    from stack.prompt import BOLD, DIM, GREEN, ORANGE, RESET, TEAL
+
+    after_title = result.classification.get("title") or before["title"]
+    after_date = result.updates_applied.get("created") or before["date"]
+
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
+    print()
+    print(f"  {ORANGE}#{doc_id}{RESET}  {BOLD}{after_title}{RESET}{marker}")
+
+    _diff_row("title", before["title"], after_title)
+    _diff_row("topic", ", ".join(before["topics"]),
+              ", ".join(sorted(_union(before["topics"], result.resolved_topics))))
+    _diff_row("person", ", ".join(before["persons"]),
+              ", ".join(sorted(_union(before["persons"], result.resolved_persons))))
+    _diff_row("correspondent", before["correspondent"],
+              result.resolved_correspondent or before["correspondent"])
+    _diff_row("document_type", before["document_type"],
+              result.resolved_type or before["document_type"])
+    _diff_row("date", before["date"], after_date)
+
+    if reformatted:
+        verb = "would reformat" if dry_run else "reformatted"
+        print(f"    {DIM}reformat:{RESET}       {TEAL}{verb}{RESET}")
+
+    if dry_run:
+        if mirror_enabled:
+            print(f"    {DIM}mirror:{RESET}         {DIM}skipped (--dry-run){RESET}")
+    elif mirror_enabled:
+        status = f"{GREEN}{mirror_path}{RESET}" if mirror_path else f"{ORANGE}failed{RESET}"
+        print(f"    {DIM}mirror:{RESET}         {status}")
+
+    if result.created_new:
+        print(f"    {DIM}created:{RESET}        {TEAL}{', '.join(result.created_new)}{RESET}")
+
+
+def _diff_row(label: str, before_value, after_value) -> None:
+    from stack.prompt import DIM, RESET, TEAL
+    before_disp = before_value if before_value else "(none)"
+    after_disp = after_value if after_value else "(none)"
+    if str(before_disp) == str(after_disp):
+        return
+    print(f"    {DIM}{label + ':':<15}{RESET} {before_disp}  {DIM}→{RESET}  {TEAL}{after_disp}{RESET}")
+
+
+def _union(a: list[str], b: list[str]) -> list[str]:
+    """Preserve order-insensitive union for diff rendering."""
+    seen = set()
+    out = []
+    for item in [*a, *b]:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def _print_reclassify_summary(successes: int, failures: int, *, dry_run: bool) -> None:
+    from stack.prompt import DIM, GREEN, ORANGE, RESET
+    total = successes + failures
+    verb = "would reclassify" if dry_run else "reclassified"
+    print()
+    icon = f"{GREEN}✓{RESET}" if failures == 0 else f"{ORANGE}!{RESET}"
+    print(f"  {icon} {verb} {successes}/{total}" + (
+        f" ({failures} failed)" if failures else ""))
+    if dry_run:
+        print(f"  {DIM}--dry-run: no changes made to Paperless or the mirror.{RESET}")
+    print()
+
+
+# ── mirror (push existing docs, no LLM) ────────────────────────────────
+
+async def _mirror_cmd(paperless: PaperlessAPI, classifier: Classifier,
+                      argv: list[str]) -> int:
+    dry_run = "--dry-run" in argv
+    flag_tokens = {"--dry-run"}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
+    if not positional:
+        _err("Usage: mirror <id> [<id>...] [--dry-run]")
+        return 2
+
+    doc_ids: list[int] = []
+    for p in positional:
+        parsed = _parse_doc_id(p)
+        if parsed is None:
+            return 2
+        doc_ids.append(parsed)
+
+    settings = _read_bot_toml_settings()
+    if not settings.get("mirror_to_git", False):
+        _err("Mirror is disabled in stacklets/docs/bot/bot.toml (mirror_to_git = false). "
+             "Flip it to true first, then `stack up core` to reboot the bot.")
+        return 1
+
+    mirror = _build_mirror_like_bot()
+    if mirror is None:
+        _err("Mirror env missing — bring up `code` so CODE_URL / admin creds are set.")
+        return 1
+
+    tags = await paperless.get_tags()
+    doc_types = await paperless.get_doc_types()
+    correspondents = await paperless.get_correspondents()
+
+    successes = 0
+    failures = 0
+    for doc_id in doc_ids:
+        doc = await paperless.get_doc(doc_id)
+        if not doc:
+            _err(f"#{doc_id}: not found")
+            failures += 1
+            continue
+
+        if dry_run:
+            _print_mirror_row(doc, path=None, dry_run=True)
+            successes += 1
+            continue
+
+        path = await _mirror_existing(mirror, doc, tags, doc_types, correspondents)
+        _print_mirror_row(doc, path, dry_run=False)
+        if path:
+            successes += 1
+        else:
+            failures += 1
+
+    _print_mirror_summary(successes, failures, dry_run=dry_run)
+    return 0 if failures == 0 else 1
+
+
+async def _mirror_existing(mirror, doc: dict, tags: dict, doc_types: dict,
+                           correspondents: dict) -> str | None:
+    """Publish a mirror entry from the doc's current Paperless state.
+
+    No LLM call, no reclassification. `processing` is set to "ocr" because
+    we're shipping whatever Paperless's content field currently holds —
+    could be raw OCR, could be an earlier ai_formatted body. We don't
+    track provenance for backfill; the important thing is the mirror entry
+    exists and matches Paperless.
+    """
+    classification = _classification_from_doc(doc, tags, doc_types, correspondents)
+    paperless_tag_names = [
+        *classification.get("topics", []),
+        *(f"Person: {p}" for p in classification.get("persons", [])),
+    ]
+    body_text = doc.get("content") or ""
+    paperless_url = (os.environ.get("PAPERLESS_PUBLIC_URL")
+                     or os.environ.get("PAPERLESS_URL", ""))
+
+    try:
+        ok = await mirror.publish(
+            paperless_id=doc["id"],
+            classification=classification,
+            body_text=body_text,
+            processing="ocr",
+            model=None,
+            paperless_url=paperless_url,
+            tags=paperless_tag_names,
+            fallback_title=doc.get("title"),
+        )
+    except Exception as e:
+        _err(f"#{doc['id']}: mirror publish failed — {e}")
+        return None
+    return mirror._cache.get(doc["id"]) if ok else None
+
+
+def _classification_from_doc(doc: dict, tags: dict, doc_types: dict,
+                              correspondents: dict) -> dict:
+    """Reshape a Paperless doc's current fields into classification form.
+
+    Mirror.publish expects topics / persons / correspondent / document_type
+    as human-readable strings (not ids) — same shape the LLM produces.
+    """
+    tag_name = {tid: name for name, tid in tags.items()}
+    type_name = {tid: name for name, tid in doc_types.items()}
+    corr_name = {tid: name for name, tid in correspondents.items()}
+
+    doc_tag_names = [tag_name[t] for t in (doc.get("tags") or []) if t in tag_name]
+    topics = [t for t in doc_tag_names if not t.startswith("Person: ")]
+    persons = [t.replace("Person: ", "") for t in doc_tag_names
+               if t.startswith("Person: ")]
+    date = (doc.get("created") or "")[:10] or None
+
+    return {
+        "title": doc.get("title") or "",
+        "date": date,
+        "topics": topics,
+        "persons": persons,
+        "correspondent": corr_name.get(doc.get("correspondent")),
+        "document_type": type_name.get(doc.get("document_type")),
+    }
+
+
+def _print_mirror_row(doc: dict, path: str | None, *, dry_run: bool) -> None:
+    from stack.prompt import BOLD, DIM, GREEN, ORANGE, RESET, TEAL
+    title = doc.get("title") or "(no title)"
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
+    print()
+    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{title}{RESET}{marker}")
+    if dry_run:
+        print(f"    {DIM}mirror:{RESET} {TEAL}would publish{RESET}")
+    elif path:
+        print(f"    {DIM}mirror:{RESET} {GREEN}{path}{RESET}")
+    else:
+        print(f"    {DIM}mirror:{RESET} {ORANGE}failed{RESET}")
+
+
+def _print_mirror_summary(successes: int, failures: int, *, dry_run: bool) -> None:
+    from stack.prompt import DIM, GREEN, ORANGE, RESET
+    total = successes + failures
+    verb = "would mirror" if dry_run else "mirrored"
+    icon = f"{GREEN}✓{RESET}" if failures == 0 else f"{ORANGE}!{RESET}"
+    print()
+    print(f"  {icon} {verb} {successes}/{total}" + (
+        f" ({failures} failed)" if failures else ""))
+    if dry_run:
+        print(f"  {DIM}--dry-run: no commits to Forgejo.{RESET}")
+    print()
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -620,14 +620,16 @@ def _print_reprocess_diff(*, doc_id: int, before: dict, result: EnrichResult,
     print(f"  {ORANGE}#{doc_id}{RESET}  {BOLD}{after_title}{RESET}{marker}")
 
     _diff_row("title", before["title"], after_title)
+    # Fresh-reprocess semantics: the resolved_* lists ARE the new full
+    # state for topics and persons, not additions to the prior set.
     _diff_row("topic", ", ".join(before["topics"]),
-              ", ".join(sorted(_union(before["topics"], result.resolved_topics))))
+              ", ".join(sorted(result.resolved_topics)))
     _diff_row("person", ", ".join(before["persons"]),
-              ", ".join(sorted(_union(before["persons"], result.resolved_persons))))
+              ", ".join(sorted(result.resolved_persons)))
     _diff_row("correspondent", before["correspondent"],
-              result.resolved_correspondent or before["correspondent"])
+              result.resolved_correspondent)
     _diff_row("document_type", before["document_type"],
-              result.resolved_type or before["document_type"])
+              result.resolved_type)
     _diff_row("date", before["date"], after_date)
 
     if reformatted:
@@ -652,17 +654,6 @@ def _diff_row(label: str, before_value, after_value) -> None:
     if str(before_disp) == str(after_disp):
         return
     print(f"    {DIM}{label + ':':<15}{RESET} {before_disp}  {DIM}→{RESET}  {TEAL}{after_disp}{RESET}")
-
-
-def _union(a: list[str], b: list[str]) -> list[str]:
-    """Preserve order-insensitive union for diff rendering."""
-    seen = set()
-    out = []
-    for item in [*a, *b]:
-        if item not in seen:
-            seen.add(item)
-            out.append(item)
-    return out
 
 
 def _print_reprocess_summary(successes: int, failures: int, *, dry_run: bool) -> None:

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -39,6 +39,12 @@ Commands:
                                 delete seeded tags + types from the given
                                 language section that have zero documents.
                                 Safe cleanup for cold-start duplicates.
+    tags delete <name> [--type] [--dry]
+                                delete a single tag. Refuses to delete a
+                                tag that has documents attached — use
+                                merge instead to preserve assignments.
+                                With --type the operation runs on
+                                document_types.
 
 All dry flags accept `--dry` and `--dry-run` interchangeably.
 """
@@ -897,18 +903,20 @@ def _read_taxonomy() -> dict:
 
 # ── tags (dispatcher) ──────────────────────────────────────────────────
 
-_TAGS_SUBCOMMANDS = {"merge", "prune"}
+_TAGS_SUBCOMMANDS = {"merge", "prune", "delete"}
 
 
 async def _tags(paperless: PaperlessAPI, classifier: Classifier,
                 argv: list[str]) -> int:
-    """Dispatch `tags [merge|prune|...]`. Bare `tags` lists."""
+    """Dispatch `tags [merge|prune|delete|...]`. Bare `tags` lists."""
     if argv and argv[0] in _TAGS_SUBCOMMANDS:
         sub, rest = argv[0], argv[1:]
         if sub == "merge":
             return await _tags_merge(paperless, rest)
         if sub == "prune":
             return await _tags_prune(paperless, rest)
+        if sub == "delete":
+            return await _tags_delete(paperless, rest)
     return await _tags_list(paperless, argv)
 
 
@@ -1186,6 +1194,55 @@ def _print_merge_summary(src_name: str, dst_name: str, retagged: int,
     print(f"  {GREEN}✓{RESET} merged {kind} {src_name} → {dst_name} "
           f"({retagged} doc(s) retagged, source deleted)")
     print()
+
+
+# ── tags delete ────────────────────────────────────────────────────────
+
+async def _tags_delete(paperless: PaperlessAPI, argv: list[str]) -> int:
+    dry_run = _is_dry(argv)
+    is_type = "--type" in argv or "--types" in argv
+
+    flag_tokens = {"--type", "--types", *_DRY_FLAGS}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
+    if len(positional) != 1:
+        _err("Usage: tags delete <name> [--type] [--dry|--dry-run]")
+        return 2
+    name = positional[0]
+
+    endpoint = "document_types" if is_type else "tags"
+    kind = "type" if is_type else "tag"
+    records = await _paperless_list_full(paperless, endpoint)
+    by_name = {r["name"]: r for r in records}
+
+    entity = by_name.get(name)
+    if not entity:
+        _err(f"{kind.capitalize()} not found: {name!r}")
+        return 1
+    if (entity.get("document_count") or 0) > 0:
+        _err(f"{kind.capitalize()} {name!r} has {entity['document_count']} "
+             f"document(s) — use `tags merge` instead.")
+        return 1
+
+    from stack.prompt import BOLD, DIM, GREEN, ORANGE, RESET
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
+    verb = "Would delete" if dry_run else "Deleting"
+    print()
+    print(f"  {BOLD}{verb} {kind}: {name}{RESET}{marker}")
+    print(f"    {ORANGE}#{entity['id']}{RESET}  "
+          f"{DIM}(owner={entity.get('owner')}){RESET}")
+
+    if dry_run:
+        print()
+        return 0
+
+    if not await _paperless_delete(paperless, endpoint, entity["id"]):
+        return 1
+    print(f"  {GREEN}✓{RESET} deleted {kind} {name}\n")
+    return 0
 
 
 if __name__ == "__main__":

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -28,6 +28,17 @@ Commands:
                                 current Paperless state (no LLM). Useful for
                                 backfilling after enabling mirror_to_git.
                                 flags: --dry
+    tags [--types] [--owner=N] [--used|--unused]
+                                list Paperless tags (or types with --types),
+                                showing id, owner, document_count, name.
+    tags merge <from> <to> [--type] [--dry]
+                                retag every doc carrying <from> to carry
+                                <to> instead, then delete <from>. With
+                                --type the operation runs on document_types.
+    tags prune --lang <de|en> [--dry]
+                                delete seeded tags + types from the given
+                                language section that have zero documents.
+                                Safe cleanup for cold-start duplicates.
 
 All dry flags accept `--dry` and `--dry-run` interchangeably.
 """
@@ -70,6 +81,7 @@ async def main(argv: list[str]) -> int:
         "reformat": _reformat,
         "reprocess": _reprocess,
         "mirror": _mirror_cmd,
+        "tags": _tags,
     }
     fn = handlers.get(cmd)
     if not fn:
@@ -829,6 +841,351 @@ def _parse_doc_id(raw: str) -> int | None:
     except ValueError:
         _err(f"Invalid document id: {raw!r} (must be an integer)")
         return None
+
+
+# ── tags / prune / merge: taxonomy housekeeping ────────────────────────
+#
+# These three commands share one concern: Paperless's tag + document_type
+# tables drift over time (seed-language flips, pre-taxonomy legacy labels,
+# LLM-invented one-offs). The housekeeping path is:
+#
+#   tags            see what's there, grouped by owner and doc count
+#   prune           delete dead wrong-language entries (safe, 0 docs)
+#   merge           fold one tag/type into another, retagging live docs
+#
+# They talk directly to the tag + document_type endpoints via the same
+# aiohttp session PaperlessAPI owns, reusing its auth headers. PaperlessAPI
+# itself only knows about the bot's enrich path; keeping the CRUD extras
+# here avoids bloating the bot runtime with admin-only operations.
+
+
+async def _paperless_list_full(paperless: PaperlessAPI, endpoint: str) -> list[dict]:
+    """Return full entity records (with owner + document_count)."""
+    async with paperless.http.get(
+        f"{paperless.url}/api/{endpoint}/?page_size=1000",
+        headers=paperless._headers,
+    ) as resp:
+        if resp.status != 200:
+            return []
+        return (await resp.json()).get("results", [])
+
+
+async def _paperless_delete(paperless: PaperlessAPI, endpoint: str,
+                             entity_id: int) -> bool:
+    async with paperless.http.delete(
+        f"{paperless.url}/api/{endpoint}/{entity_id}/",
+        headers=paperless._headers,
+    ) as resp:
+        if resp.status in (200, 204):
+            return True
+        body = (await resp.text())[:200]
+        _err(f"DELETE /{endpoint}/{entity_id}/ → {resp.status}: {body}")
+        return False
+
+
+def _read_taxonomy() -> dict:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        from stack._compat import tomllib
+    path = Path("/stacklets/docs/taxonomy.toml")
+    if not path.exists():
+        return {}
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+# ── tags (dispatcher) ──────────────────────────────────────────────────
+
+_TAGS_SUBCOMMANDS = {"merge", "prune"}
+
+
+async def _tags(paperless: PaperlessAPI, classifier: Classifier,
+                argv: list[str]) -> int:
+    """Dispatch `tags [merge|prune|...]`. Bare `tags` lists."""
+    if argv and argv[0] in _TAGS_SUBCOMMANDS:
+        sub, rest = argv[0], argv[1:]
+        if sub == "merge":
+            return await _tags_merge(paperless, rest)
+        if sub == "prune":
+            return await _tags_prune(paperless, rest)
+    return await _tags_list(paperless, argv)
+
+
+async def _tags_list(paperless: PaperlessAPI, argv: list[str]) -> int:
+    show_types = "--types" in argv
+    only_used = "--used" in argv
+    only_unused = "--unused" in argv
+    owner_filter: int | None = None
+    for a in argv:
+        if a.startswith("--owner="):
+            try:
+                owner_filter = int(a.split("=", 1)[1])
+            except ValueError:
+                _err(f"Invalid --owner value: {a}")
+                return 2
+
+    flag_tokens = {"--types", "--used", "--unused"}
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens
+               and not a.startswith("--owner=")]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
+    if only_used and only_unused:
+        _err("--used and --unused are mutually exclusive")
+        return 2
+
+    endpoint = "document_types" if show_types else "tags"
+    records = await _paperless_list_full(paperless, endpoint)
+    if owner_filter is not None:
+        records = [r for r in records if r.get("owner") == owner_filter]
+    if only_used:
+        records = [r for r in records if (r.get("document_count") or 0) > 0]
+    if only_unused:
+        records = [r for r in records if (r.get("document_count") or 0) == 0]
+
+    _print_tags_table(records, kind="type" if show_types else "tag")
+    return 0
+
+
+def _print_tags_table(records: list[dict], *, kind: str) -> None:
+    from stack.prompt import BOLD, DIM, RESET
+    if not records:
+        print(f"\n  No {kind}s match.\n")
+        return
+    records.sort(key=lambda r: (-(r.get("document_count") or 0),
+                                r.get("name", "")))
+    print()
+    print(f"  {BOLD}{'ID':>4}  {'DOCS':>4}  {'OWNER':>5}  NAME{RESET}")
+    print(f"  {DIM}{'─' * 60}{RESET}")
+    for r in records:
+        rid = r.get("id", "?")
+        count = r.get("document_count") or 0
+        owner = r.get("owner")
+        owner_str = str(owner) if owner is not None else "-"
+        name = r.get("name", "")
+        dim_name = f"{DIM}{name}{RESET}" if count == 0 else name
+        print(f"  {rid:>4}  {count:>4}  {owner_str:>5}  {dim_name}")
+    print()
+    print(f"  {DIM}{len(records)} {kind}(s){RESET}\n")
+
+
+# ── tags prune ─────────────────────────────────────────────────────────
+
+async def _tags_prune(paperless: PaperlessAPI, argv: list[str]) -> int:
+    dry_run = _is_dry(argv)
+
+    lang: str | None = None
+    for a in argv:
+        if a.startswith("--lang="):
+            lang = a.split("=", 1)[1].strip().lower()
+            break
+    if lang is None and "--lang" in argv:
+        idx = argv.index("--lang")
+        if idx + 1 < len(argv):
+            lang = argv[idx + 1].strip().lower()
+
+    if lang not in ("de", "en"):
+        _err("Usage: tags prune --lang <de|en> [--dry|--dry-run]")
+        return 2
+
+    taxonomy = _read_taxonomy()
+    section = taxonomy.get(lang)
+    if not section:
+        _err(f"No [{lang}] section in taxonomy.toml")
+        return 1
+
+    target_tags = set(section.get("tags") or [])
+    target_types = set(section.get("types") or [])
+
+    tags = await _paperless_list_full(paperless, "tags")
+    types_ = await _paperless_list_full(paperless, "document_types")
+
+    prune_tags = [t for t in tags
+                  if t.get("name") in target_tags
+                  and (t.get("document_count") or 0) == 0]
+    prune_types = [t for t in types_
+                   if t.get("name") in target_types
+                   and (t.get("document_count") or 0) == 0]
+
+    _print_prune_plan(prune_tags, prune_types, lang=lang, dry_run=dry_run)
+
+    if dry_run or not (prune_tags or prune_types):
+        return 0
+
+    failures = 0
+    for t in prune_tags:
+        if not await _paperless_delete(paperless, "tags", t["id"]):
+            failures += 1
+    for t in prune_types:
+        if not await _paperless_delete(paperless, "document_types", t["id"]):
+            failures += 1
+
+    _print_prune_summary(len(prune_tags) + len(prune_types), failures)
+    return 0 if failures == 0 else 1
+
+
+def _print_prune_plan(prune_tags: list[dict], prune_types: list[dict],
+                      *, lang: str, dry_run: bool) -> None:
+    from stack.prompt import BOLD, DIM, ORANGE, RESET
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
+    verb = "Would delete" if dry_run else "Deleting"
+    print()
+    print(f"  {BOLD}tags prune --lang {lang}{RESET}{marker}")
+    print(f"  {DIM}{'─' * 60}{RESET}")
+    if not prune_tags and not prune_types:
+        print(f"  {DIM}Nothing to prune — no dead [{lang}] entries.{RESET}\n")
+        return
+    if prune_tags:
+        print(f"  {verb} {len(prune_tags)} tag(s):")
+        for t in prune_tags:
+            print(f"    {ORANGE}#{t['id']}{RESET}  {t['name']}  "
+                  f"{DIM}(owner={t.get('owner')}){RESET}")
+    if prune_types:
+        print(f"  {verb} {len(prune_types)} type(s):")
+        for t in prune_types:
+            print(f"    {ORANGE}#{t['id']}{RESET}  {t['name']}  "
+                  f"{DIM}(owner={t.get('owner')}){RESET}")
+    print()
+
+
+def _print_prune_summary(total: int, failures: int) -> None:
+    from stack.prompt import GREEN, ORANGE, RESET
+    ok = total - failures
+    icon = f"{GREEN}✓{RESET}" if failures == 0 else f"{ORANGE}!{RESET}"
+    print(f"  {icon} pruned {ok}/{total}"
+          + (f" ({failures} failed)" if failures else ""))
+    print()
+
+
+# ── tags merge ─────────────────────────────────────────────────────────
+
+async def _tags_merge(paperless: PaperlessAPI, argv: list[str]) -> int:
+    dry_run = _is_dry(argv)
+    is_type = "--type" in argv or "--types" in argv
+
+    flag_tokens = {"--type", "--types", *_DRY_FLAGS}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
+    if len(positional) != 2:
+        _err("Usage: tags merge <from> <to> [--type] [--dry|--dry-run]")
+        return 2
+    from_name, to_name = positional
+
+    endpoint = "document_types" if is_type else "tags"
+    kind = "type" if is_type else "tag"
+    records = await _paperless_list_full(paperless, endpoint)
+    by_name = {r["name"]: r for r in records}
+
+    src = by_name.get(from_name)
+    dst = by_name.get(to_name)
+    if not src:
+        _err(f"Source {kind} not found: {from_name!r}")
+        return 1
+    if not dst:
+        _err(f"Target {kind} not found: {to_name!r}")
+        return 1
+    if src["id"] == dst["id"]:
+        _err(f"{from_name!r} and {to_name!r} resolve to the same {kind}")
+        return 1
+
+    doc_ids = await _docs_with_entity(paperless, endpoint, src["id"])
+    _print_merge_plan(src, dst, doc_ids, kind=kind, dry_run=dry_run)
+
+    if dry_run:
+        return 0
+
+    if doc_ids and not await _bulk_reassign(
+        paperless, endpoint, doc_ids, src["id"], dst["id"],
+    ):
+        _err("Bulk reassign failed; aborting before delete.")
+        return 1
+    if not await _paperless_delete(paperless, endpoint, src["id"]):
+        return 1
+
+    _print_merge_summary(src["name"], dst["name"], len(doc_ids), kind=kind)
+    return 0
+
+
+async def _docs_with_entity(paperless: PaperlessAPI, endpoint: str,
+                             entity_id: int) -> list[int]:
+    """Return every doc id carrying a given tag or assigned a given type."""
+    field = "tags__id__in" if endpoint == "tags" else "document_type__id"
+    ids: list[int] = []
+    page = 1
+    while True:
+        async with paperless.http.get(
+            f"{paperless.url}/api/documents/",
+            headers=paperless._headers,
+            params={field: str(entity_id), "page_size": "100",
+                    "page": str(page)},
+        ) as resp:
+            if resp.status != 200:
+                body = (await resp.text())[:200]
+                _err(f"GET /documents/ → {resp.status}: {body}")
+                return ids
+            data = await resp.json()
+            ids.extend(d["id"] for d in (data.get("results") or []))
+            if not data.get("next"):
+                return ids
+            page += 1
+
+
+async def _bulk_reassign(paperless: PaperlessAPI, endpoint: str,
+                          doc_ids: list[int], src_id: int, dst_id: int) -> bool:
+    if endpoint == "tags":
+        payload = {
+            "documents": doc_ids,
+            "method": "modify_tags",
+            "parameters": {"add_tags": [dst_id], "remove_tags": [src_id]},
+        }
+    else:
+        payload = {
+            "documents": doc_ids,
+            "method": "set_document_type",
+            "parameters": {"document_type": dst_id},
+        }
+    async with paperless.http.post(
+        f"{paperless.url}/api/documents/bulk_edit/",
+        headers=paperless._json_headers, json=payload,
+    ) as resp:
+        if resp.status == 200:
+            return True
+        body = (await resp.text())[:200]
+        _err(f"bulk_edit → {resp.status}: {body}")
+        return False
+
+
+def _print_merge_plan(src: dict, dst: dict, doc_ids: list[int],
+                      *, kind: str, dry_run: bool) -> None:
+    from stack.prompt import BOLD, DIM, ORANGE, RESET, TEAL
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
+    verb = "Would merge" if dry_run else "Merging"
+    print()
+    print(f"  {BOLD}{verb} {kind}: {src['name']} → {dst['name']}{RESET}{marker}")
+    print(f"  {DIM}{'─' * 60}{RESET}")
+    print(f"    {DIM}source:{RESET}   {ORANGE}#{src['id']}{RESET}  {src['name']}  "
+          f"{DIM}(owner={src.get('owner')}, {src.get('document_count', 0)} doc(s)){RESET}")
+    print(f"    {DIM}target:{RESET}   {TEAL}#{dst['id']}{RESET}  {dst['name']}  "
+          f"{DIM}(owner={dst.get('owner')}, {dst.get('document_count', 0)} doc(s)){RESET}")
+    if doc_ids:
+        preview = ", ".join(f"#{i}" for i in doc_ids[:10])
+        suffix = " …" if len(doc_ids) > 10 else ""
+        print(f"    {DIM}docs:{RESET}     {len(doc_ids)} → {preview}{suffix}")
+    else:
+        print(f"    {DIM}docs:{RESET}     (none — source has no documents)")
+    print()
+
+
+def _print_merge_summary(src_name: str, dst_name: str, retagged: int,
+                         *, kind: str) -> None:
+    from stack.prompt import GREEN, RESET
+    print(f"  {GREEN}✓{RESET} merged {kind} {src_name} → {dst_name} "
+          f"({retagged} doc(s) retagged, source deleted)")
+    print()
 
 
 if __name__ == "__main__":

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -1,0 +1,279 @@
+"""Docs CLI commands — executed inside stack-core-bot-runner.
+
+The host-side `stack docs <cmd>` dispatchers `docker exec` into the
+bot-runner container and invoke this entry point. The container already
+has aiohttp, loguru, yaml, and the rendered Paperless / AI env vars —
+so the host CLI stays stdlib-only while the pipeline logic is shared
+verbatim with the archivist bot.
+
+The pattern is deliberately reusable: any stacklet CLI that needs
+non-stdlib deps can grow its own `cli_entrypoint.py` here and a thin
+dispatcher on the host. Beats either "install aiohttp on the host" or
+"duplicate HTTP code in urllib".
+
+Commands:
+    show <id> [--content]       pretty-print Paperless state
+    classify <id> [--json]      dry classify — LLM JSON output, no writes
+    reformat <id> [--raw]       dry reformat — clean markdown, no writes
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))  # pipeline, matching
+sys.path.insert(0, "/app")  # stack.resolve_model, stack.prompt
+
+import aiohttp
+
+from pipeline import Classifier, PaperlessAPI
+
+
+def _err(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+async def main(argv: list[str]) -> int:
+    if not argv:
+        _usage()
+        return 2
+
+    cmd, *rest = argv
+    handlers = {
+        "show": _show,
+        "classify": _classify,
+        "reformat": _reformat,
+    }
+    fn = handlers.get(cmd)
+    if not fn:
+        _err(f"Unknown command: {cmd}")
+        _usage()
+        return 2
+
+    paperless_url = os.environ.get("PAPERLESS_URL", "")
+    paperless_token = os.environ.get("PAPERLESS_TOKEN", "")
+    if not paperless_url or not paperless_token:
+        _err("PAPERLESS_URL / PAPERLESS_TOKEN not set — bot-runner env missing docs creds.")
+        return 1
+
+    async with aiohttp.ClientSession() as http:
+        paperless = PaperlessAPI(http, paperless_url, paperless_token)
+        classifier = Classifier(
+            http,
+            os.environ.get("OPENAI_URL", ""),
+            os.environ.get("OPENAI_KEY", ""),
+        )
+        return await fn(paperless, classifier, rest)
+
+
+def _usage() -> None:
+    _err(__doc__.rstrip())
+
+
+# ── show ────────────────────────────────────────────────────────────────
+
+async def _show(paperless: PaperlessAPI, classifier: Classifier,
+                argv: list[str]) -> int:
+    full = "--content" in argv
+    positional = [a for a in argv if a != "--content"]
+    if not positional:
+        _err("Usage: show <id> [--content]")
+        return 2
+    doc_id = _parse_doc_id(positional[0])
+    if doc_id is None:
+        return 2
+
+    doc = await paperless.get_doc(doc_id)
+    if not doc:
+        _err(f"Document #{doc_id} not found")
+        return 1
+
+    tags = await paperless.get_tags()
+    doc_types = await paperless.get_doc_types()
+    correspondents = await paperless.get_correspondents()
+    _render_show(doc, tags, doc_types, correspondents, full=full)
+    return 0
+
+
+def _render_show(doc: dict, tags: dict, doc_types: dict,
+                 correspondents: dict, *, full: bool) -> None:
+    from stack.prompt import BOLD, DIM, ORANGE, RESET, TEAL
+
+    # Flip name→id lookups so numeric Paperless fields print as human names.
+    tag_name = {tid: name for name, tid in tags.items()}
+    type_name = {tid: name for name, tid in doc_types.items()}
+    corr_name = {tid: name for name, tid in correspondents.items()}
+
+    doc_id = doc.get("id")
+    title = doc.get("title") or "(no title)"
+    created = (doc.get("created") or "")[:10]
+    tag_ids = doc.get("tags") or []
+    tag_names = sorted(tag_name.get(t, f"#{t}") for t in tag_ids)
+    content = doc.get("content") or ""
+
+    print()
+    print(f"  {ORANGE}#{doc_id}{RESET}  {BOLD}{title}{RESET}")
+    print(f"  {DIM}{'─' * 60}{RESET}")
+    print(f"  {DIM}{'Date':<14}{RESET}  {TEAL}{created or '—'}{RESET}")
+    print(f"  {DIM}{'Type':<14}{RESET}  {TEAL}{type_name.get(doc.get('document_type'), '—')}{RESET}")
+    print(f"  {DIM}{'Correspondent':<14}{RESET}  {TEAL}{corr_name.get(doc.get('correspondent'), '—')}{RESET}")
+    print(f"  {DIM}{'Tags':<14}{RESET}  {TEAL}{', '.join(tag_names) or '—'}{RESET}")
+    print(f"  {DIM}{'Content':<14}{RESET}  {len(content):,} chars")
+    print()
+
+    if not content.strip():
+        print(f"  {DIM}(no OCR text){RESET}\n")
+        return
+
+    if full:
+        print(content)
+        print()
+        return
+
+    for line in content[:500].strip().splitlines():
+        print(f"    {line}")
+    if len(content) > 500:
+        print(f"    {DIM}... ({len(content) - 500:,} more chars — pass --content for full body){RESET}")
+    print()
+
+
+# ── classify ────────────────────────────────────────────────────────────
+
+async def _classify(paperless: PaperlessAPI, classifier: Classifier,
+                    argv: list[str]) -> int:
+    raw_json = "--json" in argv
+    positional = [a for a in argv if a != "--json"]
+    if not positional:
+        _err("Usage: classify <id> [--json]")
+        return 2
+    doc_id = _parse_doc_id(positional[0])
+    if doc_id is None:
+        return 2
+
+    doc = await paperless.get_doc(doc_id)
+    if not doc:
+        _err(f"Document #{doc_id} not found")
+        return 1
+
+    ocr_text = (doc.get("content") or "").strip()
+    if len(ocr_text) < 10:
+        _err(f"Document #{doc_id} has no usable OCR text ({len(ocr_text)} chars)")
+        return 1
+
+    tags = await paperless.get_tags()
+    doc_types = await paperless.get_doc_types()
+    correspondents = await paperless.get_correspondents()
+
+    if not raw_json:
+        _print_classify_header(doc, ocr_text)
+
+    try:
+        result = await classifier.classify(
+            ocr_text=ocr_text, tags=tags,
+            doc_types=doc_types, correspondents=correspondents,
+        )
+    except Exception as e:
+        _err(f"Classifier failed: {e}")
+        return 1
+
+    if raw_json:
+        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+    else:
+        _print_classification(result)
+    return 0
+
+
+def _print_classify_header(doc: dict, ocr_text: str) -> None:
+    from stack.prompt import BOLD, DIM, ORANGE, RESET
+    print()
+    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{doc.get('title') or '(no title)'}{RESET}")
+    print(f"  {DIM}Classifying {len(ocr_text):,} chars of OCR text...{RESET}")
+    print()
+
+
+def _print_classification(result: dict) -> None:
+    from stack.prompt import DIM, GREEN, RESET, TEAL
+    if not result:
+        print(f"  {DIM}LLM returned no classification (empty dict).{RESET}\n")
+        return
+    print(f"  {GREEN}✓{RESET}  Classification:\n")
+    for line in json.dumps(result, indent=2, ensure_ascii=False).splitlines():
+        print(f"    {TEAL}{line}{RESET}")
+    print(f"\n  {DIM}--dry-run: no changes made to Paperless.{RESET}\n")
+
+
+# ── reformat ────────────────────────────────────────────────────────────
+
+async def _reformat(paperless: PaperlessAPI, classifier: Classifier,
+                    argv: list[str]) -> int:
+    raw = "--raw" in argv
+    positional = [a for a in argv if a != "--raw"]
+    if not positional:
+        _err("Usage: reformat <id> [--raw]")
+        return 2
+    doc_id = _parse_doc_id(positional[0])
+    if doc_id is None:
+        return 2
+
+    doc = await paperless.get_doc(doc_id)
+    if not doc:
+        _err(f"Document #{doc_id} not found")
+        return 1
+
+    ocr_text = (doc.get("content") or "").strip()
+    if len(ocr_text) < 10:
+        _err(f"Document #{doc_id} has no usable OCR text ({len(ocr_text)} chars)")
+        return 1
+
+    if not raw:
+        _print_reformat_header(doc, ocr_text)
+
+    formatted = await classifier.reformat(ocr_text)
+
+    if raw:
+        if formatted:
+            sys.stdout.write(formatted)
+            sys.stdout.write("\n")
+        return 0 if formatted else 1
+
+    _print_reformat_result(formatted, len(ocr_text))
+    return 0 if formatted else 1
+
+
+def _print_reformat_header(doc: dict, ocr_text: str) -> None:
+    from stack.prompt import BOLD, DIM, ORANGE, RESET
+    print()
+    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{doc.get('title') or '(no title)'}{RESET}")
+    print(f"  {DIM}Reformatting {len(ocr_text):,} chars of OCR text...{RESET}")
+    print()
+
+
+def _print_reformat_result(formatted: str | None, source_chars: int) -> None:
+    from stack.prompt import DIM, GREEN, ORANGE, RESET
+    if not formatted:
+        print(f"  {ORANGE}✗{RESET}  Reformat returned nothing — LLM may be down or too short a response.\n")
+        return
+    print(f"  {GREEN}✓{RESET}  Reformatted ({source_chars:,} → {len(formatted):,} chars):")
+    print(f"  {DIM}{'─' * 60}{RESET}\n")
+    print(formatted)
+    print(f"\n  {DIM}{'─' * 60}{RESET}")
+    print(f"  {DIM}--dry-run: no changes made to Paperless.{RESET}\n")
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def _parse_doc_id(raw: str) -> int | None:
+    try:
+        return int(raw)
+    except ValueError:
+        _err(f"Invalid document id: {raw!r} (must be an integer)")
+        return None
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main(sys.argv[1:])))

--- a/stacklets/docs/bot/cli_entrypoint.py
+++ b/stacklets/docs/bot/cli_entrypoint.py
@@ -12,17 +12,24 @@ dispatcher on the host. Beats either "install aiohttp on the host" or
 "duplicate HTTP code in urllib".
 
 Commands:
-    show <id> [--content]       pretty-print Paperless state
-    classify <id> [--json]      dry classify — LLM JSON output, no writes
-    reformat <id> [--raw]       dry reformat — clean markdown, no writes
-    reclassify <id> [<id>...]   re-run the pipeline + apply to Paperless.
-                                reformat + mirror default to bot.toml's
-                                [settings] — flags below only override.
-                                flags: --[no-]reformat --[no-]mirror --dry-run
+    show <id> [--content]           pretty-print Paperless state
+    classify <id>   [--dry] [--json]
+                                classify + apply (title, tags, type,
+                                correspondent, date). --dry skips writes;
+                                --json prints raw LLM output (implies --dry).
+    reformat <id>   [--dry] [--raw]
+                                reformat OCR + apply content to Paperless.
+                                --dry skips writes; --raw prints the raw
+                                markdown (implies --dry).
+    reprocess <id> [<id>...]    full pipeline (classify + reformat + mirror)
+                                respecting archivist bot.toml [settings].
+                                flags: --[no-]reformat --[no-]mirror --dry
     mirror <id> [<id>...]       push docs to the Forgejo mirror using their
                                 current Paperless state (no LLM). Useful for
                                 backfilling after enabling mirror_to_git.
-                                flags: --dry-run
+                                flags: --dry
+
+All dry flags accept `--dry` and `--dry-run` interchangeably.
 """
 
 from __future__ import annotations
@@ -61,7 +68,7 @@ async def main(argv: list[str]) -> int:
         "show": _show,
         "classify": _classify,
         "reformat": _reformat,
-        "reclassify": _reclassify,
+        "reprocess": _reprocess,
         "mirror": _mirror_cmd,
     }
     fn = handlers.get(cmd)
@@ -157,36 +164,69 @@ def _render_show(doc: dict, tags: dict, doc_types: dict,
     print()
 
 
+# ── dry-run flag set (shared by every write-capable command) ───────────
+
+_DRY_FLAGS = ("--dry-run", "--dry")
+
+
+def _is_dry(argv: list[str]) -> bool:
+    return any(f in argv for f in _DRY_FLAGS)
+
+
 # ── classify ────────────────────────────────────────────────────────────
 
 async def _classify(paperless: PaperlessAPI, classifier: Classifier,
                     argv: list[str]) -> int:
     raw_json = "--json" in argv
-    positional = [a for a in argv if a != "--json"]
+    dry_run = _is_dry(argv) or raw_json  # --json implies no-writes
+
+    flag_tokens = {"--json", *_DRY_FLAGS}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
     if not positional:
-        _err("Usage: classify <id> [--json]")
+        _err("Usage: classify <id> [--dry|--dry-run] [--json]")
         return 2
     doc_id = _parse_doc_id(positional[0])
     if doc_id is None:
         return 2
 
+    if raw_json:
+        return await _classify_raw_json(paperless, classifier, doc_id)
+
+    # Default / --dry-run: classify + apply (or plan) via the shared pipeline,
+    # rendered as a before/after diff. No reformat, no mirror — classify is
+    # scoped to classification only.
+    ok = await _reprocess_one(
+        paperless, classifier, mirror=None,
+        doc_id=doc_id, reformat=False, dry_run=dry_run,
+    )
+    if ok:
+        from stack.prompt import DIM, GREEN, RESET
+        verb = "would classify" if dry_run else "classified"
+        print(f"  {GREEN}✓{RESET} {verb}")
+        if dry_run:
+            print(f"  {DIM}--dry-run: no changes made to Paperless.{RESET}")
+        print()
+    return 0 if ok else 1
+
+
+async def _classify_raw_json(paperless: PaperlessAPI, classifier: Classifier,
+                             doc_id: int) -> int:
+    """--json mode: call the classifier directly and dump raw JSON. No writes."""
     doc = await paperless.get_doc(doc_id)
     if not doc:
         _err(f"Document #{doc_id} not found")
         return 1
-
     ocr_text = (doc.get("content") or "").strip()
     if len(ocr_text) < 10:
         _err(f"Document #{doc_id} has no usable OCR text ({len(ocr_text)} chars)")
         return 1
-
     tags = await paperless.get_tags()
     doc_types = await paperless.get_doc_types()
     correspondents = await paperless.get_correspondents()
-
-    if not raw_json:
-        _print_classify_header(doc, ocr_text)
-
     try:
         result = await classifier.classify(
             ocr_text=ocr_text, tags=tags,
@@ -195,32 +235,9 @@ async def _classify(paperless: PaperlessAPI, classifier: Classifier,
     except Exception as e:
         _err(f"Classifier failed: {e}")
         return 1
-
-    if raw_json:
-        json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
-        print()
-    else:
-        _print_classification(result)
+    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    print()
     return 0
-
-
-def _print_classify_header(doc: dict, ocr_text: str) -> None:
-    from stack.prompt import BOLD, DIM, ORANGE, RESET
-    print()
-    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{doc.get('title') or '(no title)'}{RESET}")
-    print(f"  {DIM}Classifying {len(ocr_text):,} chars of OCR text...{RESET}")
-    print()
-
-
-def _print_classification(result: dict) -> None:
-    from stack.prompt import DIM, GREEN, RESET, TEAL
-    if not result:
-        print(f"  {DIM}LLM returned no classification (empty dict).{RESET}\n")
-        return
-    print(f"  {GREEN}✓{RESET}  Classification:\n")
-    for line in json.dumps(result, indent=2, ensure_ascii=False).splitlines():
-        print(f"    {TEAL}{line}{RESET}")
-    print(f"\n  {DIM}--dry-run: no changes made to Paperless.{RESET}\n")
 
 
 # ── reformat ────────────────────────────────────────────────────────────
@@ -228,9 +245,16 @@ def _print_classification(result: dict) -> None:
 async def _reformat(paperless: PaperlessAPI, classifier: Classifier,
                     argv: list[str]) -> int:
     raw = "--raw" in argv
-    positional = [a for a in argv if a != "--raw"]
+    dry_run = _is_dry(argv) or raw  # --raw implies no-writes
+
+    flag_tokens = {"--raw", *_DRY_FLAGS}
+    positional = [a for a in argv if a not in flag_tokens]
+    unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
+    if unknown:
+        _err(f"Unknown flag(s): {' '.join(unknown)}")
+        return 2
     if not positional:
-        _err("Usage: reformat <id> [--raw]")
+        _err("Usage: reformat <id> [--dry|--dry-run] [--raw]")
         return 2
     doc_id = _parse_doc_id(positional[0])
     if doc_id is None:
@@ -246,46 +270,67 @@ async def _reformat(paperless: PaperlessAPI, classifier: Classifier,
         _err(f"Document #{doc_id} has no usable OCR text ({len(ocr_text)} chars)")
         return 1
 
-    if not raw:
-        _print_reformat_header(doc, ocr_text)
-
-    formatted = await classifier.reformat(ocr_text)
-
     if raw:
+        # Pipe-friendly: direct classifier call, raw markdown, no writes.
+        formatted = await classifier.reformat(ocr_text)
         if formatted:
             sys.stdout.write(formatted)
             sys.stdout.write("\n")
         return 0 if formatted else 1
 
-    _print_reformat_result(formatted, len(ocr_text))
+    _print_reformat_header(doc, ocr_text, dry_run=dry_run)
+
+    # apply or plan through reformat_document (_DryRunPaperless swallows the
+    # PATCH so dry-run and real runs share the same code path).
+    pipeline_paperless = _DryRunPaperless(paperless) if dry_run else paperless
+    formatted = await reformat_document(
+        paperless=pipeline_paperless, classifier=classifier,
+        doc_id=doc_id, ocr_text=ocr_text,
+    )
+
+    _print_reformat_result(formatted, len(ocr_text), dry_run=dry_run)
     return 0 if formatted else 1
 
 
-def _print_reformat_header(doc: dict, ocr_text: str) -> None:
+def _print_reformat_header(doc: dict, ocr_text: str, *, dry_run: bool) -> None:
     from stack.prompt import BOLD, DIM, ORANGE, RESET
+    marker = f"  {DIM}(DRY RUN){RESET}" if dry_run else ""
     print()
-    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{doc.get('title') or '(no title)'}{RESET}")
-    print(f"  {DIM}Reformatting {len(ocr_text):,} chars of OCR text...{RESET}")
+    print(f"  {ORANGE}#{doc.get('id')}{RESET}  {BOLD}{doc.get('title') or '(no title)'}{RESET}{marker}")
+    verb = "Would reformat" if dry_run else "Reformatting"
+    print(f"  {DIM}{verb} {len(ocr_text):,} chars of OCR text...{RESET}")
     print()
 
 
-def _print_reformat_result(formatted: str | None, source_chars: int) -> None:
+def _print_reformat_result(formatted: str | None, source_chars: int,
+                           *, dry_run: bool) -> None:
     from stack.prompt import DIM, GREEN, ORANGE, RESET
     if not formatted:
         print(f"  {ORANGE}✗{RESET}  Reformat returned nothing — LLM may be down or too short a response.\n")
         return
-    print(f"  {GREEN}✓{RESET}  Reformatted ({source_chars:,} → {len(formatted):,} chars):")
-    print(f"  {DIM}{'─' * 60}{RESET}\n")
-    print(formatted)
-    print(f"\n  {DIM}{'─' * 60}{RESET}")
-    print(f"  {DIM}--dry-run: no changes made to Paperless.{RESET}\n")
+    verb = "Would reformat" if dry_run else "Reformatted"
+    print(f"  {GREEN}✓{RESET}  {verb} ({source_chars:,} → {len(formatted):,} chars)")
+    if dry_run:
+        # Show the full markdown so the operator can sanity-check before
+        # a non-dry run overwrites the Paperless body.
+        print(f"  {DIM}{'─' * 60}{RESET}\n")
+        print(formatted)
+        print(f"\n  {DIM}{'─' * 60}{RESET}")
+        print(f"  {DIM}--dry-run: no changes made to Paperless.{RESET}")
+    else:
+        # Applied. The new content is already in Paperless — `stack docs
+        # show <id> --content` retrieves it if the user wants to inspect.
+        print(f"  {DIM}applied to Paperless. `stack docs show <id> --content` to view.{RESET}")
+    print()
 
 
-# ── reclassify ──────────────────────────────────────────────────────────
 
-async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
+
+# ── reprocess ──────────────────────────────────────────────────────────
+
+async def _reprocess(paperless: PaperlessAPI, classifier: Classifier,
                       argv: list[str]) -> int:
-    dry_run = "--dry-run" in argv
+    dry_run = _is_dry(argv)
 
     # Defaults come from the archivist's bot.toml so the CLI behaves the
     # same way the bot does for a new upload. Explicit flags override.
@@ -301,7 +346,7 @@ async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
     elif "--mirror" in argv:
         mirror_enabled = True
 
-    flag_tokens = {"--dry-run", "--reformat", "--no-reformat",
+    flag_tokens = {*_DRY_FLAGS, "--reformat", "--no-reformat",
                    "--mirror", "--no-mirror"}
     positional = [a for a in argv if a not in flag_tokens]
     unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
@@ -309,7 +354,7 @@ async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
         _err(f"Unknown flag(s): {' '.join(unknown)}")
         return 2
     if not positional:
-        _err("Usage: reclassify <id> [<id>...] [--[no-]reformat] [--[no-]mirror] [--dry-run]")
+        _err("Usage: reprocess <id> [<id>...] [--[no-]reformat] [--[no-]mirror] [--dry|--dry-run]")
         return 2
 
     doc_ids: list[int] = []
@@ -328,7 +373,7 @@ async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
     successes = 0
     failures = 0
     for doc_id in doc_ids:
-        ok = await _reclassify_one(
+        ok = await _reprocess_one(
             paperless, classifier, mirror,
             doc_id=doc_id, reformat=reformat, dry_run=dry_run,
         )
@@ -337,11 +382,11 @@ async def _reclassify(paperless: PaperlessAPI, classifier: Classifier,
         else:
             failures += 1
 
-    _print_reclassify_summary(successes, failures, dry_run=dry_run)
+    _print_reprocess_summary(successes, failures, dry_run=dry_run)
     return 0 if failures == 0 else 1
 
 
-async def _reclassify_one(
+async def _reprocess_one(
     paperless: PaperlessAPI, classifier: Classifier, mirror,
     *, doc_id: int, reformat: bool, dry_run: bool,
 ) -> bool:
@@ -391,7 +436,7 @@ async def _reclassify_one(
             mirror, refreshed, result, formatted=formatted,
         )
 
-    _print_reclassify_diff(
+    _print_reprocess_diff(
         doc_id=doc_id, before=before, result=result,
         reformatted=bool(formatted), mirror_path=mirror_path,
         mirror_enabled=mirror is not None, dry_run=dry_run,
@@ -399,7 +444,7 @@ async def _reclassify_one(
     return True
 
 
-# ── reclassify: no-op writer for --dry-run ──────────────────────────────
+# ── reprocess: no-op writer for --dry-run ──────────────────────────────
 
 class _DryRunPaperless:
     """Read-through wrapper that stubs every write so `enrich_document`
@@ -434,7 +479,7 @@ class _DryRunPaperless:
         return self._fake_id
 
 
-# ── reclassify: mirror bootstrap ────────────────────────────────────────
+# ── reprocess: mirror bootstrap ────────────────────────────────────────
 
 def _read_bot_toml_settings() -> dict:
     """Read [settings] from the archivist's bot.toml (same file the bot reads)."""
@@ -538,7 +583,7 @@ async def _publish_mirror(
     return mirror._cache.get(doc["id"]) if ok else None
 
 
-# ── reclassify: state snapshot + diff rendering ─────────────────────────
+# ── reprocess: state snapshot + diff rendering ─────────────────────────
 
 def _snapshot_doc(doc: dict, tags: dict, doc_types: dict,
                   correspondents: dict) -> dict:
@@ -562,7 +607,7 @@ def _snapshot_doc(doc: dict, tags: dict, doc_types: dict,
     }
 
 
-def _print_reclassify_diff(*, doc_id: int, before: dict, result: EnrichResult,
+def _print_reprocess_diff(*, doc_id: int, before: dict, result: EnrichResult,
                             reformatted: bool, mirror_path: str | None,
                             mirror_enabled: bool, dry_run: bool) -> None:
     from stack.prompt import BOLD, DIM, GREEN, ORANGE, RESET, TEAL
@@ -620,10 +665,10 @@ def _union(a: list[str], b: list[str]) -> list[str]:
     return out
 
 
-def _print_reclassify_summary(successes: int, failures: int, *, dry_run: bool) -> None:
+def _print_reprocess_summary(successes: int, failures: int, *, dry_run: bool) -> None:
     from stack.prompt import DIM, GREEN, ORANGE, RESET
     total = successes + failures
-    verb = "would reclassify" if dry_run else "reclassified"
+    verb = "would reprocess" if dry_run else "reprocessed"
     print()
     icon = f"{GREEN}✓{RESET}" if failures == 0 else f"{ORANGE}!{RESET}"
     print(f"  {icon} {verb} {successes}/{total}" + (
@@ -637,15 +682,15 @@ def _print_reclassify_summary(successes: int, failures: int, *, dry_run: bool) -
 
 async def _mirror_cmd(paperless: PaperlessAPI, classifier: Classifier,
                       argv: list[str]) -> int:
-    dry_run = "--dry-run" in argv
-    flag_tokens = {"--dry-run"}
+    dry_run = _is_dry(argv)
+    flag_tokens = set(_DRY_FLAGS)
     positional = [a for a in argv if a not in flag_tokens]
     unknown = [a for a in argv if a.startswith("--") and a not in flag_tokens]
     if unknown:
         _err(f"Unknown flag(s): {' '.join(unknown)}")
         return 2
     if not positional:
-        _err("Usage: mirror <id> [<id>...] [--dry-run]")
+        _err("Usage: mirror <id> [<id>...] [--dry|--dry-run]")
         return 2
 
     doc_ids: list[int] = []
@@ -699,7 +744,7 @@ async def _mirror_existing(mirror, doc: dict, tags: dict, doc_types: dict,
                            correspondents: dict) -> str | None:
     """Publish a mirror entry from the doc's current Paperless state.
 
-    No LLM call, no reclassification. `processing` is set to "ocr" because
+    No LLM call, no classification run. `processing` is set to "ocr" because
     we're shipping whatever Paperless's content field currently holds —
     could be raw OCR, could be an earlier ai_formatted body. We don't
     track provenance for backfill; the important thing is the mirror entry

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -567,9 +567,16 @@ async def enrich_document(
     if title and isinstance(title, str):
         updates["title"] = title[:MAX_TITLE_LENGTH]
 
+    # Fresh-filed semantics: the classification result IS the full state
+    # of the doc after this call. We don't merge with whatever was there
+    # before — that would accumulate tags on every re-run (the "Haushalt
+    # sticks around after reprocess" bug). The bot's new-upload path is
+    # unaffected: a just-filed doc has no prior tags or type, so starting
+    # from a blank slate is a no-op.
+    tag_ids: list[int] = []
+
     # Topics — open set. matching.py splits into existing vs new; new tags
     # are created in Paperless and treated as resolved.
-    tag_ids = list(doc.get("tags", []))
     category_tags = {t: tid for t, tid in tags.items() if not t.startswith("Person: ")}
     topics_raw = classification.get("topics") or classification.get("topic")
     matched_topics, new_topics = match_topics(topics_raw, category_tags)
@@ -592,27 +599,27 @@ async def enrich_document(
         tag_ids.append(tags[pt])
         result.resolved_persons.append(pt.replace("Person: ", ""))
 
-    if tag_ids:
-        updates["tags"] = list(set(tag_ids))
+    # Always write the tag set — even an empty list. A reprocess that
+    # yields no topics/persons should leave the doc with no tags, matching
+    # the state a fresh upload would produce from the same LLM output.
+    updates["tags"] = list(set(tag_ids))
 
-    # Document type — respect a manually-set type on the doc: the user
-    # curated it and the LLM shouldn't overwrite. When unset, apply the
-    # LLM's call (matching existing or creating new).
+    # Document type — LLM-decided, no manual-type preservation. "Fresh
+    # reprocess" means the LLM's pick wins; a user who curated a type
+    # manually before should reprocess knowing they're asking for the
+    # AI's verdict.
     doc_type = classification.get("document_type")
     if not _is_empty(doc_type):
-        if doc.get("document_type"):
-            result.resolved_type = doc_type
+        matched = fuzzy_match_entity(doc_type, doc_types)
+        if matched:
+            updates["document_type"] = doc_types[matched]
+            result.resolved_type = matched
         else:
-            matched = fuzzy_match_entity(doc_type, doc_types)
-            if matched:
-                updates["document_type"] = doc_types[matched]
-                result.resolved_type = matched
-            else:
-                new_id = await paperless.create_doc_type(doc_type)
-                if new_id:
-                    updates["document_type"] = new_id
-                    result.resolved_type = doc_type
-                    result.created_new.append(f'document type "{doc_type}"')
+            new_id = await paperless.create_doc_type(doc_type)
+            if new_id:
+                updates["document_type"] = new_id
+                result.resolved_type = doc_type
+                result.created_new.append(f'document type "{doc_type}"')
 
     # Correspondent — always overwrite. Paperless's auto-classifier guesses
     # wrong with few samples; the LLM has read the actual text.

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -1,7 +1,7 @@
 """Document enrichment pipeline — shared by the archivist bot and the docs CLI.
 
 The archivist bot runs this on every new Paperless upload; the
-`stack docs reclassify` CLI runs the same pipeline against already-filed
+`stack docs reprocess` CLI runs the same pipeline against already-filed
 documents when the operator wants to re-tag, re-title, or refresh a stale
 classification after taxonomy changes.
 

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -1,0 +1,667 @@
+"""Document enrichment pipeline — shared by the archivist bot and the docs CLI.
+
+The archivist bot runs this on every new Paperless upload; the
+`stack docs reclassify` CLI runs the same pipeline against already-filed
+documents when the operator wants to re-tag, re-title, or refresh a stale
+classification after taxonomy changes.
+
+Design boundary: the module holds no Matrix, chat, or stdout state. Callers
+feed in a fully-fetched Paperless doc dict and a classifier; they receive an
+`EnrichResult` they can render into whatever surface they own (chat reply,
+Forgejo mirror frontmatter, terminal diff).
+
+Split of concerns:
+
+    PaperlessAPI   async HTTP wrapper — every endpoint the pipeline touches
+    Classifier     OpenAI-compatible client — owns the prompts and parsing
+    enrich_document  classify → reconcile via matching.py → PATCH Paperless
+    reformat_document  LLM-rewrite the body → PATCH content (best-effort)
+
+Why two top-level functions rather than a class: neither has state worth
+holding between calls. A bot processes one upload at a time; the CLI walks
+a list of ids sequentially. Functions thread the collaborators explicitly,
+which makes the contract visible in every call site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+from loguru import logger
+
+from matching import (
+    MAX_TITLE_LENGTH,
+    _is_empty,
+    fuzzy_match_entity,
+    match_persons,
+    match_topics,
+)
+from stack import resolve_model
+
+
+# ── Errors ───────────────────────────────────────────────────────────────
+
+class LLMUnavailableError(Exception):
+    """LLM service is not reachable — oMLX/Ollama might not be running."""
+
+
+class LLMModelNotFoundError(Exception):
+    """The configured model is not loaded on the LLM server."""
+
+
+class LLMTimeoutError(Exception):
+    """LLM took too long — large documents or cold model start can cause this."""
+
+
+class PaperlessDuplicateError(Exception):
+    """Paperless rejected the upload as a content-hash duplicate.
+
+    Carries the original doc's id + title so the caller can point the user
+    at what's already filed instead of reporting a generic upload failure.
+    """
+    def __init__(self, doc_id: int | None, title: str | None):
+        self.doc_id = doc_id
+        self.title = title
+        super().__init__(f"duplicate of #{doc_id}: {title}")
+
+
+_DUPLICATE_RE = re.compile(r"duplicate of\s+(.+?)\s+\(#(\d+)\)", re.IGNORECASE)
+
+
+# ── Enrichment result ────────────────────────────────────────────────────
+
+@dataclass
+class EnrichResult:
+    """Structured outcome of enrich_document().
+
+    `classification` holds the raw LLM response — summary, facts,
+    action_items, and anything else the caller wants to render. The
+    `resolved_*` fields carry the values actually written to Paperless
+    after fuzzy matching, so a mirror entry or CLI diff can show what
+    the archive agreed to rather than what the LLM first proposed.
+    """
+    classification: dict = field(default_factory=dict)
+    resolved_topics: list[str] = field(default_factory=list)
+    resolved_persons: list[str] = field(default_factory=list)
+    resolved_correspondent: str | None = None
+    resolved_type: str | None = None
+    created_new: list[str] = field(default_factory=list)
+    updates_applied: dict = field(default_factory=dict)
+    # When classify raised, ("unavailable" | "model_missing" | "timeout", detail)
+    llm_error: tuple[str, str] | None = None
+
+
+# ── Paperless HTTP wrapper ───────────────────────────────────────────────
+
+class PaperlessAPI:
+    """Async client for every Paperless endpoint the docs stacklet touches.
+
+    Used by enrich_document / reformat_document (entity reads + updates)
+    and by the archivist bot (upload + OCR task polling + search). The bot
+    and CLI share the same instance shape, which keeps Paperless HTTP
+    errors, header wiring, and pagination in one place.
+    """
+
+    def __init__(self, http: aiohttp.ClientSession, url: str, token: str):
+        self.http = http
+        self.url = url.rstrip("/")
+        self.token = token
+
+    @property
+    def _headers(self) -> dict:
+        return {"Authorization": f"Token {self.token}"}
+
+    @property
+    def _json_headers(self) -> dict:
+        return {**self._headers, "Content-Type": "application/json"}
+
+    # ── Document reads ───────────────────────────────────────────────
+
+    async def get_doc(self, doc_id: int) -> dict | None:
+        async with self.http.get(
+            f"{self.url}/api/documents/{doc_id}/", headers=self._headers,
+        ) as resp:
+            return await resp.json() if resp.status == 200 else None
+
+    async def search(self, query: str, limit: int = 5) -> list[dict]:
+        async with self.http.get(
+            f"{self.url}/api/documents/", headers=self._headers,
+            params={"query": query, "page_size": limit, "ordering": "-created"},
+        ) as resp:
+            if resp.status == 200:
+                return (await resp.json()).get("results", [])
+            return []
+
+    async def _list_entity(self, endpoint: str) -> dict:
+        async with self.http.get(
+            f"{self.url}/api/{endpoint}/?page_size=1000", headers=self._headers,
+        ) as resp:
+            if resp.status == 200:
+                return {t["name"]: t["id"] for t in (await resp.json()).get("results", [])}
+            return {}
+
+    async def get_tags(self) -> dict:
+        return await self._list_entity("tags")
+
+    async def get_doc_types(self) -> dict:
+        return await self._list_entity("document_types")
+
+    async def get_correspondents(self) -> dict:
+        return await self._list_entity("correspondents")
+
+    async def update_doc(self, doc_id: int, updates: dict) -> bool:
+        async with self.http.patch(
+            f"{self.url}/api/documents/{doc_id}/",
+            headers=self._json_headers, json=updates,
+        ) as resp:
+            return resp.status == 200
+
+    # ── Upload + OCR ─────────────────────────────────────────────────
+
+    async def upload(self, filename: str, data: bytes,
+                     content_type: str | None = None) -> str | None:
+        """Post a file to /post_document/. Returns the task id on success.
+
+        When `content_type` is given it's set on the multipart field —
+        important for text-like files where aiohttp's default of
+        application/octet-stream stops Paperless from matching a parser
+        and the server returns 400 with no useful diagnostic. On failure
+        we log the response body (truncated) so the next 400 isn't a
+        mystery.
+        """
+        form = aiohttp.FormData()
+        field_kwargs: dict = {"filename": filename}
+        if content_type:
+            field_kwargs["content_type"] = content_type
+        form.add_field("document", data, **field_kwargs)
+        try:
+            async with self.http.post(
+                f"{self.url}/api/documents/post_document/",
+                headers=self._headers, data=form,
+            ) as resp:
+                if resp.status == 200:
+                    task_id = (await resp.text()).strip().strip('"')
+                    logger.info("[pipeline] Uploaded {} → task {}", filename, task_id)
+                    return task_id
+                body = (await resp.text())[:400]
+                logger.error("[pipeline] Upload failed (HTTP {}): {} — body: {}",
+                             resp.status, filename, body)
+                return None
+        except (aiohttp.ClientConnectionError, aiohttp.ClientError, OSError) as e:
+            logger.error("[pipeline] Paperless unreachable: {}", e)
+            return None
+
+    async def wait_task(self, task_id: str, timeout: int = 120) -> int | None:
+        """Poll /tasks/ until the task completes.
+
+        Raises PaperlessDuplicateError when Paperless rejects the upload
+        as a duplicate; returns None for every other FAILURE / timeout /
+        transport error so the caller can render a generic failure.
+        """
+        import time
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                async with self.http.get(
+                    f"{self.url}/api/tasks/?task_id={task_id}",
+                    headers=self._headers,
+                ) as resp:
+                    if resp.status == 200:
+                        tasks = await resp.json()
+                        if tasks:
+                            task = tasks[0] if isinstance(tasks, list) else tasks
+                            status = task.get("status", "")
+                            if status == "SUCCESS":
+                                doc_id = task.get("related_document")
+                                return int(doc_id) if doc_id else None
+                            if status == "FAILURE":
+                                result = task.get("result") or ""
+                                logger.error("[pipeline] Task failed: {}", result)
+                                match = _DUPLICATE_RE.search(result)
+                                if match:
+                                    title = match.group(1).strip()
+                                    dup_id = int(match.group(2))
+                                    raise PaperlessDuplicateError(dup_id, title)
+                                return None
+            except (aiohttp.ClientConnectionError, aiohttp.ClientError, OSError) as e:
+                logger.error("[pipeline] Paperless unreachable while waiting for task: {}", e)
+                return None
+            await asyncio.sleep(3)
+        logger.error("[pipeline] Task {} timed out", task_id)
+        return None
+
+    # ── Entity creation ──────────────────────────────────────────────
+    #
+    # All entities use matching_algorithm=0 (disabled). The LLM classifies
+    # every document; Paperless just stores what the LLM decides.
+    #
+    # Why not auto-learn (algorithm 6)?
+    #
+    # Paperless auto-assigns during document consumption — BEFORE the LLM
+    # runs. With algorithm 6, Paperless learns from the first few
+    # LLM-assigned documents, then starts pre-assigning based on that tiny
+    # sample:
+    #
+    #   1. LLM tags three invoices as "Shopping"
+    #   2. Paperless learns: "Shopping" = common tag
+    #   3. Paperless auto-assigns "Shopping" to every new document at ingest
+    #   4. LLM adds the correct tag, but "Shopping" is already there too
+    #   5. Result: every document gets "Shopping" regardless of content
+    #
+    # Same failure mode hit correspondents: "Denny Gunawan" (first
+    # correspondent created) got auto-assigned to every subsequent document.
+    #
+    # Algorithm 0 means: Paperless never guesses. The LLM reads the actual
+    # document text and makes the call. If the LLM is unavailable,
+    # documents get filed without tags — the user can classify manually in
+    # the UI.
+
+    async def create_tag(self, name: str, color: str = "#9e9e9e") -> int | None:
+        async with self.http.post(
+            f"{self.url}/api/tags/", headers=self._json_headers,
+            json={
+                "name": name, "color": color,
+                "matching_algorithm": 0, "is_insensitive": True,
+            },
+        ) as resp:
+            if resp.status == 201:
+                data = await resp.json()
+                return data["id"]
+            return None
+
+    async def create_doc_type(self, name: str) -> int | None:
+        async with self.http.post(
+            f"{self.url}/api/document_types/", headers=self._json_headers,
+            json={"name": name, "matching_algorithm": 0, "is_insensitive": True},
+        ) as resp:
+            if resp.status == 201:
+                return (await resp.json())["id"]
+            return None
+
+    async def create_correspondent(self, name: str) -> int | None:
+        async with self.http.post(
+            f"{self.url}/api/correspondents/", headers=self._json_headers,
+            json={"name": name, "matching_algorithm": 0},
+        ) as resp:
+            if resp.status == 201:
+                return (await resp.json())["id"]
+            return None
+
+
+# ── LLM client ───────────────────────────────────────────────────────────
+
+class Classifier:
+    """OpenAI-compatible classifier + reformatter.
+
+    Resolves the concrete model via the framework's `resolve_model(path)`
+    chain — "archivist-bot/classifier" falls back through bot-level and
+    global defaults. Callers set AI_DEFAULT_MODEL / AI_MODELS_JSON in the
+    environment before building a Classifier so resolve_model sees the
+    same config the bot runtime does.
+
+    classify() raises on transport / model errors so the caller can
+    distinguish 'the LLM is down' from 'the LLM returned nothing'.
+    reformat() is best-effort and swallows the same errors, returning
+    None — rewriting OCR is enrichment, never a gate.
+    """
+
+    def __init__(self, http: aiohttp.ClientSession, url: str,
+                 key: str = "", bot_name: str = "archivist-bot"):
+        self.http = http
+        self.url = url.rstrip("/")
+        self.key = key
+        self.bot_name = bot_name
+
+    def _endpoint(self) -> str:
+        if not self.url:
+            raise LLMUnavailableError("No AI endpoint configured — set up AI with 'stack up ai'")
+        return self.url if self.url.endswith("/chat/completions") else f"{self.url}/chat/completions"
+
+    async def _request(self, task: str, prompt: str, *, json_mode: bool = False) -> str:
+        """Send a prompt to the LLM and return the response text.
+
+        The task name (e.g. "classifier", "reformat") is resolved to a
+        concrete model via resolve_model("<bot>/<task>"). The fallback chain:
+
+          1. [ai.models] <bot>.<task> — task-specific override
+          2. [ai.models] <bot>        — bot-level default
+          3. [ai] default             — global fallback
+
+        Uses the OpenAI-compatible chat completions API — works with oMLX,
+        Ollama, LM Studio, or any provider that serves /v1/chat/completions.
+        """
+        model = resolve_model(f"{self.bot_name}/{task}")
+
+        headers = {"Content-Type": "application/json"}
+        if self.key:
+            headers["Authorization"] = f"Bearer {self.key}"
+
+        body: dict = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if json_mode:
+            body["response_format"] = {"type": "json_object"}
+
+        try:
+            async with self.http.post(
+                self._endpoint(), headers=headers, json=body,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as resp:
+                if resp.status == 200:
+                    result = await resp.json()
+                    return result["choices"][0]["message"]["content"]
+                if resp.status == 401:
+                    raise LLMUnavailableError("Authentication failed — check [ai].openai_key in stack.toml")
+                if resp.status == 404:
+                    body_text = await resp.text()
+                    if "not found" in body_text.lower():
+                        raise LLMModelNotFoundError(f"{model} — is it loaded in oMLX?")
+                    raise LLMUnavailableError(f"HTTP 404: {body_text[:200]}")
+                raise LLMUnavailableError(f"HTTP {resp.status}")
+        except asyncio.TimeoutError:
+            raise LLMTimeoutError(f"{model} — model may still be loading, try again")
+        except (LLMUnavailableError, LLMModelNotFoundError, LLMTimeoutError):
+            raise
+        except Exception as e:
+            raise LLMUnavailableError(f"{e}")
+
+    async def classify(
+        self, *,
+        ocr_text: str,
+        tags: dict,
+        doc_types: dict,
+        correspondents: dict,
+    ) -> dict:
+        """Ask the LLM to classify a document based on its OCR text.
+
+        Returns structured JSON with:
+          - topics: subject areas (1-2 tags, e.g. ["Insurance", "Medical"])
+          - persons: which family members this belongs to
+          - correspondent: who sent / issued this document
+          - document_type: optional format (Invoice, Receipt, ...)
+          - title, date, summary, facts, action_items (rendered by caller)
+
+        Invalid JSON from the LLM → {} (logged warning). Transport failures
+        raise LLMUnavailableError / LLMModelNotFoundError / LLMTimeoutError
+        so the caller can distinguish 'LLM is down' from 'LLM gave nothing'.
+        """
+        person_tags = [t for t in tags if t.startswith("Person: ")]
+        person_names = [t.replace("Person: ", "") for t in person_tags]
+        category_tags = [t for t in tags if not t.startswith("Person: ")]
+        prompt = _build_classify_prompt(
+            ocr_text=ocr_text[:3000],
+            person_names=person_names,
+            category_tags=category_tags,
+            doc_types=list(doc_types.keys()),
+            correspondents=list(correspondents.keys()),
+        )
+
+        response = await self._request("classifier", prompt, json_mode=True)
+        if not response:
+            return {}
+        try:
+            return json.loads(response)
+        except json.JSONDecodeError:
+            logger.warning("[pipeline] LLM returned invalid JSON: {}", response[:200])
+            return {}
+
+    async def reformat(self, ocr_text: str) -> str | None:
+        """Reformat raw OCR text into clean, readable Markdown.
+
+        OCR output is often messy: broken lines, garbled characters, no
+        structure. The LLM fixes artifacts while preserving all factual
+        content. The reformatted text replaces the original in Paperless,
+        making documents actually readable.
+
+        Non-critical — transport failures return None and the caller's
+        fallback is to keep the raw OCR. Length-based usability filtering
+        is the pipeline's job (see `reformat_document`); this returns
+        whatever the LLM produced, trimmed.
+        """
+        prompt = _build_reformat_prompt(ocr_text[:6000])
+        try:
+            result = await self._request("reformat", prompt)
+        except (LLMUnavailableError, LLMModelNotFoundError, LLMTimeoutError):
+            return None
+        return result.strip() if result else None
+
+
+# ── Prompts ──────────────────────────────────────────────────────────────
+#
+# Extracted into module-level builders so the bot and CLI can print them
+# for debugging (`--dry-run --show-prompt` may land in v1.1) without
+# depending on classifier internals.
+
+def _build_classify_prompt(*, ocr_text: str, person_names: list[str],
+                           category_tags: list[str],
+                           doc_types: list[str],
+                           correspondents: list[str]) -> str:
+    """The classification prompt.
+
+    Simplified to three clear axes:
+      topic         = what is this about?   "Insurance", "Shopping"
+      person        = which family member?  "Homer", "Bart", or null
+      correspondent = who sent it?          "Springfield Nuclear", "Kwik-E-Mart"
+
+    Worked examples — a Kwik-E-Mart receipt for Homer:
+      topic="Shopping", person="Homer", correspondent="Kwik-E-Mart"
+    A school letter about Bart:
+      topics=["School"], person="Bart", correspondent="Springfield Elementary"
+    A health insurance invoice for Homer:
+      topics=["Insurance", "Medical"], person="Homer", correspondent="AOK"
+
+    Person names arrive stripped of the "Person: " prefix so the LLM sees
+    clean first names like "Homer" rather than "Person: Homer".
+    """
+    return f"""Classify this document. Return ONLY a JSON object.
+
+IMPORTANT: Always prefer existing values from the lists below. Only suggest
+a new value when NOTHING in the list is a reasonable match.
+
+Family members: {json.dumps(person_names, ensure_ascii=False)}
+Existing topic tags: {json.dumps(category_tags, ensure_ascii=False)}
+Existing document types: {json.dumps(doc_types, ensure_ascii=False)}
+Existing correspondents: {json.dumps(correspondents, ensure_ascii=False)}
+
+Return this exact JSON structure:
+{{
+  "title": "scannable title: [Correspondent] - [what] [key amount]. E.g. 'Anthropic - Max Plan EUR 90.00', 'ADAC - Kfz-Versicherung 2026 EUR 340'. Must be useful when scanning a list of 500 documents. Max 128 chars. Document's language.",
+  "date": "YYYY-MM-DD or null",
+  "topics": ["what is this document about? One or two subject areas. E.g. ['Insurance'], ['Insurance', 'Vehicle'], ['Shopping']. A health insurance bill is ['Insurance', 'Medical']. A car repair invoice is ['Vehicle']. Pick from existing topic tags when possible. Usually one topic, two only when the document genuinely spans two areas."],
+  "persons": ["which family members does this belong to? Pick from the family members list by first name. Can be multiple for joint documents (marriage, family insurance). Empty list if unclear. These are who the document is FOR or ABOUT, not who sent it."],
+  "document_type": "optional: what format is this? Invoice, Receipt, Contract, Letter, Certificate, or null if unclear.",
+  "correspondent": "the SENDER or ISSUING ORGANIZATION, or null if unclear. Who wrote or sent this? NOT the recipient. On an invoice, this is the company that billed, not the customer. Use the shortest recognizable name. null is better than guessing.",
+  "summary": "2-3 sentence summary with key facts: amounts, dates, names, deadlines",
+  "facts": ["key structured facts, e.g. 'Total: EUR 90.00', 'Invoice: #12345', 'Plan: Premium'"],
+  "action_items": [{{"action": "what needs to happen", "due": "YYYY-MM-DD or null"}}]
+}}
+
+Rules:
+- LANGUAGE: use the document's original language for title, summary, facts, and action_items. A German document gets a German title and German facts. Never translate.
+- topics: the subject area(s), not the document format. An invoice from a shop is ["Shopping"], not ["Invoice"]. An invoice for insurance is ["Insurance"]. A health insurance claim is ["Insurance", "Medical"]. Use the document's language for new topic tags too. Most documents have one topic; use two only when clearly spanning two areas.
+- persons: match by first name from the family members list. Can be multiple for joint documents. A marriage certificate for Homer and Marge: ["Homer", "Marge"]. A personal invoice for Homer only: ["Homer"].
+- correspondent: always the SENDER, never the addressee/customer/recipient. Use null if the sender is not clearly identifiable. Do not guess from fragments.
+- facts: concrete numbers, dates, account numbers, amounts. Empty list if none.
+- action_items: deadlines, payments due, forms to return. Empty list if none.
+
+Document text:
+---
+{ocr_text}
+---"""
+
+
+def _build_reformat_prompt(ocr_text: str) -> str:
+    """The OCR-to-clean-markdown prompt."""
+    return f"""Reformat this OCR-scanned document into clean, well-structured Markdown.
+
+Rules:
+- Fix OCR artifacts, broken lines, and garbled text
+- Correct obvious OCR errors in names and words
+- Preserve ALL factual content: numbers, dates, names, amounts, addresses
+- Structure with appropriate headings, lists, and tables
+- Do NOT summarize, translate, or add any content not in the original
+- NEVER guess or invent values — mark unreadable text as [unreadable]
+- If something is unreadable garbage (TSE signatures, hash strings), omit it
+- Keep the document language as-is
+- Output ONLY the formatted markdown, nothing else
+
+OCR text:
+---
+{ocr_text}
+---"""
+
+
+# ── Enrichment ───────────────────────────────────────────────────────────
+
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_NEW_TOPIC_COLOR = "#4caf50"
+
+
+async def enrich_document(
+    *,
+    paperless: PaperlessAPI,
+    classifier: Classifier,
+    doc: dict,
+) -> EnrichResult:
+    """Classify a doc, reconcile entities, PATCH Paperless. Pure data out.
+
+    No HTTP assumptions about the caller — collaborators are injected.
+    No stdout / Matrix concerns — caller renders the result. Never raises:
+    LLM / Paperless failures arrive through `EnrichResult.llm_error` or as
+    empty resolved_* lists.
+    """
+    ocr_text = (doc.get("content") or "").strip()
+    if not ocr_text:
+        return EnrichResult()
+
+    tags = await paperless.get_tags()
+    doc_types = await paperless.get_doc_types()
+    correspondents = await paperless.get_correspondents()
+
+    try:
+        classification = await classifier.classify(
+            ocr_text=ocr_text, tags=tags,
+            doc_types=doc_types, correspondents=correspondents,
+        )
+    except LLMUnavailableError as e:
+        return EnrichResult(llm_error=("unavailable", str(e)))
+    except LLMModelNotFoundError as e:
+        return EnrichResult(llm_error=("model_missing", str(e)))
+    except LLMTimeoutError as e:
+        return EnrichResult(llm_error=("timeout", str(e)))
+
+    if not classification:
+        return EnrichResult()
+
+    result = EnrichResult(classification=classification)
+    updates: dict[str, Any] = {}
+
+    # Title — capped at Paperless's 128-char column length.
+    title = classification.get("title")
+    if title and isinstance(title, str):
+        updates["title"] = title[:MAX_TITLE_LENGTH]
+
+    # Topics — open set. matching.py splits into existing vs new; new tags
+    # are created in Paperless and treated as resolved.
+    tag_ids = list(doc.get("tags", []))
+    category_tags = {t: tid for t, tid in tags.items() if not t.startswith("Person: ")}
+    topics_raw = classification.get("topics") or classification.get("topic")
+    matched_topics, new_topics = match_topics(topics_raw, category_tags)
+    for mt in matched_topics:
+        tag_ids.append(tags[mt])
+        result.resolved_topics.append(mt)
+    for nt in new_topics:
+        new_id = await paperless.create_tag(nt, _NEW_TOPIC_COLOR)
+        if new_id:
+            tag_ids.append(new_id)
+            result.resolved_topics.append(nt)
+            result.created_new.append(f'tag "{nt}"')
+
+    # Persons — closed set seeded from users.toml. match_persons handles
+    # full names, lists, "Person: X" prefixes, and returns the prefixed
+    # tag name; we strip the prefix for the resolved-name list callers
+    # want to render.
+    persons_raw = classification.get("persons") or classification.get("person")
+    for pt in match_persons(persons_raw, tags):
+        tag_ids.append(tags[pt])
+        result.resolved_persons.append(pt.replace("Person: ", ""))
+
+    if tag_ids:
+        updates["tags"] = list(set(tag_ids))
+
+    # Document type — respect a manually-set type on the doc: the user
+    # curated it and the LLM shouldn't overwrite. When unset, apply the
+    # LLM's call (matching existing or creating new).
+    doc_type = classification.get("document_type")
+    if not _is_empty(doc_type):
+        if doc.get("document_type"):
+            result.resolved_type = doc_type
+        else:
+            matched = fuzzy_match_entity(doc_type, doc_types)
+            if matched:
+                updates["document_type"] = doc_types[matched]
+                result.resolved_type = matched
+            else:
+                new_id = await paperless.create_doc_type(doc_type)
+                if new_id:
+                    updates["document_type"] = new_id
+                    result.resolved_type = doc_type
+                    result.created_new.append(f'document type "{doc_type}"')
+
+    # Correspondent — always overwrite. Paperless's auto-classifier guesses
+    # wrong with few samples; the LLM has read the actual text.
+    correspondent = classification.get("correspondent")
+    if not _is_empty(correspondent):
+        matched = fuzzy_match_entity(correspondent, correspondents)
+        if matched:
+            updates["correspondent"] = correspondents[matched]
+            result.resolved_correspondent = matched
+        else:
+            new_id = await paperless.create_correspondent(correspondent)
+            if new_id:
+                updates["correspondent"] = new_id
+                result.resolved_correspondent = correspondent
+                result.created_new.append(f'correspondent "{correspondent}"')
+
+    date = classification.get("date")
+    if date and isinstance(date, str) and _ISO_DATE.match(date):
+        updates["created"] = date
+
+    if updates:
+        await paperless.update_doc(doc["id"], updates)
+        result.updates_applied = updates
+
+    return result
+
+
+_REFORMAT_MIN_CHARS = 20
+
+
+async def reformat_document(
+    *,
+    paperless: PaperlessAPI,
+    classifier: Classifier,
+    doc_id: int,
+    ocr_text: str,
+) -> str | None:
+    """Ask the LLM to rewrite OCR text into clean Markdown, PATCH Paperless.
+
+    Returns the new text on success, None on any failure (LLM down, too
+    short to be a usable body, Paperless PATCH rejected). Non-critical —
+    the caller's fallback is to leave the original OCR in place.
+
+    The minimum-length guard catches the model returning a single token
+    or a stray " ok" when it misinterprets the prompt. Better to keep
+    the OCR text than replace it with garbage.
+    """
+    formatted = await classifier.reformat(ocr_text)
+    if not formatted or len(formatted) <= _REFORMAT_MIN_CHARS:
+        return None
+    ok = await paperless.update_doc(doc_id, {"content": formatted})
+    return formatted if ok else None

--- a/stacklets/docs/cli/_common.py
+++ b/stacklets/docs/cli/_common.py
@@ -1,0 +1,65 @@
+"""Docker-exec dispatcher for docs CLI commands.
+
+The stack CLI plugin loader skips `_`-prefixed files, so this module
+hosts shared plumbing without registering as a command.
+
+Design: the archivist pipeline needs aiohttp + loguru + the rendered
+Paperless/AI env vars to run. The host-side `./stack` is stdlib-only by
+design (fast startup, no pip install needed). Rather than cloning the
+pipeline in urllib or breaking the stdlib invariant, host commands
+docker-exec into the bot-runner container — it already has every dep
+the archivist uses and the env is pre-rendered.
+
+The same pattern generalises: any stacklet CLI that needs non-stdlib
+deps can grow a sibling `bot/cli_entrypoint.py` and a thin host
+dispatcher here. Keeps the host wrapper minimal and reuses the
+container's Python environment as the stack's "tools runtime".
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+BOT_RUNNER_CONTAINER = "stack-core-bot-runner"
+ENTRYPOINT_PATH = "/stacklets/docs/bot/cli_entrypoint.py"
+
+
+def _bot_runner_running() -> bool:
+    """True when the bot-runner container is up. False if absent or stopped."""
+    result = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", BOT_RUNNER_CONTAINER],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def dispatch(command: str, *argv: str) -> dict:
+    """docker exec the bot-runner's cli_entrypoint with the given args.
+
+    Returns `{"ok": True}` on success, `{"error": ...}` on failure. stdout
+    and stderr stream straight through so the caller sees live output.
+    When the host is a TTY the exec is allocated one too, so ANSI colors
+    from stack.prompt render correctly.
+    """
+    if not _bot_runner_running():
+        return {"error": f"{BOT_RUNNER_CONTAINER} is not running — bring core up first: stack up core"}
+
+    tty_flags = ["-it"] if sys.stdout.isatty() else ["-i"]
+    cmd = [
+        "docker", "exec", *tty_flags,
+        BOT_RUNNER_CONTAINER,
+        "python", ENTRYPOINT_PATH, command, *argv,
+    ]
+    try:
+        rc = subprocess.call(cmd)
+    except FileNotFoundError:
+        return {"error": "docker CLI not found on this host"}
+
+    # Pass rc through to the shell without letting the harness print a
+    # generic "command failed (exit N)" on top of the container's own
+    # stderr diagnostic. sys.exit bypasses the {"error": ...} path, so
+    # scripts still see the right return code without the double message.
+    if rc != 0:
+        sys.exit(rc)
+    return {"ok": True}

--- a/stacklets/docs/cli/classify.py
+++ b/stacklets/docs/cli/classify.py
@@ -1,18 +1,22 @@
-"""stack docs classify <id> — dry-run classifier against a filed document.
+"""stack docs classify <id> — classify a filed document and apply to Paperless.
 
-Runs the archivist's classify prompt against the doc's OCR text and prints
-the LLM's JSON output. Paperless is not touched, mirror is not updated.
+Runs the archivist's classify prompt against the doc's OCR text and
+applies the result (title, topic/person tags, type, correspondent, date)
+to Paperless. No reformat, no mirror — scoped to classification only.
 
-Useful for:
-  - Tuning the prompt (compare outputs across tweaks)
-  - Debugging a misclassification (what did the LLM actually see?)
-  - Validating a new model before switching the default
+Use `--dry-run` (or `--dry`) to preview without writes. Use `--json` for
+pipe-friendly raw LLM output (implies dry).
 
 Usage:
-    stack docs classify <id> [--json]    --json prints raw JSON (pipe-friendly).
+    stack docs classify <id> [--dry | --dry-run] [--json]
+
+Examples:
+    stack docs classify 42                  # apply classification
+    stack docs classify 42 --dry-run        # preview, no writes
+    stack docs classify 42 --json | jq      # raw JSON, pipeable
 """
 
-HELP = "Run the classifier on a filed document (dry, no writes)"
+HELP = "Classify a filed document and apply to Paperless"
 
 import sys
 from pathlib import Path

--- a/stacklets/docs/cli/classify.py
+++ b/stacklets/docs/cli/classify.py
@@ -1,0 +1,28 @@
+"""stack docs classify <id> — dry-run classifier against a filed document.
+
+Runs the archivist's classify prompt against the doc's OCR text and prints
+the LLM's JSON output. Paperless is not touched, mirror is not updated.
+
+Useful for:
+  - Tuning the prompt (compare outputs across tweaks)
+  - Debugging a misclassification (what did the LLM actually see?)
+  - Validating a new model before switching the default
+
+Usage:
+    stack docs classify <id> [--json]    --json prints raw JSON (pipe-friendly).
+"""
+
+HELP = "Run the classifier on a filed document (dry, no writes)"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]
+    return dispatch("classify", *argv)

--- a/stacklets/docs/cli/mirror.py
+++ b/stacklets/docs/cli/mirror.py
@@ -1,0 +1,32 @@
+"""stack docs mirror <id> [<id>...] — push existing docs to the Forgejo mirror.
+
+Useful for backfilling the mirror after enabling `mirror_to_git` in
+bot.toml: docs already in Paperless weren't mirrored at upload time, and
+this command walks each requested id, publishing the current Paperless
+state (title, tags, correspondent, content) to Forgejo. No LLM call —
+classification stays exactly as it is in Paperless.
+
+Fails fast when `mirror_to_git = false` in bot.toml: flip it, then run.
+
+Usage:
+    stack docs mirror <id> [<id>...] [--dry-run]
+
+Examples:
+    stack docs mirror 42                     # publish doc #42
+    stack docs mirror 42 43 44 --dry-run     # plan only, no commits
+"""
+
+HELP = "Publish existing documents to the Forgejo mirror (no LLM)"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]
+    return dispatch("mirror", *argv)

--- a/stacklets/docs/cli/reclassify.py
+++ b/stacklets/docs/cli/reclassify.py
@@ -1,0 +1,37 @@
+"""stack docs reclassify <id> [<id>...] — re-run the archivist pipeline.
+
+Fetches the filed doc, classifies it again, applies topic/person/type/
+correspondent/date to Paperless, optionally reformats the OCR body, and
+optionally updates the Forgejo mirror.
+
+`--reformat` and `--mirror` default to whatever the archivist's bot.toml
+[settings] says, so the CLI behaves the same way the bot does on a new
+upload. Pass the `--no-*` form to opt out for a single run.
+
+Usage:
+    stack docs reclassify <id> [<id>...] \\
+        [--reformat | --no-reformat] \\
+        [--mirror   | --no-mirror]   \\
+        [--dry-run]
+
+Examples:
+    stack docs reclassify 42                 # respect bot.toml, apply
+    stack docs reclassify 42 43 44           # batch, one at a time
+    stack docs reclassify 42 --dry-run       # plan only, no writes
+    stack docs reclassify 42 --no-reformat   # skip the reformat LLM call
+"""
+
+HELP = "Re-run the archivist pipeline on filed documents (apply + mirror)"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]
+    return dispatch("reclassify", *argv)

--- a/stacklets/docs/cli/reformat.py
+++ b/stacklets/docs/cli/reformat.py
@@ -1,14 +1,21 @@
-"""stack docs reformat <id> — dry-run reformatter against a filed document.
+"""stack docs reformat <id> — reformat a doc's OCR body and apply to Paperless.
 
-Runs the archivist's OCR-to-markdown prompt and prints the result. Paperless
-is not touched, mirror is not updated. Useful for previewing what the
-reformat pass would do and for debugging reformats that seem to drop content.
+Runs the archivist's OCR-to-markdown prompt on the doc's current content
+and replaces the Paperless body with the clean markdown.
+
+Use `--dry-run` (or `--dry`) to preview without writes. Use `--raw` for
+pipe-friendly raw markdown output (implies dry).
 
 Usage:
-    stack docs reformat <id> [--raw]     --raw prints markdown only (pipe-friendly).
+    stack docs reformat <id> [--dry | --dry-run] [--raw]
+
+Examples:
+    stack docs reformat 42                  # reformat + apply
+    stack docs reformat 42 --dry-run        # preview, no writes
+    stack docs reformat 42 --raw > doc.md   # raw markdown, pipeable
 """
 
-HELP = "Run the reformatter on a filed document (dry, no writes)"
+HELP = "Reformat a document's OCR body and apply to Paperless"
 
 import sys
 from pathlib import Path

--- a/stacklets/docs/cli/reformat.py
+++ b/stacklets/docs/cli/reformat.py
@@ -1,0 +1,24 @@
+"""stack docs reformat <id> — dry-run reformatter against a filed document.
+
+Runs the archivist's OCR-to-markdown prompt and prints the result. Paperless
+is not touched, mirror is not updated. Useful for previewing what the
+reformat pass would do and for debugging reformats that seem to drop content.
+
+Usage:
+    stack docs reformat <id> [--raw]     --raw prints markdown only (pipe-friendly).
+"""
+
+HELP = "Run the reformatter on a filed document (dry, no writes)"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]
+    return dispatch("reformat", *argv)

--- a/stacklets/docs/cli/reprocess.py
+++ b/stacklets/docs/cli/reprocess.py
@@ -1,4 +1,4 @@
-"""stack docs reclassify <id> [<id>...] — re-run the archivist pipeline.
+"""stack docs reprocess <id> [<id>...] — re-run the archivist pipeline.
 
 Fetches the filed doc, classifies it again, applies topic/person/type/
 correspondent/date to Paperless, optionally reformats the OCR body, and
@@ -9,16 +9,16 @@ optionally updates the Forgejo mirror.
 upload. Pass the `--no-*` form to opt out for a single run.
 
 Usage:
-    stack docs reclassify <id> [<id>...] \\
+    stack docs reprocess <id> [<id>...] \\
         [--reformat | --no-reformat] \\
         [--mirror   | --no-mirror]   \\
-        [--dry-run]
+        [--dry-run | --dry]
 
 Examples:
-    stack docs reclassify 42                 # respect bot.toml, apply
-    stack docs reclassify 42 43 44           # batch, one at a time
-    stack docs reclassify 42 --dry-run       # plan only, no writes
-    stack docs reclassify 42 --no-reformat   # skip the reformat LLM call
+    stack docs reprocess 42                 # respect bot.toml, apply
+    stack docs reprocess 42 43 44           # batch, one at a time
+    stack docs reprocess 42 --dry-run       # plan only, no writes
+    stack docs reprocess 42 --no-reformat   # skip the reformat LLM call
 """
 
 HELP = "Re-run the archivist pipeline on filed documents (apply + mirror)"
@@ -34,4 +34,4 @@ def run(args, stacklet, config):
     if not config["is_healthy"]():
         return {"error": "Docs is not running — start it with 'stack up docs'"}
     argv = sys.argv[3:]
-    return dispatch("reclassify", *argv)
+    return dispatch("reprocess", *argv)

--- a/stacklets/docs/cli/show.py
+++ b/stacklets/docs/cli/show.py
@@ -1,7 +1,7 @@
 """stack docs show <id> — inspect a document's current Paperless state.
 
 Read-only: title, date, type, correspondent, tags, and a content preview.
-Useful for sanity-checking a doc before reclassify, and for comparing
+Useful for sanity-checking a doc before reprocess, and for comparing
 before/after when tuning prompts or seeding new taxonomy.
 
 Usage:

--- a/stacklets/docs/cli/show.py
+++ b/stacklets/docs/cli/show.py
@@ -1,0 +1,24 @@
+"""stack docs show <id> — inspect a document's current Paperless state.
+
+Read-only: title, date, type, correspondent, tags, and a content preview.
+Useful for sanity-checking a doc before reclassify, and for comparing
+before/after when tuning prompts or seeding new taxonomy.
+
+Usage:
+    stack docs show <id> [--content]    --content prints the full body.
+"""
+
+HELP = "Show a document's current Paperless state"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]  # skip 'stack', 'docs', 'show'
+    return dispatch("show", *argv)

--- a/stacklets/docs/cli/tags.py
+++ b/stacklets/docs/cli/tags.py
@@ -1,0 +1,31 @@
+"""stack docs tags — inspect and clean up Paperless tags + types.
+
+Subcommands:
+    stack docs tags                              List tags (default view).
+    stack docs tags --types                      List document types instead.
+    stack docs tags --owner=N                    Filter by owner id.
+    stack docs tags --used | --unused            Filter by document_count.
+    stack docs tags merge <from> <to> [--type]   Retag every doc, then delete
+                                                 <from>. With --type, merges
+                                                 document_types instead.
+    stack docs tags prune --lang <de|en>         Delete seeded entries from
+                                                 that language section that
+                                                 have zero documents.
+
+All write-capable subcommands accept --dry / --dry-run for a preview.
+"""
+
+HELP = "Inspect and clean up Paperless tags and types"
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import dispatch  # noqa: E402
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Docs is not running — start it with 'stack up docs'"}
+    argv = sys.argv[3:]  # skip 'stack', 'docs', 'tags'
+    return dispatch("tags", *argv)

--- a/stacklets/docs/taxonomy.toml
+++ b/stacklets/docs/taxonomy.toml
@@ -14,11 +14,11 @@ tags = [
     "Finanzen",            # bank statements, retirement, accounts
     "Investments",         # stocks, funds, portfolios, dividends
     "Einkommen",           # salary, freelance income, side jobs
-    "Steuern",             # returns, assessments, deductions
+    "Steuer",              # returns, assessments, deductions
     "Finanzamt",           # tax office correspondence, Steuerbescheid
     "Gesundheit",          # doctors, prescriptions, lab results
     "Schule",              # report cards, enrollment, school letters
-    "Kinder",              # daycare, activities, allowances, Kindergeld
+    "Kind",                # daycare, activities, allowances, Kindergeld
     "Ehe",                 # marriage certificate, divorce, joint documents
     "Fahrzeug",            # registration, inspections, repairs, fuel
     "Wohnen",              # rent, mortgage, renovations, maintenance
@@ -26,22 +26,22 @@ tags = [
     "Nebenkosten",         # electricity, water, gas, heating
     "Arbeit",              # contracts, pay slips, references
     "Recht",               # legal contracts, notary, court
-    "Behörden",            # ID, permits, registrations, Meldebescheinigung
+    "Behörde",             # ID, permits, registrations, Meldebescheinigung
     "Mitgliedschaft",      # clubs, associations, memberships
     "Abonnement",          # streaming, software, magazines
     "Einkauf",             # general shopping, warranties, returns
     "Elektronik",          # computers, phones, gadgets, tech purchases
     "Lebensmittel",        # groceries, supermarket receipts
     "Reise",               # bookings, tickets, travel insurance
-    "Haustiere",           # vet, registration, insurance
+    "Haustier",            # vet, registration, insurance
     "Telekommunikation",   # phone, internet, mobile contracts
-    "Rezepte",             # family recipes, grandma's classics, cooking and baking
-    "Erinnerungen",        # kids' artwork, letters, postcards, milestone docs
-    "Urkunden",            # birth/death certificates, passports, wills, Vollmacht
+    "Rezept",              # family recipes, grandma's classics, cooking and baking
+    "Erinnerung",          # kids' artwork, letters, postcards, milestone docs
+    "Urkunde",             # birth/death certificates, passports, wills, Vollmacht
     "Rente",               # state pension, Riester, company pension, Altersvorsorge
-    "Spenden",             # charity donations, tax-deductible receipts
+    "Spende",              # charity donations, tax-deductible receipts
     "Garantie",            # warranty cards, proof of purchase for claims
-    "Impfungen",           # vaccination records, allergy passes, blood type
+    "Impfung",             # vaccination records, allergy passes, blood type
     "Zugangsdaten",        # WiFi passwords, serial numbers, access codes
 ]
 types = [
@@ -72,16 +72,16 @@ tags = [
     "Finance",             # bank statements, retirement, accounts
     "Investments",         # stocks, funds, portfolios, dividends
     "Income",              # salary, freelance income, side jobs
-    "Taxes",               # returns, assessments, deductions
+    "Tax",                 # returns, assessments, deductions
     "Tax Office",          # IRS/HMRC correspondence, tax notices
     "Medical",             # doctors, prescriptions, lab results
     "School",              # report cards, enrollment, school letters
-    "Children",            # daycare, activities, allowances, child benefit
+    "Child",               # daycare, activities, allowances, child benefit
     "Marriage",            # marriage certificate, divorce, joint documents
     "Vehicle",             # registration, inspections, repairs, fuel
     "Housing",             # rent, mortgage, renovations, maintenance
     "Property",            # property purchase, deed, real estate agent
-    "Utilities",           # electricity, water, gas, heating
+    "Utility",             # electricity, water, gas, heating
     "Employment",          # contracts, pay slips, references
     "Legal",               # contracts, notary, court
     "Government",          # ID, permits, registrations
@@ -91,16 +91,16 @@ tags = [
     "Electronics",         # computers, phones, gadgets, tech purchases
     "Groceries",           # supermarket receipts
     "Travel",              # bookings, tickets, travel insurance
-    "Pets",                # vet, registration, insurance
+    "Pet",                 # vet, registration, insurance
     "Telecom",             # phone, internet, mobile contracts
-    "Recipes",             # family recipes, grandma's classics, cooking and baking
-    "Memories",            # kids' artwork, letters, postcards, milestone docs
-    "Personal Records",    # birth/death certificates, passports, wills, power of attorney
+    "Recipe",              # family recipes, grandma's classics, cooking and baking
+    "Memory",              # kids' artwork, letters, postcards, milestone docs
+    "Personal Record",     # birth/death certificates, passports, wills, power of attorney
     "Pension",             # state pension, 401k, company pension, retirement
-    "Donations",           # charity donations, tax-deductible receipts
+    "Donation",            # charity donations, tax-deductible receipts
     "Warranty",            # warranty cards, proof of purchase for claims
-    "Vaccinations",        # vaccination records, allergy passes, blood type
-    "Credentials",         # WiFi passwords, serial numbers, access codes
+    "Vaccination",         # vaccination records, allergy passes, blood type
+    "Credential",          # WiFi passwords, serial numbers, access codes
 ]
 types = [
     "Invoice",

--- a/stacklets/docs/taxonomy.toml
+++ b/stacklets/docs/taxonomy.toml
@@ -17,12 +17,13 @@ tags = [
     "Steuer",              # returns, assessments, deductions
     "Finanzamt",           # tax office correspondence, Steuerbescheid
     "Gesundheit",          # doctors, prescriptions, lab results
-    "Schule",              # report cards, enrollment, school letters
+    "Bildung",             # school, university, courses, further education
     "Kind",                # daycare, activities, allowances, Kindergeld
     "Ehe",                 # marriage certificate, divorce, joint documents
     "Fahrzeug",            # registration, inspections, repairs, fuel
     "Wohnen",              # rent, mortgage, renovations, maintenance
     "Immobilien",          # property purchase, Grundbuch, Makler
+    "Architektur",         # floor plans, drawings, building designs
     "Nebenkosten",         # electricity, water, gas, heating
     "Arbeit",              # contracts, pay slips, references
     "Recht",               # legal contracts, notary, court
@@ -75,12 +76,13 @@ tags = [
     "Tax",                 # returns, assessments, deductions
     "Tax Office",          # IRS/HMRC correspondence, tax notices
     "Medical",             # doctors, prescriptions, lab results
-    "School",              # report cards, enrollment, school letters
+    "Education",           # school, university, courses, further education
     "Child",               # daycare, activities, allowances, child benefit
     "Marriage",            # marriage certificate, divorce, joint documents
     "Vehicle",             # registration, inspections, repairs, fuel
     "Housing",             # rent, mortgage, renovations, maintenance
     "Property",            # property purchase, deed, real estate agent
+    "Architecture",        # floor plans, drawings, building designs
     "Utility",             # electricity, water, gas, heating
     "Employment",          # contracts, pay slips, references
     "Legal",               # contracts, notary, court

--- a/stacklets/docs/taxonomy.toml
+++ b/stacklets/docs/taxonomy.toml
@@ -57,6 +57,13 @@ types = [
     "Bedienungsanleitung",
     "Protokoll",
     "Buchung",
+    "Antrag",
+    "Mahnung",
+    "Attest",
+    "Merkblatt",
+    "Verschreibung",
+    "Steuerbescheid",
+    "Lohnabrechnung",
 ]
 
 [en]
@@ -108,4 +115,11 @@ types = [
     "Manual",
     "Protocol",
     "Booking",
+    "Application",
+    "Payment Reminder",
+    "Medical Certificate",
+    "Fact Sheet",
+    "Prescription",
+    "Tax Assessment",
+    "Pay Slip",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -121,6 +121,82 @@ def test_stack() -> TestStack:
     return TestStack()
 
 
+# ── Beta features — enable before any container comes up ────────────────
+#
+# Some stacklets ship beta-grade features as opt-in (false by default in
+# bot.toml / stacklet.toml). For tests we want the full feature set
+# exercised, so flags are flipped in `pytest_sessionstart` before any
+# fixture runs. A fresh test run gets its first `stack up <stacklet>`
+# already picking up the beta flag; if a container is already running
+# with the stale default (previous session, no cleanup) we restart the
+# affected container so the in-memory state catches up with the file.
+#
+# Each flag declares the container(s) it lives inside — restart those
+# if and only if the flag actually changed on disk.
+#
+# Current beta flags:
+#   - stacklets/docs/bot/bot.toml : mirror_to_git (Forgejo markdown mirror)
+
+_BETA_FLAGS: list[tuple[Path, str, str, tuple[str, ...]]] = [
+    (
+        REPO_ROOT / "stacklets" / "docs" / "bot" / "bot.toml",
+        "mirror_to_git = false", "mirror_to_git = true",
+        ("stack-core-bot-runner",),
+    ),
+]
+_BETA_BACKUPS: dict[Path, str] = {}
+
+
+def _set_beta_flags(enable: bool) -> None:
+    """Flip flags to `true` (enable=True) or restore the committed default.
+
+    Tracks containers whose in-memory config depends on the flag and
+    restarts them if they're currently running — so a stale bot-runner
+    from a previous session picks up the new bot.toml without the test
+    having to tear down core first.
+    """
+    containers_to_restart: set[str] = set()
+    for path, off, on, containers in _BETA_FLAGS:
+        if not path.exists():
+            continue
+        current = path.read_text()
+        if enable:
+            if off in current:
+                _BETA_BACKUPS[path] = current
+                path.write_text(current.replace(off, on))
+                containers_to_restart.update(containers)
+        else:
+            original = _BETA_BACKUPS.pop(path, None)
+            if original is not None and current != original:
+                path.write_text(original)
+                containers_to_restart.update(containers)
+
+    for container in containers_to_restart:
+        _restart_if_running(container)
+
+
+def _restart_if_running(container: str) -> None:
+    running = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", container],
+        capture_output=True, text=True,
+    )
+    if running.returncode == 0 and running.stdout.strip() == "true":
+        subprocess.run(
+            ["docker", "restart", container],
+            capture_output=True, timeout=30,
+        )
+
+
+def pytest_sessionstart(session):  # noqa: D401 - pytest hook
+    """Pre-flight: enable beta features before any fixture boots a container."""
+    _set_beta_flags(enable=True)
+
+
+def pytest_sessionfinish(session, exitstatus):  # noqa: D401 - pytest hook
+    """Restore on-disk flags regardless of how the session ended."""
+    _set_beta_flags(enable=False)
+
+
 @pytest.fixture(scope="session")
 def stack():
     """A Stack instance pointed at the test instance — for tests that

--- a/tests/stacklets/test_archivist_duplicate.py
+++ b/tests/stacklets/test_archivist_duplicate.py
@@ -14,10 +14,9 @@ import pytest
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "lib"))
-sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "core" / "bot-runner"))
 sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "docs" / "bot"))
 
-from archivist import _DUPLICATE_RE, PaperlessDuplicateError  # noqa: E402
+from pipeline import _DUPLICATE_RE, PaperlessDuplicateError  # noqa: E402
 
 
 class TestDuplicateRegex:

--- a/tests/stacklets/test_pipeline.py
+++ b/tests/stacklets/test_pipeline.py
@@ -365,26 +365,61 @@ class TestEnrichCreateNew:
         assert all(not name.startswith("Person: ") for name, _ in seeded_paperless.created_tags)
 
 
-# ── Document type invariant ───────────────────────────────────────────────
+# ── Fresh-reprocess semantics ─────────────────────────────────────────────
 
-class TestEnrichDocTypeRespectsExisting:
-    """A manually-assigned document_type on the doc is never overwritten."""
+class TestEnrichFreshReprocess:
+    """enrich_document treats each run as a full fresh classification:
+    prior tags are dropped, prior document_type is overwritten."""
 
     @pytest.mark.asyncio
-    async def test_manual_type_not_overwritten(self, seeded_paperless):
+    async def test_prior_tags_cleared(self, seeded_paperless):
+        """Old classified tags don't accumulate on reprocess."""
         classifier = StubClassifier(payload={
-            "title": "x", "document_type": "Letter",
+            "title": "x", "topics": ["Insurance"], "persons": ["Homer"],
         })
-        doc = _doc(document_type=100)  # existing type id
+        # Doc had an old classification ("Shopping" + Person: Marge) plus a
+        # tag id the user added by hand (#999). All three should go; only
+        # the new classification remains.
+        doc = _doc(tags=[2, 11, 999])  # Shopping, Person: Marge, stray
 
         result = await enrich_document(
             paperless=seeded_paperless, classifier=classifier, doc=doc,
         )
 
-        # Type is resolved for the chat-reply/mirror summary but not PATCHed
-        assert result.resolved_type == "Letter"
         _, updates = seeded_paperless.updates[0]
-        assert "document_type" not in updates
+        assert set(updates["tags"]) == {1, 10}  # Insurance, Person: Homer
+        assert result.resolved_topics == ["Insurance"]
+        assert result.resolved_persons == ["Homer"]
+
+    @pytest.mark.asyncio
+    async def test_tags_cleared_when_llm_returns_no_categories(self, seeded_paperless):
+        """LLM returned a classification but no topics/persons — doc ends
+        up with no tags. Matches what a fresh upload with the same LLM
+        output would produce."""
+        classifier = StubClassifier(payload={"title": "x"})
+        doc = _doc(tags=[2, 11])  # had old classification
+
+        await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+        _, updates = seeded_paperless.updates[0]
+        assert updates["tags"] == []
+
+    @pytest.mark.asyncio
+    async def test_document_type_overwritten(self, seeded_paperless):
+        """A prior document_type is replaced with the LLM's pick, not preserved."""
+        classifier = StubClassifier(payload={
+            "title": "x", "document_type": "Letter",
+        })
+        doc = _doc(document_type=100)  # Invoice id
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        _, updates = seeded_paperless.updates[0]
+        assert updates["document_type"] == 102  # Letter id
+        assert result.resolved_type == "Letter"
 
 
 # ── Title / date edge cases ───────────────────────────────────────────────

--- a/tests/stacklets/test_pipeline.py
+++ b/tests/stacklets/test_pipeline.py
@@ -1,0 +1,450 @@
+"""Unit tests for the archivist enrichment pipeline.
+
+The pipeline is the shared classify + apply-to-Paperless + reformat core
+used by the archivist bot (live uploads) and the `stack docs reclassify`
+CLI (reprocessing filed documents). Tests use in-memory stub versions of
+PaperlessAPI and Classifier so the unit exercises matching + update
+assembly without HTTP or LLM calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "lib"))
+sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "docs" / "bot"))
+
+from pipeline import (  # noqa: E402
+    EnrichResult,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+    LLMUnavailableError,
+    enrich_document,
+    reformat_document,
+)
+
+
+# ── Stub collaborators ────────────────────────────────────────────────────
+
+class StubPaperless:
+    """In-memory PaperlessAPI stand-in. Records calls for assertions."""
+
+    def __init__(self, tags=None, doc_types=None, correspondents=None):
+        self.tags = dict(tags or {})
+        self.doc_types = dict(doc_types or {})
+        self.correspondents = dict(correspondents or {})
+        self._next_id = 1000
+        self.updates: list[tuple[int, dict]] = []
+        self.created_tags: list[tuple[str, str]] = []  # (name, color)
+        self.created_doc_types: list[str] = []
+        self.created_correspondents: list[str] = []
+
+    async def get_tags(self):
+        return dict(self.tags)
+
+    async def get_doc_types(self):
+        return dict(self.doc_types)
+
+    async def get_correspondents(self):
+        return dict(self.correspondents)
+
+    async def update_doc(self, doc_id, updates):
+        self.updates.append((doc_id, dict(updates)))
+        return True
+
+    async def create_tag(self, name, color="#4caf50"):
+        tid = self._next_id
+        self._next_id += 1
+        self.tags[name] = tid
+        self.created_tags.append((name, color))
+        return tid
+
+    async def create_doc_type(self, name):
+        tid = self._next_id
+        self._next_id += 1
+        self.doc_types[name] = tid
+        self.created_doc_types.append(name)
+        return tid
+
+    async def create_correspondent(self, name):
+        tid = self._next_id
+        self._next_id += 1
+        self.correspondents[name] = tid
+        self.created_correspondents.append(name)
+        return tid
+
+
+class StubClassifier:
+    """Returns a pre-canned classify/reformat payload or raises."""
+
+    def __init__(self, payload=None, classify_raises=None,
+                 reformat_text=None, reformat_raises=None):
+        self.payload = payload
+        self.classify_raises = classify_raises
+        self.reformat_text = reformat_text
+        self.reformat_raises = reformat_raises
+        self.classify_calls: list[dict] = []
+        self.reformat_calls: list[str] = []
+
+    async def classify(self, *, ocr_text, tags, doc_types, correspondents):
+        self.classify_calls.append({
+            "ocr_text": ocr_text, "tags": tags,
+            "doc_types": doc_types, "correspondents": correspondents,
+        })
+        if self.classify_raises:
+            raise self.classify_raises
+        return self.payload or {}
+
+    async def reformat(self, ocr_text):
+        self.reformat_calls.append(ocr_text)
+        if self.reformat_raises:
+            raise self.reformat_raises
+        return self.reformat_text
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def seeded_paperless():
+    """Paperless with a small Springfield-themed taxonomy pre-seeded.
+
+    Tags carry both categories and the closed-set "Person: X" tags so
+    enrich_document's topic/person split has something real to match.
+    """
+    return StubPaperless(
+        tags={
+            "Insurance": 1, "Shopping": 2, "Medical": 3,
+            "Person: Homer": 10, "Person: Marge": 11, "Person: Bart": 12,
+        },
+        doc_types={"Invoice": 100, "Receipt": 101, "Letter": 102},
+        correspondents={"ADAC": 200, "Kwik-E-Mart": 201},
+    )
+
+
+def _doc(doc_id=42, content="Invoice text from ADAC for car insurance.",
+         tags=None, document_type=None):
+    """Build a Paperless doc dict in the shape the pipeline expects."""
+    return {
+        "id": doc_id,
+        "content": content,
+        "tags": list(tags or []),
+        "document_type": document_type,
+    }
+
+
+# ── Happy path ────────────────────────────────────────────────────────────
+
+class TestEnrichHappyPath:
+    """A well-formed LLM classification flows through to Paperless."""
+
+    @pytest.mark.asyncio
+    async def test_full_classification_applied(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "ADAC - Kfz-Versicherung 2026 EUR 340",
+            "date": "2026-03-15",
+            "topics": ["Insurance"],
+            "persons": ["Homer"],
+            "correspondent": "ADAC",
+            "document_type": "Invoice",
+            "summary": "Annual renewal.",
+            "facts": ["EUR 340.00"],
+            "action_items": [],
+        })
+        doc = _doc(doc_id=42, tags=[])
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        assert result.resolved_topics == ["Insurance"]
+        assert result.resolved_persons == ["Homer"]
+        assert result.resolved_correspondent == "ADAC"
+        assert result.resolved_type == "Invoice"
+        assert result.created_new == []
+        assert result.llm_error is None
+
+        # One PATCH to Paperless with the full update set
+        assert len(seeded_paperless.updates) == 1
+        doc_id, updates = seeded_paperless.updates[0]
+        assert doc_id == 42
+        assert updates["title"] == "ADAC - Kfz-Versicherung 2026 EUR 340"
+        assert updates["created"] == "2026-03-15"
+        assert updates["correspondent"] == 200  # ADAC id
+        assert updates["document_type"] == 100  # Invoice id
+        # Tag ids — Insurance + Person: Homer
+        assert set(updates["tags"]) == {1, 10}
+
+    @pytest.mark.asyncio
+    async def test_multiple_topics_and_persons(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "Family health insurance receipt",
+            "topics": ["Insurance", "Medical"],
+            "persons": ["Homer", "Marge"],
+        })
+        doc = _doc(doc_id=43)
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        assert result.resolved_topics == ["Insurance", "Medical"]
+        assert sorted(result.resolved_persons) == ["Homer", "Marge"]
+        _, updates = seeded_paperless.updates[0]
+        assert set(updates["tags"]) == {1, 3, 10, 11}  # Insurance, Medical, Homer, Marge
+
+
+# ── Empty / missing inputs ────────────────────────────────────────────────
+
+class TestEnrichEmptyContent:
+    """Empty or tiny OCR text short-circuits without calling the LLM."""
+
+    @pytest.mark.asyncio
+    async def test_empty_content_skips_classify(self, seeded_paperless):
+        classifier = StubClassifier(payload={"title": "ignored"})
+        doc = _doc(content="")
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        assert result.classification == {}
+        assert result.resolved_topics == []
+        assert classifier.classify_calls == []
+        assert seeded_paperless.updates == []
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_skips_classify(self, seeded_paperless):
+        classifier = StubClassifier(payload={"title": "ignored"})
+        doc = _doc(content="   \n\t  ")
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        assert result.classification == {}
+        assert classifier.classify_calls == []
+
+
+class TestEnrichEmptyClassification:
+    """Classifier returned {} — no updates, no mistaken creations."""
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_applies_nothing(self, seeded_paperless):
+        classifier = StubClassifier(payload={})
+        doc = _doc()
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        assert result.classification == {}
+        assert result.resolved_topics == []
+        assert result.resolved_correspondent is None
+        assert seeded_paperless.updates == []
+        assert seeded_paperless.created_tags == []
+
+
+# ── LLM errors ────────────────────────────────────────────────────────────
+
+class TestEnrichLLMErrors:
+    """Each LLM exception maps to a structured llm_error tuple."""
+
+    @pytest.mark.asyncio
+    async def test_unavailable(self, seeded_paperless):
+        classifier = StubClassifier(
+            classify_raises=LLMUnavailableError("HTTP 502"),
+        )
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.llm_error == ("unavailable", "HTTP 502")
+        assert result.classification == {}
+        assert seeded_paperless.updates == []
+
+    @pytest.mark.asyncio
+    async def test_model_missing(self, seeded_paperless):
+        classifier = StubClassifier(
+            classify_raises=LLMModelNotFoundError("qwen3.5:14b"),
+        )
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.llm_error == ("model_missing", "qwen3.5:14b")
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, seeded_paperless):
+        classifier = StubClassifier(
+            classify_raises=LLMTimeoutError("qwen3.5:14b timed out"),
+        )
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.llm_error == ("timeout", "qwen3.5:14b timed out")
+
+
+# ── Fuzzy matching at the apply step ──────────────────────────────────────
+
+class TestEnrichFuzzyMatching:
+    """LLM output goes through matching.py before Paperless touches."""
+
+    @pytest.mark.asyncio
+    async def test_correspondent_fuzzy_match_avoids_duplicate(self, seeded_paperless):
+        # LLM says "ADAC e.V." — should match existing "ADAC", not create new
+        classifier = StubClassifier(payload={
+            "title": "Invoice", "correspondent": "ADAC e.V.",
+        })
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_correspondent == "ADAC"
+        assert seeded_paperless.created_correspondents == []
+        _, updates = seeded_paperless.updates[0]
+        assert updates["correspondent"] == 200
+
+    @pytest.mark.asyncio
+    async def test_topic_fuzzy_match(self, seeded_paperless):
+        # "Shopping Groceries" wouldn't fuzzy-match "Shopping" at word boundary
+        # with the prefix semantics — but "Insurance" vs "Insurance" is exact.
+        classifier = StubClassifier(payload={"topics": ["insurance"]})
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_topics == ["Insurance"]
+        assert seeded_paperless.created_tags == []
+
+
+class TestEnrichCreateNew:
+    """Unknown tags/types/correspondents get created — except persons."""
+
+    @pytest.mark.asyncio
+    async def test_new_topic_tag_created(self, seeded_paperless):
+        classifier = StubClassifier(payload={"topics": ["School"]})
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_topics == ["School"]
+        assert seeded_paperless.created_tags == [("School", "#4caf50")]
+        assert 'tag "School"' in result.created_new
+
+    @pytest.mark.asyncio
+    async def test_new_correspondent_created(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "x", "correspondent": "Springfield Elementary",
+        })
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_correspondent == "Springfield Elementary"
+        assert seeded_paperless.created_correspondents == ["Springfield Elementary"]
+        assert 'correspondent "Springfield Elementary"' in result.created_new
+
+    @pytest.mark.asyncio
+    async def test_new_document_type_created(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "x", "document_type": "Certificate",
+        })
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_type == "Certificate"
+        assert seeded_paperless.created_doc_types == ["Certificate"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_person_not_created(self, seeded_paperless):
+        """Persons are a closed set seeded from users.toml — never mint new."""
+        classifier = StubClassifier(payload={"persons": ["Maggie"]})
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        assert result.resolved_persons == []
+        # No new "Person: Maggie" tag
+        assert all(not name.startswith("Person: ") for name, _ in seeded_paperless.created_tags)
+
+
+# ── Document type invariant ───────────────────────────────────────────────
+
+class TestEnrichDocTypeRespectsExisting:
+    """A manually-assigned document_type on the doc is never overwritten."""
+
+    @pytest.mark.asyncio
+    async def test_manual_type_not_overwritten(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "x", "document_type": "Letter",
+        })
+        doc = _doc(document_type=100)  # existing type id
+
+        result = await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=doc,
+        )
+
+        # Type is resolved for the chat-reply/mirror summary but not PATCHed
+        assert result.resolved_type == "Letter"
+        _, updates = seeded_paperless.updates[0]
+        assert "document_type" not in updates
+
+
+# ── Title / date edge cases ───────────────────────────────────────────────
+
+class TestEnrichTitleAndDate:
+
+    @pytest.mark.asyncio
+    async def test_title_truncated_to_paperless_limit(self, seeded_paperless):
+        from pipeline import MAX_TITLE_LENGTH
+        long_title = "A" * (MAX_TITLE_LENGTH + 50)
+        classifier = StubClassifier(payload={"title": long_title})
+        await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        _, updates = seeded_paperless.updates[0]
+        assert len(updates["title"]) == MAX_TITLE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_bad_date_ignored(self, seeded_paperless):
+        classifier = StubClassifier(payload={
+            "title": "x", "date": "March 2026",  # not ISO
+        })
+        await enrich_document(
+            paperless=seeded_paperless, classifier=classifier, doc=_doc(),
+        )
+        _, updates = seeded_paperless.updates[0]
+        assert "created" not in updates
+
+
+# ── Reformat ──────────────────────────────────────────────────────────────
+
+class TestReformatDocument:
+
+    @pytest.mark.asyncio
+    async def test_reformat_success_patches_content(self, seeded_paperless):
+        classifier = StubClassifier(reformat_text="# Clean markdown\n\nbody")
+        updated = await reformat_document(
+            paperless=seeded_paperless, classifier=classifier,
+            doc_id=42, ocr_text="messy\nOCR",
+        )
+        assert updated == "# Clean markdown\n\nbody"
+        assert seeded_paperless.updates == [(42, {"content": "# Clean markdown\n\nbody"})]
+
+    @pytest.mark.asyncio
+    async def test_reformat_returns_none_leaves_content_alone(self, seeded_paperless):
+        classifier = StubClassifier(reformat_text=None)
+        updated = await reformat_document(
+            paperless=seeded_paperless, classifier=classifier,
+            doc_id=42, ocr_text="original",
+        )
+        assert updated is None
+        assert seeded_paperless.updates == []
+
+    @pytest.mark.asyncio
+    async def test_reformat_too_short_treated_as_failure(self, seeded_paperless):
+        """LLM occasionally returns a token or empty string — guard against it."""
+        classifier = StubClassifier(reformat_text="ok")
+        updated = await reformat_document(
+            paperless=seeded_paperless, classifier=classifier,
+            doc_id=42, ocr_text="original",
+        )
+        assert updated is None
+        assert seeded_paperless.updates == []

--- a/tests/stacklets/test_pipeline.py
+++ b/tests/stacklets/test_pipeline.py
@@ -1,7 +1,7 @@
 """Unit tests for the archivist enrichment pipeline.
 
 The pipeline is the shared classify + apply-to-Paperless + reformat core
-used by the archivist bot (live uploads) and the `stack docs reclassify`
+used by the archivist bot (live uploads) and the `stack docs reprocess`
 CLI (reprocessing filed documents). Tests use in-memory stub versions of
 PaperlessAPI and Classifier so the unit exercises matching + update
 assembly without HTTP or LLM calls.


### PR DESCRIPTION
feat(docs): stack docs CLI — inspect, reprocess, mirror, tags

      show <id> [--content]                 Paperless state (read-only)
      classify <id> [--dry] [--json]        classify + apply
      reformat <id> [--dry] [--raw]         reformat + apply
      reprocess <id>... [--dry]             full pipeline, respects bot.toml
      mirror <id>... [--dry]                publish to Forgejo (no LLM)
      tags [--types] [--used|--unused]      list tags or document_types
      tags merge <from> <to> [--type] [--dry]  retag docs, drop source
      tags prune --lang <de|en> [--dry]     delete unused seeded entries
      tags delete <name> [--type] [--dry]   delete one (refuses if in use)

  Write commands apply by default; --dry previews. reprocess is
  clean-slate — LLM output becomes the full tag state, no accumulation.

  Pipeline (classify + apply + reformat) extracted into a shared module
  used by the archivist bot and every CLI command. Host ./stack stays
  stdlib-only; commands docker-exec into stack-core-bot-runner for
  non-stdlib work.

  Also: stack CLI no longer eats plugin `--json`; pytest_sessionstart
  flips beta flags before container boot so mirror e2e tests stay green.