### PR TITLE
fix(core): bot rooms appear after every stacklet up

### DIFF
--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -34,21 +34,27 @@ def _refresh_core(stck, stacklet_id):
 
     Core's env references secrets from other stacklets (API tokens etc.)
     that only exist after those stacklets run on_install_success.
-    Must use compose up (not docker restart) so containers pick up
-    the new env vars — docker restart reuses the old environment.
+    `compose_up` force-recreates unconditionally, so the bot-runner
+    picks up a freshly-written token even though compose's service-
+    config hash doesn't cover env_file contents.
+
+    Failures here used to be swallowed by a bare-except, which masked
+    real bugs (a render error in core's env left the bot-runner stale
+    and the user with no signal). We now surface failures via the
+    output channel — the parent `up` succeeded, so we don't abort, but
+    we don't pretend nothing went wrong either.
     """
     if stacklet_id == "core":
         return
     from .docker import running_project_ids
     if "core" not in running_project_ids():
         return
-    try:
-        stck.refresh_env("core")
-        core_compose = docker.find_compose_file(stck.root / "stacklets" / "core")
-        if core_compose:
-            docker.compose_up(core_compose)
-    except Exception:
-        pass
+    stck.refresh_env("core")
+    core_compose = docker.find_compose_file(stck.root / "stacklets" / "core")
+    if core_compose:
+        code, err = docker.compose_up(core_compose)
+        if code != 0 and err:
+            stck.output.step(f"core refresh failed: {err.strip().splitlines()[-1] if err.strip() else 'unknown error'}")
 
 
 def _notify(stck, message):

--- a/lib/stack/docker.py
+++ b/lib/stack/docker.py
@@ -52,10 +52,18 @@ def compose(compose_file: str | Path, *args) -> tuple[int, str, str]:
 
 
 def compose_up(compose_file: str | Path, env: dict = None) -> tuple[int, str]:
-    """Start containers. Returns (exit_code, error_output)."""
+    """Start containers, always force-recreating. Returns (exit_code, error_output).
+
+    `--force-recreate` is unconditional because compose's service-config
+    hash does not cover env_file *contents*: tokens or settings written
+    into a stacklet's .env between runs are invisible to a plain
+    `up -d`, leaving running containers stuck on stale env. `stack up`
+    is a deliberate user action, so bouncing healthy containers is an
+    acceptable cost for a reliable config-propagation contract.
+    """
     full_env = {**__import__("os").environ, **(env or {})}
     result = _docker(
-        "compose", "-f", str(compose_file), "up", "-d",
+        "compose", "-f", str(compose_file), "up", "-d", "--force-recreate",
         capture_output=True, text=True, timeout=300, env=full_env,
     )
     return result.returncode, result.stderr

--- a/stacklets/core/docker-compose.yml
+++ b/stacklets/core/docker-compose.yml
@@ -11,7 +11,11 @@ name: stack-core
 
 services:
   stack-core-watchtower:
-    image: containrrr/watchtower:latest
+    # nickfedor/watchtower is the actively maintained fork. The original
+    # containrrr/watchtower was archived in 2024 and ships an old Docker
+    # SDK pinned to API v1.25, which modern daemons (incl. OrbStack)
+    # reject — the container crashlooped and poisoned core's health.
+    image: nickfedor/watchtower:latest
     container_name: stack-core-watchtower
     restart: unless-stopped
     environment:

--- a/tests/framework/test_cli_class.py
+++ b/tests/framework/test_cli_class.py
@@ -128,6 +128,80 @@ class TestSetupDoneMarkerGating:
         assert not marker.exists()
 
 
+class TestRefreshCore:
+    """`_refresh_core` re-renders core's env after a sibling stacklet
+    populates a secret core consumes (e.g. docs__API_TOKEN) and runs
+    `compose up` against core. Because `compose_up` itself is now
+    unconditionally force-recreate (compose's hash doesn't cover
+    env_file *contents*), the bot-runner reliably picks up the fresh
+    token — the bug that previously left 'Documents Room' invisible
+    until the user manually bounced core."""
+
+    def _setup(self, tmp_path):
+        """A stack root with a core stacklet that has a docker-compose.yml,
+        plus a sibling whose `_refresh_core` call we want to test."""
+        from stack import Stack
+        from stack.output import CollectorOutput
+
+        (tmp_path / "stack.toml").write_text("[core]\ntimezone = \"Europe/Berlin\"\n")
+        (tmp_path / ".stack").mkdir(exist_ok=True)
+        (tmp_path / ".stack" / "secrets.toml").write_text('global__ADMIN_PASSWORD = "test"\n')
+
+        for sid in ("core", "docs"):
+            sdir = tmp_path / "stacklets" / sid
+            (sdir / "hooks").mkdir(parents=True, exist_ok=True)
+            (sdir / "stacklet.toml").write_text(
+                f'id = "{sid}"\nname = "{sid.title()}"\nversion = "0.1.0"\ncategory = "test"\n'
+            )
+        (tmp_path / "stacklets" / "core" / "docker-compose.yml").write_text(
+            "name: stack-core\nservices: {}\n"
+        )
+
+        return Stack(root=tmp_path, data=tmp_path / "data", output=CollectorOutput())
+
+    def test_calls_compose_up_against_core_when_core_running(self, tmp_path, monkeypatch):
+        from stack.cli import _refresh_core
+        stck = self._setup(tmp_path)
+
+        monkeypatch.setattr("stack.docker.running_project_ids", lambda: {"core", "docs"})
+        calls = []
+
+        def fake_up(compose_file, env=None):
+            calls.append(str(compose_file))
+            return (0, "")
+
+        monkeypatch.setattr("stack.docker.compose_up", fake_up)
+
+        _refresh_core(stck, "docs")
+
+        assert len(calls) == 1, "expected one compose_up call against core"
+        assert calls[0].endswith("stacklets/core/docker-compose.yml")
+
+    def test_skips_when_core_not_running(self, tmp_path, monkeypatch):
+        from stack.cli import _refresh_core
+        stck = self._setup(tmp_path)
+
+        monkeypatch.setattr("stack.docker.running_project_ids", lambda: {"docs"})
+        calls = []
+        monkeypatch.setattr("stack.docker.compose_up",
+                            lambda *a, **kw: (calls.append(a), (0, ""))[1])
+
+        _refresh_core(stck, "docs")
+        assert calls == []
+
+    def test_skips_when_target_is_core(self, tmp_path, monkeypatch):
+        from stack.cli import _refresh_core
+        stck = self._setup(tmp_path)
+
+        monkeypatch.setattr("stack.docker.running_project_ids", lambda: {"core"})
+        calls = []
+        monkeypatch.setattr("stack.docker.compose_up",
+                            lambda *a, **kw: (calls.append(a), (0, ""))[1])
+
+        _refresh_core(stck, "core")
+        assert calls == []
+
+
 class TestCLIDown:
     """CLI.down() runs Stack.down() then Docker compose stop."""
 

--- a/tests/framework/test_docker_runtime.py
+++ b/tests/framework/test_docker_runtime.py
@@ -108,3 +108,25 @@ class TestDockerCommand:
             docker._docker("info", capture_output=True)
             cmd = run.call_args[0][0]
         assert cmd == ["docker", "info"]
+
+
+class TestComposeUpForceRecreate:
+    """compose_up always passes --force-recreate. Compose's service-config
+    hash does not cover env_file *contents*, so a token written into a
+    stacklet's .env between runs is invisible to a plain `up -d` and the
+    running container stays on stale env. `stack up` is a deliberate
+    user action, so unconditional bounce is the right trade for a
+    reliable config-propagation contract."""
+
+    def test_force_recreate_is_unconditional(self):
+        from stack import docker
+        docker._context = None
+
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.stderr = ""
+        with patch("subprocess.run", return_value=mock) as run:
+            docker.compose_up("/tmp/compose.yml")
+            cmd = run.call_args[0][0]
+        assert "--force-recreate" in cmd
+        assert cmd.index("up") < cmd.index("--force-recreate")


### PR DESCRIPTION
Bringing up a stacklet that ships a bot (e.g. docs) used to leave its room (e.g. "Documents Room") invisible until you manually restarted core. Two issues stacked on top of each other:

- watchtower (containrrr/watchtower, archived in 2024) crashlooped on modern Docker daemons, which pushed core into "failing" state and silently disabled the post-install refresh. Swapped to the maintained nickfedor/watchtower fork.

Also surfaced the previously-swallowed _refresh_core errors so the next regression here won't be invisible.