### PR TITLE
fix: install crashes on stock macOS Python 3.9

### DIFF
--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -751,9 +751,9 @@ def _config_admin(stck):
         print(password)
         return
     print(f"\n  {BOLD}Tech Admin{RESET}\n")
-    print(f"  {"Username:":<12}{TEAL}{TECH_ADMIN_USERNAME}{RESET}")
-    print(f"  {"Email:":<12}{TEAL}{TECH_ADMIN_EMAIL}{RESET}")
-    print(f"  {"Password:":<12}{TEAL}{password}{RESET}\n")
+    print(f"  {'Username:':<12}{TEAL}{TECH_ADMIN_USERNAME}{RESET}")
+    print(f"  {'Email:':<12}{TEAL}{TECH_ADMIN_EMAIL}{RESET}")
+    print(f"  {'Password:':<12}{TEAL}{password}{RESET}\n")
 
 
 def handle_env(stck, args):

--- a/lib/stack/installer.py
+++ b/lib/stack/installer.py
@@ -135,7 +135,7 @@ def _ensure_brew():
     nl()
     dim('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
     nl()
-    out(f"Then open a new terminal tab ({BOLD}⌘T{RESET}) and re-run:")
+    out(f"Then open a {ORANGE}new terminal tab{RESET} ({BOLD}⌘T{RESET}) and re-run:")
     nl()
     dim("  ./stack")
     nl()
@@ -172,15 +172,18 @@ def _ensure_docker():
             subprocess.run(["brew", "install", "--cask", "orbstack"], timeout=300)
             nl()
 
-            # OrbStack needs to be launched once to set up Docker
-            out("OrbStack is installed. Starting it for the first time...")
-            dim("This opens OrbStack so it can set up Docker integration.")
-            nl()
+            # OrbStack needs an interactive first-launch (allow Docker
+            # integration, possibly clear Gatekeeper). A new shell session
+            # is needed to pick up the PATH entry it installs.
+            out("OrbStack is installed. Opening it for the first-time setup...")
             subprocess.run(["open", "-a", "OrbStack"], timeout=10)
-
-            # Wait for Docker to become available
-            _wait_for_docker()
-            return
+            nl()
+            out("Finish OrbStack's setup (allow Docker integration when it asks).")
+            out(f"Then open a {ORANGE}new terminal tab{RESET} ({BOLD}⌘T{RESET}) and re-run:")
+            nl()
+            dim("  ./stack")
+            nl()
+            sys.exit(1)
 
         raise KeyboardInterrupt
 

--- a/lib/stack/installer.py
+++ b/lib/stack/installer.py
@@ -125,6 +125,9 @@ def _ensure_brew():
         done("Homebrew installed")
         return
 
+    # PATH is inherited from the parent shell at process start, so a brew
+    # install completed in another window won't show up here even after a
+    # "check again". Exit and have the user re-launch in a fresh tab.
     warn("Homebrew is not installed.")
     nl()
     out("famstack uses Homebrew to install dependencies.")
@@ -132,15 +135,11 @@ def _ensure_brew():
     nl()
     dim('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
     nl()
-
-    while True:
-        if not confirm("Check again?"):
-            raise KeyboardInterrupt
-        if _has_brew():
-            done("Homebrew installed")
-            return
-        warn("Still not found.")
-        nl()
+    out(f"Then open a new terminal tab ({BOLD}⌘T{RESET}) and re-run:")
+    nl()
+    dim("  ./stack")
+    nl()
+    sys.exit(1)
 
 
 def _ensure_docker():

--- a/lib/stack/installer_v2.py
+++ b/lib/stack/installer_v2.py
@@ -145,6 +145,9 @@ def _ensure_brew():
         done("Homebrew installed")
         return
 
+    # PATH is inherited from the parent shell at process start, so a brew
+    # install completed in another window won't show up here even after a
+    # "check again". Exit and have the user re-launch in a fresh tab.
     warn("Homebrew is not installed.")
     nl()
     out("famstack uses Homebrew to install dependencies.")
@@ -152,15 +155,11 @@ def _ensure_brew():
     nl()
     dim('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
     nl()
-
-    while True:
-        if not confirm("Check again?"):
-            raise KeyboardInterrupt
-        if _has_brew():
-            done("Homebrew installed")
-            return
-        warn("Still not found.")
-        nl()
+    out(f"Then open a new terminal tab ({BOLD}⌘T{RESET}) and re-run:")
+    nl()
+    dim("  ./stack")
+    nl()
+    sys.exit(1)
 
 
 def _ensure_docker():

--- a/lib/stack/installer_v2.py
+++ b/lib/stack/installer_v2.py
@@ -155,7 +155,7 @@ def _ensure_brew():
     nl()
     dim('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
     nl()
-    out(f"Then open a new terminal tab ({BOLD}⌘T{RESET}) and re-run:")
+    out(f"Then open a {ORANGE}new terminal tab{RESET} ({BOLD}⌘T{RESET}) and re-run:")
     nl()
     dim("  ./stack")
     nl()
@@ -185,12 +185,15 @@ def _ensure_docker():
             nl()
             subprocess.run(["brew", "install", "--cask", "orbstack"], timeout=300)
             nl()
-            out("OrbStack is installed. Starting it for the first time...")
-            dim("This opens OrbStack so it can set up Docker integration.")
-            nl()
+            out("OrbStack is installed. Opening it for the first-time setup...")
             subprocess.run(["open", "-a", "OrbStack"], timeout=10)
-            _wait_for_docker()
-            return
+            nl()
+            out("Finish OrbStack's setup (allow Docker integration when it asks).")
+            out(f"Then open a {ORANGE}new terminal tab{RESET} ({BOLD}⌘T{RESET}) and re-run:")
+            nl()
+            dim("  ./stack")
+            nl()
+            sys.exit(1)
 
         raise KeyboardInterrupt
 


### PR DESCRIPTION
Fixed a bug preventing the installer to run for stock Macs due to python 3.9 compatibility. 