### PR TITLE
feat(tools): pi-dev sandbox for the pi coding agent

### DIFF
--- a/tools/pi-dev/.gitignore
+++ b/tools/pi-dev/.gitignore
@@ -1,0 +1,1 @@
+data-dirs.toml

--- a/tools/pi-dev/Dockerfile
+++ b/tools/pi-dev/Dockerfile
@@ -1,0 +1,26 @@
+# pi-dev: sandboxed pi coding agent.
+#
+# pi and any npm package it pulls runs as an unprivileged user inside this
+# image. The host is protected by mounts and runtime flags chosen in the
+# launcher (--cap-drop, --read-only, --security-opt), not by anything in
+# this Dockerfile.
+
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        git ripgrep ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install pi at build time so runtime never invokes npm. --ignore-scripts
+# is pi's own recommendation: it blocks postinstall hooks across the dep
+# tree.
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent \
+ && npm cache clean --force
+
+# The base image already provides an unprivileged `node` user (UID 1000).
+# Reuse it rather than creating a duplicate.
+USER node
+WORKDIR /workspace
+
+CMD ["pi"]

--- a/tools/pi-dev/README.md
+++ b/tools/pi-dev/README.md
@@ -1,0 +1,71 @@
+# pi-dev
+
+Sandboxed [pi coding agent](https://github.com/earendil-works/pi) for working
+on famstack on the server. Pi runs in a Docker container with the current
+repo mounted as the workspace; data directories are opt-in.
+
+## Threat model
+
+This protects the **host** from malicious npm packages bundled into pi or its
+transitive dependencies. It does **not** restrict the container's network.
+If you mount a data directory while running an untrusted snapshot of pi, that
+data can be exfiltrated.
+
+What the sandbox does:
+
+- Runs as the unprivileged `node` user (UID 1000) inside the container.
+- Drops all Linux capabilities and disables privilege escalation.
+- Root filesystem is read-only; only the workspace, data mounts, `/tmp`,
+  and `~/.pi` are writable.
+- No host SSH keys, no docker socket, no host home directory exposed.
+- Pi is installed with `--ignore-scripts` (blocks postinstall hooks).
+
+What it doesn't do:
+
+- No network restriction. The container can reach anything you can reach.
+- No CPU/memory limits.
+- No protection against bugs in Docker itself.
+
+## One-time setup
+
+1. Install Docker.
+2. Make sure `~/.pi/agent/models.json` exists on the host with at least one
+   provider configured. Run `pi` once on the host (or hand-write the file).
+3. Copy the data-dirs template if you want to mount data dirs:
+   ```
+   cp tools/pi-dev/data-dirs.toml.example tools/pi-dev/data-dirs.toml
+   ```
+   Edit the paths to match this machine. The file is gitignored.
+4. Symlink the launcher onto `$PATH`:
+   ```
+   ln -s "$(pwd)/tools/pi-dev/pi-dev" ~/.local/bin/pi-dev
+   ```
+
+The image is built on first run.
+
+## Usage
+
+```
+cd ~/famstack/famstack
+pi-dev                          # source RW, no data dirs
+pi-dev --with vault             # + memory vault RO
+pi-dev --with vault,paperless   # + paperless RO
+pi-dev --rw vault               # vault mounted RW (rare)
+pi-dev --list-data              # show configured data dirs
+pi-dev --dry-run                # print docker command, do not run
+pi-dev --rebuild                # rebuild the image
+pi-dev -- --print "summarise README.md"   # passthrough to pi
+```
+
+Mounts inside the container:
+
+| Container path     | Host path                | Mode |
+|--------------------|--------------------------|------|
+| `/workspace`       | `git rev-parse --show-toplevel` of $PWD | rw |
+| `/home/node/.pi`   | `~/.pi`                  | rw |
+| `/data/<name>`     | from `data-dirs.toml`    | per --with / --rw |
+
+## Git pushes
+
+Pi commits inside `/workspace`; you push from the host after reviewing the
+diff. The container has no credentials to push anywhere.

--- a/tools/pi-dev/data-dirs.toml.example
+++ b/tools/pi-dev/data-dirs.toml.example
@@ -1,0 +1,19 @@
+# Opt-in data directories for pi-dev sessions.
+#
+# Copy this file to data-dirs.toml (gitignored) and list paths you
+# want to be able to mount into pi sessions on this machine. Nothing
+# is mounted by default; --with <name> opts a directory in.
+#
+# default_mode: "ro" (default) or "rw". --rw <name> overrides to rw.
+
+[vault]
+path = "/Users/arthur/famstack-data/memory/vault"
+default_mode = "ro"
+
+[paperless]
+path = "/Users/arthur/famstack-data/paperless/consume"
+default_mode = "ro"
+
+[immich-thumbs]
+path = "/Users/arthur/famstack-data/immich/library/thumbs"
+default_mode = "ro"

--- a/tools/pi-dev/pi-dev
+++ b/tools/pi-dev/pi-dev
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""pi-dev: run the pi coding agent in a sandboxed container.
+
+The current git repo is mounted as the workspace (read-write). Data
+directories from data-dirs.toml are opt-in via --with (read-only by
+default) or --rw (read-write). The host ~/.pi config is bind-mounted so
+pi inherits your provider settings and session history.
+
+Threat model: this protects the host from malicious npm packages bundled
+into pi or its transitive dependencies. It does not restrict the
+container's network. If you mount a data directory while running an
+untrusted package snapshot, that data can be exfiltrated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+IMAGE = "pi-dev:latest"
+
+
+def load_data_dirs() -> dict:
+    """Read the (gitignored) data-dirs.toml registry.
+
+    Missing file is not an error; most invocations don't opt into any
+    data directories.
+    """
+    toml_path = SCRIPT_DIR / "data-dirs.toml"
+    if not toml_path.exists():
+        return {}
+    with toml_path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def git_toplevel() -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL
+        )
+        return Path(out.decode().strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        sys.exit("error: not inside a git repo (cd into one or pass --cwd)")
+
+
+def image_exists() -> bool:
+    r = subprocess.run(
+        ["docker", "image", "inspect", IMAGE],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return r.returncode == 0
+
+
+def build_image() -> None:
+    print(f"building {IMAGE} ...", file=sys.stderr)
+    subprocess.check_call(["docker", "build", "-t", IMAGE, str(SCRIPT_DIR)])
+
+
+def parse_csv(value: str | None) -> list[str]:
+    return [x.strip() for x in value.split(",") if x.strip()] if value else []
+
+
+def cmd_list_data(data_dirs: dict) -> int:
+    if not data_dirs:
+        print("no data dirs configured.")
+        print(
+            f"copy {SCRIPT_DIR}/data-dirs.toml.example "
+            f"to {SCRIPT_DIR}/data-dirs.toml and edit."
+        )
+        return 0
+    for name, cfg in data_dirs.items():
+        mode = cfg.get("default_mode", "ro")
+        path = cfg.get("path", "?")
+        print(f"  {name:20s} {mode:3s}  {path}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="pi-dev",
+        description="Run pi in a sandboxed container against the current repo.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="extra args after `--` are passed to pi.",
+    )
+    p.add_argument("--with", dest="with_", metavar="name[,name...]",
+                   help="opt-in data dirs (mode from data-dirs.toml)")
+    p.add_argument("--rw", metavar="name[,name...]",
+                   help="opt-in data dirs forced read-write")
+    p.add_argument("--cwd", help="repo to mount (default: git toplevel of $PWD)")
+    p.add_argument("--list-data", action="store_true",
+                   help="list configured data dirs and exit")
+    p.add_argument("--rebuild", action="store_true",
+                   help="rebuild the docker image before running")
+    p.add_argument("--dry-run", action="store_true",
+                   help="print the docker command without running it")
+    args, pi_args = p.parse_known_args()
+
+    data_dirs = load_data_dirs()
+
+    if args.list_data:
+        return cmd_list_data(data_dirs)
+
+    requested = parse_csv(args.with_)
+    rw = parse_csv(args.rw)
+    unknown = [n for n in requested + rw if n not in data_dirs]
+    if unknown:
+        sys.exit(f"error: unknown data dir(s): {', '.join(unknown)} (try --list-data)")
+
+    repo = Path(args.cwd).resolve() if args.cwd else git_toplevel()
+    if not repo.is_dir():
+        sys.exit(f"error: {repo} is not a directory")
+
+    pi_config = Path.home() / ".pi"
+    if not pi_config.is_dir():
+        sys.exit(
+            f"error: {pi_config} does not exist. "
+            "run pi once on the host to initialize, or `mkdir -p ~/.pi/agent` "
+            "and drop a models.json there."
+        )
+
+    if args.rebuild or not image_exists():
+        build_image()
+
+    mounts: list[tuple[str, str, str]] = [
+        (str(repo), "/workspace", "rw"),
+        (str(pi_config), "/home/node/.pi", "rw"),
+    ]
+    for name in requested:
+        cfg = data_dirs[name]
+        mode = "rw" if name in rw else cfg.get("default_mode", "ro")
+        mounts.append((cfg["path"], f"/data/{name}", mode))
+    for name in rw:
+        if name in requested:
+            continue
+        mounts.append((data_dirs[name]["path"], f"/data/{name}", "rw"))
+
+    cmd: list[str] = [
+        "docker", "run", "--rm",
+        "--user", "1000:1000",
+        "--cap-drop", "ALL",
+        "--security-opt", "no-new-privileges",
+        "--read-only",
+        "--tmpfs", "/tmp:rw,size=64m,mode=1777",
+        "--tmpfs", "/home/node/.cache:rw,size=128m,uid=1000,gid=1000",
+        "-w", "/workspace",
+    ]
+    if sys.stdin.isatty():
+        cmd += ["-it"]
+    for host, container, mode in mounts:
+        cmd += ["-v", f"{host}:{container}:{mode}"]
+    cmd.append(IMAGE)
+    cmd += pi_args
+
+    if args.dry_run:
+        print(" ".join(cmd))
+        return 0
+
+    os.execvp("docker", cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Containerized launcher that runs pi against the current repo with no host secrets and opt-in data dir mounts. Protects the host from npm supply chain attacks in pi's dep tree; does not restrict container network.