### PR TITLE
feat(docs): include classifier summary in mirror commit messages

### DIFF
--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -337,6 +337,7 @@ class ArchivistBot(MicroBot):
         model: str | None,
         fallback_title: str,
         paperless_tags: list[str],
+        summary: str | None = None,
     ) -> None:
         """Mirror a filed doc to Forgejo — never raises, never blocks the reply.
 
@@ -357,6 +358,7 @@ class ArchivistBot(MicroBot):
                 paperless_url=self.paperless_public_url or self.paperless_url,
                 tags=paperless_tags,
                 fallback_title=fallback_title,
+                summary=summary,
             )
         except Exception as e:
             logger.warning("[archivist] Git mirror failed for doc #{}: {}", doc_id, e)
@@ -598,6 +600,7 @@ class ArchivistBot(MicroBot):
             model=model,
             fallback_title=display_name,
             paperless_tags=paperless_tags,
+            summary=result.summary,
         )
 
         # ── Chat reply ───────────────────────────────────────────────────

--- a/stacklets/docs/bot/cli/_mirror.py
+++ b/stacklets/docs/bot/cli/_mirror.py
@@ -114,6 +114,7 @@ async def publish_enriched(
             paperless_url=paperless_url,
             tags=paperless_tags,
             fallback_title=doc.get("title"),
+            summary=result.summary,
         )
     except Exception as e:
         err(f"#{doc['id']}: mirror publish failed — {e}")

--- a/stacklets/docs/bot/git_mirror.py
+++ b/stacklets/docs/bot/git_mirror.py
@@ -309,7 +309,11 @@ class GitMirror:
             "    learn: <title>         new document\n"
             "    update: <title>        reprocessed existing document\n"
             "    rename: <old> → <new>  title-driven filename change\n\n"
-            "Each commit message carries a `Paperless-Id: <N>` trailer.\n\n"
+            "When the classifier produced a summary it rides in the commit\n"
+            "body as `## Summary` / `## Facts` / `## Parties` sections, so\n"
+            "`git log` reads like a narrated archive log and `git log --grep`\n"
+            "searches across summaries out of the box. Each commit message\n"
+            "carries a `Paperless-Id: <N>` trailer.\n\n"
             "## Deletions\n\n"
             "Documents deleted in Paperless stay in this repo until a future\n"
             "`stack docs reconcile` pass tombstones them. Until then, the\n"
@@ -476,9 +480,19 @@ class GitMirror:
         verb: str, title: str,
         paperless_id: int,
         processing: str, model: str | None,
+        summary: str | None = None,
     ) -> str:
-        """Build a commit with trailers. verb = 'learn' | 'update'."""
+        """Build a commit with trailers. verb = 'learn' | 'update'.
+
+        When a classifier summary is available it rides in the commit body
+        between the subject and the trailers — turns `git log` on the
+        mirror into a browsable archive log, and gives `git log --grep`
+        a searchable index without a separate tool.
+        """
         lines = [f"{verb}: {title}", ""]
+        if summary:
+            lines.append(summary.strip())
+            lines.append("")
         lines.append(f"Paperless-Id: {paperless_id}")
         lines.append(f"Processing: {processing}")
         if model:
@@ -498,6 +512,7 @@ class GitMirror:
         paperless_url: str,
         tags: list[str] | None = None,
         fallback_title: str | None = None,
+        summary: str | None = None,
     ) -> bool:
         """Create or update a document file in the git mirror.
 
@@ -559,7 +574,7 @@ class GitMirror:
         verb = "update" if existing else "learn"
         message = self._commit_message(
             verb=verb, title=title, paperless_id=paperless_id,
-            processing=processing, model=model,
+            processing=processing, model=model, summary=summary,
         )
 
         try:

--- a/tests/stacklets/test_git_mirror.py
+++ b/tests/stacklets/test_git_mirror.py
@@ -183,6 +183,36 @@ class TestCommitMessage:
         assert "Processing: ocr" in msg
         assert "Model:" not in msg
 
+    def test_summary_rides_between_subject_and_trailers(self, mirror):
+        # The body sits in its own paragraph so `git log` renders it as a
+        # readable summary and trailers stay parseable as trailers.
+        summary = "## Summary\nADAC car insurance EUR 340/year.\n\n## Parties\nADAC → Homer"
+        msg = mirror._commit_message(
+            verb="learn", title="ADAC", paperless_id=42,
+            processing="ai_formatted", model="qwen2.5:14b",
+            summary=summary,
+        )
+        lines = msg.split("\n")
+        assert lines[0] == "learn: ADAC"
+        assert lines[1] == ""
+        # Summary block follows, ends with a blank line, then trailers.
+        body_start = 2
+        assert lines[body_start] == "## Summary"
+        trailer_idx = lines.index("Paperless-Id: 42")
+        assert lines[trailer_idx - 1] == ""
+        assert "## Parties" in lines[body_start:trailer_idx]
+        # Trailers still present and parseable.
+        assert "Processing: ai_formatted" in lines
+        assert "Model: qwen2.5:14b" in lines
+
+    def test_no_summary_keeps_old_layout(self, mirror):
+        msg = mirror._commit_message(
+            verb="learn", title="t", paperless_id=1,
+            processing="ocr", model=None, summary=None,
+        )
+        # Subject, blank, trailers — no extra blank lines from a missing body.
+        assert msg == "learn: t\n\nPaperless-Id: 1\nProcessing: ocr"
+
 
 # ── Render (full markdown) ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Forward `result.summary` from the archivist + reprocess CLI down to GitMirror.publish, which now drops the summary into the commit body between subject and trailers. `git log` on the documents repo reads like a narrated archive log; `git log --grep` searches across summaries without a separate index. README updated to match.