### PR TITLE
chore: add ruff + pre-commit hook, and fix the failures it surfaced

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Block commits that introduce ruff findings.
+#
+# Enable once per clone:
+#     git config core.hooksPath hooks
+#
+# Checks only the staged Python files, so unrelated unstaged lint never
+# blocks a commit. Runs through uvx, so no local ruff install is needed —
+# the config in pyproject.toml (ruleset + per-file ignores) is picked up
+# automatically because ruff runs from the repo root.
+
+files=$(git diff --cached --name-only --diff-filter=ACM -- '*.py')
+[ -z "$files" ] && exit 0
+
+if ! uvx ruff check $files; then
+    echo "" >&2
+    echo "ruff found issues in staged files. Fix them (try 'uvx ruff check --fix')" >&2
+    echo "or commit with --no-verify to bypass." >&2
+    exit 1
+fi

--- a/lib/stack/__init__.py
+++ b/lib/stack/__init__.py
@@ -16,3 +16,26 @@ from .models import resolve_model
 from . import docker
 from .cli import CLI
 from .commands import COMMANDS, EnvCommand, ListCommand, UpCommand, DownCommand, DestroyCommand
+
+# Re-exported names form the framework's public API (see module docstring).
+# Listing them in __all__ makes the intent explicit and keeps linters from
+# flagging the imports above as unused.
+__all__ = [
+    "Stack",
+    "TomlSecretStore",
+    "HookResolver",
+    "StackContext",
+    "build_hook_ctx",
+    "SilentOutput",
+    "CollectorOutput",
+    "user_id",
+    "resolve_model",
+    "docker",
+    "CLI",
+    "COMMANDS",
+    "EnvCommand",
+    "ListCommand",
+    "UpCommand",
+    "DownCommand",
+    "DestroyCommand",
+]

--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Stack CLI — manage your stacklets.
 
 Entry point: main(). Invoked by the ./stack shell wrapper.
@@ -14,9 +12,9 @@ This module handles everything user-facing:
 All framework logic lives in the Stack class. Docker operations use
 the docker module. This file is the glue.
 """
+from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
 import os
 import sys
@@ -45,6 +43,13 @@ def _refresh_core(stck, stacklet_id):
     we don't pretend nothing went wrong either.
     """
     if stacklet_id == "core":
+        return
+    # A "core" compose project may be running on the same Docker daemon yet
+    # belong to a different stack — tests run against the host daemon, and a
+    # host can carry a second install. Only refresh when THIS stack actually
+    # ships a core stacklet; otherwise refresh_env("core") raises on a stack
+    # that has none.
+    if not (stck.root / "stacklets" / "core").is_dir():
         return
     from .docker import running_project_ids
     if "core" not in running_project_ids():
@@ -627,7 +632,7 @@ def print_list(result: dict, stck=None) -> None:
 
 def print_status(result: dict) -> None:
     """Rich status overview: system info + stacklet list."""
-    from .prompt import TEAL, status_list
+    from .prompt import status_list
 
     name = result.get("name", "stack")
     version = result.get("version", "?")
@@ -781,12 +786,12 @@ def handle_destroy(stck, args):
             print_error({"error": "Pass --yes to confirm (non-interactive)"})
             sys.exit(1)
         print(f"\n  {ORANGE}⚠  Destroy {name}?{RESET}\n")
-        print(f"  This will permanently remove:")
-        print(f"    · Containers and volumes")
+        print("  This will permanently remove:")
+        print("    · Containers and volumes")
         if data_path.exists():
-            print(f"    · All stored data")
-        print(f"    · Secrets and config\n")
-        print(f"  You may want to back up your data first.\n")
+            print("    · All stored data")
+        print("    · Secrets and config\n")
+        print("  You may want to back up your data first.\n")
         try:
             answer = input("  Type 'destroy' to confirm: ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -872,8 +877,8 @@ def handle_init(stck, args):
     if err:
         # No Docker at all — guide to OrbStack
         print(f"\n  {ORANGE}Docker is not running.{RESET}\n")
-        print(f"  famstack uses OrbStack as its container runtime.")
-        print(f"  It's fast, lightweight, and built for macOS.\n")
+        print("  famstack uses OrbStack as its container runtime.")
+        print("  It's fast, lightweight, and built for macOS.\n")
         print(f"  Install it from {TEAL}https://orbstack.dev{RESET}")
         print(f"  or run: {TEAL}brew install orbstack{RESET}\n")
         print(f"  Then run {TEAL}./stack init{RESET} again.\n")
@@ -889,11 +894,11 @@ def handle_init(stck, args):
         # Docker works but OrbStack not available
         print(f"  {ORANGE}⚠{RESET}  {status}")
         print()
-        print(f"  famstack is tested with OrbStack only.")
-        print(f"  Docker Desktop can cause high CPU usage and a sluggish system.\n")
+        print("  famstack is tested with OrbStack only.")
+        print("  Docker Desktop can cause high CPU usage and a sluggish system.\n")
         print(f"  Install OrbStack from {TEAL}https://orbstack.dev{RESET}")
         print(f"  or run: {TEAL}brew install orbstack{RESET}\n")
-        print(f"  famstack will use it automatically once installed.\n")
+        print("  famstack will use it automatically once installed.\n")
     else:
         print(f"  {GREEN}✓{RESET} {status}")
 
@@ -1063,11 +1068,11 @@ def handle_uninstall(stck, args):
 
     if not getattr(args, "yes", False):
         print(f"\n  {ORANGE}\u26a0  Uninstall {name}?{RESET}\n")
-        print(f"  This will:")
-        print(f"    \u2022 Destroy all running services and their containers")
-        print(f"    \u2022 Remove stack.toml and users.toml")
-        print(f"    \u2022 Remove all runtime state (.stack/)")
-        print(f"    \u2022 Optionally remove all service data\n")
+        print("  This will:")
+        print("    \u2022 Destroy all running services and their containers")
+        print("    \u2022 Remove stack.toml and users.toml")
+        print("    \u2022 Remove all runtime state (.stack/)")
+        print("    \u2022 Optionally remove all service data\n")
         try:
             answer = input("  Type 'uninstall' to confirm: ").strip()
         except (EOFError, KeyboardInterrupt):

--- a/lib/stack/docker.py
+++ b/lib/stack/docker.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Docker operations for the stacklet framework.
 
 Encapsulates all Docker Compose interactions: starting, stopping,
@@ -16,6 +14,7 @@ Keeping Docker operations in one place means:
   - A future podman backend swaps this file, nothing else changes
   - Error handling for Docker issues is consistent
 """
+from __future__ import annotations
 
 import json
 import platform
@@ -177,9 +176,9 @@ def init_runtime(preferred: str = "orbstack") -> tuple[str | None, str | None]:
     if fallback:
         _context = fallback
     warning = (
-        f"famstack is tested with OrbStack only.\n"
-        f"      Docker Desktop is not recommended and can cause high CPU usage.\n"
-        f"      Install OrbStack: https://orbstack.dev"
+        "famstack is tested with OrbStack only.\n"
+        "      Docker Desktop is not recommended and can cause high CPU usage.\n"
+        "      Install OrbStack: https://orbstack.dev"
     )
     return f"Using {_context or 'default'} runtime", warning
 

--- a/lib/stack/hooks.py
+++ b/lib/stack/hooks.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Lifecycle hook resolution and execution.
 
 Hooks are the extension points of the stacklet lifecycle. Each transition
@@ -19,6 +17,7 @@ The ctx object provides:
   ctx.step()  — report progress
   ctx.shell() — run a system command
 """
+from __future__ import annotations
 
 import importlib.util
 import os

--- a/lib/stack/installer.py
+++ b/lib/stack/installer.py
@@ -15,7 +15,7 @@ import json
 from pathlib import Path
 
 from .prompt import (
-    ORANGE, TEAL, GREEN, RED, DIM, BOLD, RESET,
+    ORANGE, TEAL, DIM, BOLD, RESET,
     clear, nl, out, dim, bold, done, warn,
     heading, section, banner, rule, kv,
     Spinner, ask, confirm, choose, choose_many,
@@ -331,7 +331,7 @@ def write_users_toml(users):
         lines.append(f'name     = "{u["name"]}"')
         lines.append(f'email    = "{u["email"]}"')
         lines.append(f'role     = "{u["role"]}"')
-        lines.append(f'stacklets = ["photos", "docs", "messages"]')
+        lines.append('stacklets = ["photos", "docs", "messages"]')
         lines.append("")
 
     path = REPO_ROOT / "users.toml"
@@ -402,10 +402,10 @@ def show_existing_config():
     # How to change things
     heading("To make changes")
     out(f"Edit {TEAL}stack.toml{RESET} to change settings like timezone, LLM endpoint,")
-    out(f"or AI language. Changes take effect on the next 'stack up'.")
+    out("or AI language. Changes take effect on the next 'stack up'.")
     nl()
     out(f"Edit {TEAL}users.toml{RESET} to add or remove family members.")
-    out(f"New accounts are created on the next 'stack up' for each service.")
+    out("New accounts are created on the next 'stack up' for each service.")
     nl()
     out(f"To start fresh, run {TEAL}stack uninstall{RESET} and then {TEAL}stack install{RESET}.")
     nl()

--- a/lib/stack/installer_v2.py
+++ b/lib/stack/installer_v2.py
@@ -14,8 +14,7 @@ from pathlib import Path
 from .prompt import (
     ORANGE, TEAL, GREEN, RED, DIM, BOLD, RESET,
     clear, nl, out, dim, bold, done, warn,
-    heading, section, banner, rule, kv,
-    Spinner, ask, confirm,
+    heading, section, banner, rule, Spinner, ask, confirm,
 )
 
 
@@ -36,8 +35,8 @@ def get_help_text(detail=""):
         for line in detail.split("\n"):
             lines.append(f"  {DIM}{line}{RESET}")
     lines.append("")
-    lines.append(f"  Sorry for that. If it keeps happening, we'd love to help.")
-    lines.append(f"  Please reach out so we can fix it faster:")
+    lines.append("  Sorry for that. If it keeps happening, we'd love to help.")
+    lines.append("  Please reach out so we can fix it faster:")
     lines.append("")
     lines.extend(HELP_LINKS)
     lines.append("")
@@ -306,7 +305,7 @@ def write_users_toml(users):
         lines.append(f'name     = "{u["name"]}"')
         lines.append(f'email    = "{u["email"]}"')
         lines.append(f'role     = "{u["role"]}"')
-        lines.append(f'stacklets = ["photos", "docs", "messages"]')
+        lines.append('stacklets = ["photos", "docs", "messages"]')
         lines.append("")
 
     path = REPO_ROOT / "users.toml"
@@ -407,21 +406,21 @@ def wizard():
 
     out(f"{ORANGE}{BOLD}How it works{RESET}")
     nl()
-    out(f"  Every family member gets an account on each service you enable.")
+    out("  Every family member gets an account on each service you enable.")
     out(f"  Log in with your {TEAL}first name{RESET} or {TEAL}email{RESET}, depending on the service.")
     out(f"  Default password is your {TEAL}first name{RESET}. Change it after first login.")
     nl()
     dim(f"  famstack also creates a {TEAL}stackadmin{RESET}{DIM} service account to manage")
-    dim(f"  things behind the scenes. You'll find its password in")
+    dim("  things behind the scenes. You'll find its password in")
     dim(f"  {TEAL}.stack/secrets.toml{RESET}{DIM} if you ever need it.")
     nl()
 
     out(f"{ORANGE}{BOLD}First step{RESET}")
     nl()
     out(f"  We'll start with {TEAL}Messages{RESET}, your family's private chat.")
-    out(f"  It doubles as the operation center: manage your server")
-    out(f"  from any device, get notifications, and add more services.")
-    out(f"  Once it's running, you can continue the setup from there.")
+    out("  It doubles as the operation center: manage your server")
+    out("  from any device, get notifications, and add more services.")
+    out("  Once it's running, you can continue the setup from there.")
     nl()
 
     if not confirm("Ready?"):
@@ -513,7 +512,6 @@ def wizard():
 
     # Resolve URLs from the Stack instance
     messages_url = stck._public_url("messages", 42030)
-    synapse_url = stck._public_url("messages", 42031)
 
     # ── Step-by-step guide ────────────────────────────────────────────
 
@@ -552,7 +550,7 @@ def wizard():
     out(f"  {TEAL}stack status{RESET}        See what's running")
     nl()
 
-    dim(f"  Service admin password is in .stack/secrets.toml")
+    dim("  Service admin password is in .stack/secrets.toml")
     nl()
 
     return {"stacklets": ["messages"], "users": users}

--- a/lib/stack/ontology.py
+++ b/lib/stack/ontology.py
@@ -243,7 +243,7 @@ class Ontology:
         """Shared cross-language canonicalisation walk."""
         if not text or not text.strip():
             return Resolution(canonical=None, cross_field=False)
-        langs = [lang] + [l for l in self.languages if l != lang]
+        langs = [lang] + [other for other in self.languages if other != lang]
         for try_lang in langs:
             hit = primary(text, try_lang)
             if hit:

--- a/lib/stack/output.py
+++ b/lib/stack/output.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Output adapters for the Stack lifecycle.
 
 The Stack class reports progress through an output object instead of
@@ -10,6 +8,7 @@ Implementations:
   CollectorOutput  — captures messages in lists (for tests and JSON)
   TerminalOutput   — prints to stderr with formatting (for the CLI)
 """
+from __future__ import annotations
 
 import itertools
 import sys

--- a/lib/stack/secrets.py
+++ b/lib/stack/secrets.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Secret storage with stacklet-scoped namespacing.
 
 v1 implementation: TOML file at .stack/secrets.toml.
@@ -11,6 +9,7 @@ Namespacing: secrets are prefixed with {stacklet_id}__ (e.g. photos__DB_PASSWORD
 Reading falls back from stacklet-specific to global (global__ADMIN_PASSWORD).
 Writing always targets the stacklet namespace.
 """
+from __future__ import annotations
 
 import tomllib
 from pathlib import Path

--- a/lib/stack/stack.py
+++ b/lib/stack/stack.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """The Stack class — core framework orchestrator.
 
 Stack coordinates config, discovery, secrets, hooks, and lifecycle.
@@ -11,13 +9,12 @@ Usage:
     s.down("photos")   # run on_stop hook
     s.destroy("photos") # full teardown: hooks, secrets, data, markers
 """
+from __future__ import annotations
 
 import collections
-import json
 import platform
 import shutil
 import subprocess
-import sys
 import tomllib
 from pathlib import Path
 
@@ -390,7 +387,6 @@ class Stack:
 
     def status(self) -> dict:
         """Full system status: version, runtime, host, stacklets."""
-        from . import docker
         from .cli import VERSION
 
         info = {

--- a/lib/stack/users.py
+++ b/lib/stack/users.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 """User identity and credentials.
 
 Canonical way to resolve usernames and passwords from users.toml
 and secrets.toml. All code that needs user info goes through here.
 """
+from __future__ import annotations
 
 import tomllib
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,23 @@ norecursedirs = ["tests/integration/eval"]
 markers = [
     "v2_only: tests for the lifecycle v2 refactor (will fail until migration is complete)",
 ]
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Ruff's default rule set: pyflakes (F) catches the real bugs — undefined
+# names, unused imports and variables — alongside the pycodestyle import (E4),
+# statement (E7) and runtime-error (E9) groups. Line-length (E5) is left off
+# on purpose; the codebase favours long narrative docstrings.
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Stacklet CLI entrypoints and the test suite bootstrap sys.path so they can
+# import the framework before it is on the default path — the module-level
+# imports legitimately follow that setup, so E402 doesn't apply.
+"stacklets/**/cli/**/*.py" = ["E402"]
+"tests/**/*.py" = ["E402"]
+# The top-level CLI wires up ~30 argparse subcommands with deliberate one-line
+# `p = sub.add_parser(...); p.add_argument(...)` pairs — compact by design.
+"lib/stack/cli.py" = ["E702"]

--- a/stacklets/ai/backend.py
+++ b/stacklets/ai/backend.py
@@ -11,7 +11,6 @@ no scanning, no interactive prompts for URLs.
 import dataclasses
 import json
 import ssl
-import sys
 import tomllib
 import urllib.error
 import urllib.request
@@ -66,7 +65,7 @@ def ensure_backend(repo_root: Path, interactive=True) -> dict:
 
     Returns {"url": str, "key": str} or {"error": str}.
     """
-    from stack.prompt import done, warn, dim
+    from stack.prompt import done, dim
 
     ai_cfg = _load_ai_config(repo_root)
     url = ai_cfg.get("openai_url", "")
@@ -155,11 +154,11 @@ def ensure_model(repo_root: Path, model_id: str, interactive: bool = True,
         available = ", ".join(probe.models[:5]) if probe.models else "none"
         warn(f"Default model '{model_name}' not found on endpoint.")
         dim(f"  Available: {available}")
-        dim(f"  Load it on your server, or change [ai] default in stack.toml.")
+        dim("  Load it on your server, or change [ai] default in stack.toml.")
         return {"warning": f"Model '{model_name}' not found. Available: {available}"}
 
     # ── Managed oMLX: offer to download ─────────────────────────────
-    from omlx import OMLXClient, is_omlx, repo_id_to_model_id
+    from omlx import OMLXClient, is_omlx
 
     admin_url = base_url.rstrip("/").replace("/v1", "")
     if not is_omlx(admin_url):
@@ -213,11 +212,11 @@ def ensure_model(repo_root: Path, model_id: str, interactive: bool = True,
     warn("Download can take a while depending on your connection.")
     nl()
 
-    if not confirm(f"Download from HuggingFace?"):
+    if not confirm("Download from HuggingFace?"):
         nl()
         dim("Download skipped. You can change the model or download later:")
-        dim(f"  • stack.toml [ai] has commented alternatives — uncomment to switch")
-        dim(f"  • Run './stack setup ai' to re-run this check")
+        dim("  • stack.toml [ai] has commented alternatives — uncomment to switch")
+        dim("  • Run './stack setup ai' to re-run this check")
         return {"skipped": True, "model": model_id}
 
     return _download_and_load(client, model_id, info)
@@ -237,7 +236,7 @@ def _load_model(client, model_id: str) -> dict:
 def _download_and_load(client, repo_id: str, info) -> dict:
     """Download a model from HuggingFace with progress display, then load it."""
     import time
-    from stack.prompt import nl, out, dim, done, warn, ORANGE, TEAL, RESET
+    from stack.prompt import nl, out, dim, done, ORANGE, RESET
     from omlx import repo_id_to_model_id
 
     task = client.start_download(repo_id)

--- a/stacklets/ai/cli/hello.py
+++ b/stacklets/ai/cli/hello.py
@@ -4,7 +4,11 @@ HELP = "Play the welcome voice message"
 
 
 def run(args, stacklet, config):
-    import json, subprocess, sys, tempfile, urllib.request
+    import json
+    import subprocess
+    import sys
+    import tempfile
+    import urllib.request
     from pathlib import Path
 
     # Read language from stack.toml [ai] section, derive voice
@@ -41,7 +45,7 @@ def run(args, stacklet, config):
             "Enjoy the rest of your famstack journey."
         )
 
-    print(f"\n  Speaking...\n", file=sys.stderr)
+    print("\n  Speaking...\n", file=sys.stderr)
 
     try:
         req = urllib.request.Request(

--- a/stacklets/ai/cli/models.py
+++ b/stacklets/ai/cli/models.py
@@ -32,7 +32,7 @@ def run(args, stacklet, config):
     default_name = default_model.split("/")[-1] if "/" in default_model else default_model
 
     if sys.stderr.isatty():
-        from stack.prompt import nl, out, dim, done, warn, GREEN, ORANGE, RESET
+        from stack.prompt import nl, out, dim, warn, GREEN, ORANGE, RESET
 
         nl()
         # Check if default is loaded

--- a/stacklets/ai/hooks/on_configure.py
+++ b/stacklets/ai/hooks/on_configure.py
@@ -15,7 +15,7 @@ import os
 import sys
 from pathlib import Path
 
-from stack.prompt import section, out, nl, dim, bullet, confirm, ask, done, warn
+from stack.prompt import section, out, nl, dim, confirm, ask, done, warn
 
 
 def _probe_endpoint(url: str, key: str = "") -> bool:

--- a/stacklets/ai/hooks/on_start.py
+++ b/stacklets/ai/hooks/on_start.py
@@ -36,7 +36,7 @@ def run(ctx):
         if not url:
             nl()
             warn("External provider selected but no endpoint URL set.")
-            out(f"Set [ai].openai_url in stack.toml, or reconfigure:")
+            out("Set [ai].openai_url in stack.toml, or reconfigure:")
             nl()
             out(f"  {TEAL}stack destroy ai && stack up ai{RESET}")
             nl()

--- a/stacklets/ai/omlx.py
+++ b/stacklets/ai/omlx.py
@@ -11,7 +11,6 @@ is in backend.py which calls this for oMLX backends.
 
 import http.cookiejar
 import json
-import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass

--- a/stacklets/ai/thinking.py
+++ b/stacklets/ai/thinking.py
@@ -27,7 +27,8 @@ def disable_thinking(client, model_id: str, log=None) -> bool:
     Returns True if thinking is now disabled, False on failure.
     """
     if log is None:
-        log = lambda msg: None
+        def log(msg):
+            return None
 
     if not is_qwen35(model_id):
         log(f"Not a Qwen3.5 model ({model_id}), skipping")

--- a/stacklets/docs/bot/matching.py
+++ b/stacklets/docs/bot/matching.py
@@ -19,7 +19,10 @@ Two matching strategies:
 from __future__ import annotations
 
 import re
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from stack.ontology import Ontology
 
 
 class TopicResult(NamedTuple):

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -30,7 +30,7 @@ import base64
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from loguru import logger
@@ -45,6 +45,9 @@ from matching import (
     submitter_person_tag,
 )
 from stack import resolve_model
+
+if TYPE_CHECKING:
+    from stack.ontology import Ontology
 
 
 # A 32×32 white PNG — small enough to be cheap on the wire, large enough

--- a/stacklets/docs/hooks/on_install_success.py
+++ b/stacklets/docs/hooks/on_install_success.py
@@ -9,7 +9,6 @@ Also seeded on every `stack up docs` via on_start_ready.py
 so they stay in sync with users.toml and taxonomy.yaml changes.
 """
 
-import json
 import sys
 from pathlib import Path
 

--- a/stacklets/messages/cli/_matrix.py
+++ b/stacklets/messages/cli/_matrix.py
@@ -13,10 +13,8 @@ same session. This keeps the device list clean.
 """
 
 import json
-import os
 import random
 import ssl
-import sys
 import time
 import tomllib
 import urllib.error

--- a/stacklets/messages/cli/room.py
+++ b/stacklets/messages/cli/room.py
@@ -149,7 +149,7 @@ def _cmd_create(client, base_url, server_name, argv):
     space_id = _find_family_space(client, base_url)
     if space_id:
         client.add_space_child(space_id, room_id)
-        print(f"  Added to family Space")
+        print("  Added to family Space")
 
     print()
 
@@ -173,14 +173,14 @@ def _cmd_delete(client, base_url, server_name, argv):
     # Gate: require explicit confirmation unless --yes is passed
     if not force:
         print(f"\n  This will permanently delete #{alias}:{server_name}")
-        print(f"  All messages and media will be purged. There is no undo.\n")
+        print("  All messages and media will be purged. There is no undo.\n")
         try:
             confirm = input(f"  Type '{alias}' to confirm: ").strip()
         except (KeyboardInterrupt, EOFError):
             print("\n\n  Aborted.\n")
             return
         if confirm != alias:
-            print(f"\n  Aborted.\n")
+            print("\n  Aborted.\n")
             return
 
     status, resp = _api(

--- a/tests/framework/fixtures/test/hooks/on_install_success.py
+++ b/tests/framework/fixtures/test/hooks/on_install_success.py
@@ -18,7 +18,7 @@ def run(ctx):
 
     # Verify http_get works against our own health endpoint
     try:
-        data = ctx.http_get("http://localhost:42099/")
+        ctx.http_get("http://localhost:42099/")
     except Exception:
         step("Health endpoint not returning JSON (expected for plain text)")
 

--- a/tests/framework/test_ai_backend.py
+++ b/tests/framework/test_ai_backend.py
@@ -6,7 +6,6 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 # backend.py lives in stacklets/ai/, not in a package
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "stacklets" / "ai"))

--- a/tests/framework/test_commands.py
+++ b/tests/framework/test_commands.py
@@ -11,7 +11,6 @@ The CLI dispatch becomes:
 """
 
 import sys
-import textwrap
 from pathlib import Path
 
 import pytest

--- a/tests/framework/test_config_to_container.py
+++ b/tests/framework/test_config_to_container.py
@@ -64,6 +64,35 @@ class IsolatedStack:
                                 timeout=timeout, cwd=str(self.root), env=self._env())
         return result.returncode, result.stdout, result.stderr
 
+    def run_ok(self, *args, timeout=60) -> dict:
+        """Run a lifecycle command that must succeed.
+
+        On failure, surface the command's full stdout/stderr in the
+        assertion message — otherwise a broken `up`/`down`/`destroy`
+        either reads as a bare `assert ok` or gets swallowed entirely and
+        only shows up later as an unrelated failure.
+        """
+        result = self.run(*args, timeout=timeout)
+        assert result.get("ok"), (
+            f"`stack {' '.join(args)}` failed (exit {result.get('_code')})\n"
+            f"--- stdout ---\n{result.get('_raw', '')}\n"
+            f"--- stderr ---\n{result.get('_stderr', '')}"
+        )
+        return result
+
+    def run_pretty_ok(self, *args, timeout=60) -> tuple[str, str]:
+        """Run a command that must succeed; return (stdout, stderr).
+
+        Surfaces both streams on failure instead of a bare `assert 1 == 0`,
+        so the real traceback or error message is visible in the report.
+        """
+        code, stdout, stderr = self.run_pretty(*args, timeout=timeout)
+        assert code == 0, (
+            f"`stack {' '.join(args)}` exited {code}\n"
+            f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+        )
+        return stdout, stderr
+
     def update_config(self, old_value: str, new_value: str):
         """Update a value in stack.toml."""
         config_path = self.root / "stack.toml"
@@ -203,8 +232,7 @@ class TestConfigToContainer:
 
     def test_timezone_reaches_container(self, isolated_stack):
         """TZ from stack.toml appears in the container's environment."""
-        result = isolated_stack.run("up", "test")
-        assert result.get("ok"), f"stack up test failed: {result}"
+        isolated_stack.run_ok("up", "test")
 
         env = docker_env("stack-test")
         assert env.get("TZ") == "Europe/Berlin", \
@@ -212,12 +240,12 @@ class TestConfigToContainer:
 
     def test_config_change_propagates_on_restart(self, isolated_stack):
         """Changing stack.toml and re-running stack up updates the container."""
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         env_before = docker_env("stack-test")
         assert env_before.get("TZ") == "Europe/Berlin"
 
         isolated_stack.update_config("Europe/Berlin", "America/New_York")
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
 
         env_after = docker_env("stack-test")
         assert env_after.get("TZ") == "America/New_York", \
@@ -229,17 +257,16 @@ class TestConfigToContainer:
 class TestStopAndRestart:
 
     def test_down_stops_container(self, isolated_stack):
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         assert container_running("stack-test")
 
-        isolated_stack.run("down", "test")
+        isolated_stack.run_ok("down", "test")
         assert wait_for_stop("stack-test"), "Container did not stop in time"
 
     def test_up_after_down_brings_it_back(self, isolated_stack):
-        isolated_stack.run("up", "test")
-        isolated_stack.run("down", "test")
-        result = isolated_stack.run("up", "test")
-        assert result.get("ok"), f"up after down failed: {result}"
+        isolated_stack.run_ok("up", "test")
+        isolated_stack.run_ok("down", "test")
+        isolated_stack.run_ok("up", "test")
         assert container_running("stack-test")
 
 
@@ -248,19 +275,18 @@ class TestStopAndRestart:
 class TestDestroyAndRecreate:
 
     def test_destroy_removes_container_and_data(self, isolated_stack):
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         assert container_running("stack-test")
 
-        isolated_stack.run("destroy", "test", "--yes")
+        isolated_stack.run_ok("destroy", "test", "--yes")
         assert wait_for_stop("stack-test"), "Container did not stop in time"
         assert not (isolated_stack.data / "test").exists()
 
     def test_up_after_destroy_is_first_run(self, isolated_stack):
-        isolated_stack.run("up", "test")
-        isolated_stack.run("destroy", "test", "--yes")
+        isolated_stack.run_ok("up", "test")
+        isolated_stack.run_ok("destroy", "test", "--yes")
 
-        result = isolated_stack.run("up", "test")
-        assert result.get("ok"), f"up after destroy failed: {result}"
+        isolated_stack.run_ok("up", "test")
         assert container_running("stack-test")
 
 
@@ -271,50 +297,45 @@ class TestOutputBehavior:
 
     def test_up_shows_stacklet_name(self, isolated_stack):
         """'stack up test' output includes the stacklet name."""
-        code, stdout, stderr = isolated_stack.run_pretty("up", "test")
-        assert code == 0
+        stdout, stderr = isolated_stack.run_pretty_ok("up", "test")
         combined = stdout + stderr
         assert "Test" in combined
 
     def test_up_shows_lifecycle_steps(self, isolated_stack):
         """Framework reports progress steps during up."""
-        code, stdout, stderr = isolated_stack.run_pretty("up", "test")
-        assert code == 0
+        stdout, stderr = isolated_stack.run_pretty_ok("up", "test")
         combined = stdout + stderr
         assert "Rendering environment" in combined
         assert "Writing .env" in combined
 
     def test_up_shows_success_banner(self, isolated_stack):
         """Successful up shows the result banner with URL and hints."""
-        code, stdout, stderr = isolated_stack.run_pretty("up", "test")
-        assert code == 0
+        stdout, stderr = isolated_stack.run_pretty_ok("up", "test")
         combined = stdout + stderr
         assert "is running" in combined
         assert "42099" in combined
 
     def test_up_shows_hints(self, isolated_stack):
         """Hints from stacklet.toml are rendered in the success banner."""
-        code, stdout, stderr = isolated_stack.run_pretty("up", "test")
-        assert code == 0
+        stdout, stderr = isolated_stack.run_pretty_ok("up", "test")
         combined = stdout + stderr
         assert "Test service running" in combined
 
     def test_no_garbled_output(self, isolated_stack):
         """Output should not have overlapping/garbled lines from spinners."""
-        code, stdout, stderr = isolated_stack.run_pretty("up", "test")
+        stdout, stderr = isolated_stack.run_pretty_ok("up", "test")
         combined = stdout + stderr
-        cr_lines = [l for l in combined.split("\n") if "\r" in l and l.strip()]
+        cr_lines = [line for line in combined.split("\n") if "\r" in line and line.strip()]
         assert not cr_lines, \
             f"Carriage returns in output (spinner leaked): {cr_lines[:3]}"
 
     def test_destroy_output_is_clean(self, isolated_stack):
         """Destroy output doesn't have garbled lines."""
-        isolated_stack.run_pretty("up", "test")
-        code, stdout, stderr = isolated_stack.run_pretty("destroy", "test", "--yes")
-        assert code == 0
+        isolated_stack.run_pretty_ok("up", "test")
+        stdout, stderr = isolated_stack.run_pretty_ok("destroy", "test", "--yes")
         combined = stdout + stderr
         assert "destroyed" in combined
-        cr_lines = [l for l in combined.split("\n") if "\r" in l and l.strip()]
+        cr_lines = [line for line in combined.split("\n") if "\r" in line and line.strip()]
         assert not cr_lines, \
             f"Carriage returns in output (spinner leaked): {cr_lines[:3]}"
 
@@ -326,36 +347,35 @@ class TestConfigPropagation:
 
     def test_secret_in_env_reaches_container(self, isolated_stack):
         """A generated secret appears in the container's environment."""
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         env = docker_env("stack-test")
         assert env.get("TEST_SECRET"), \
             f"TEST_SECRET not in container env. Got: {sorted(env.keys())}"
 
     def test_admin_username_reaches_container(self, isolated_stack):
         """Tech admin username reaches the container via template vars."""
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         env = docker_env("stack-test")
         assert env.get("TEST_ADMIN") == "stackadmin", \
             f"Expected TEST_ADMIN='stackadmin', got: {env.get('TEST_ADMIN')}"
 
     def test_config_change_visible_on_next_env(self, isolated_stack):
         """Writing to stack.toml is picked up by the next 'stack env' command."""
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         isolated_stack.update_config("Europe/Berlin", "Asia/Tokyo")
 
-        code, stdout, stderr = isolated_stack.run_pretty("env", "test")
-        assert code == 0
+        stdout, stderr = isolated_stack.run_pretty_ok("env", "test")
         assert "Asia/Tokyo" in stdout, \
             f"Expected Asia/Tokyo in env output, got: {stdout[:300]}"
 
     def test_config_change_reaches_container_on_restart(self, isolated_stack):
         """Changing stack.toml and re-running stack up updates the container."""
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         env_before = docker_env("stack-test")
         assert env_before.get("TZ") == "Europe/Berlin"
 
         isolated_stack.update_config("Europe/Berlin", "America/New_York")
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
 
         env_after = docker_env("stack-test")
         assert env_after.get("TZ") == "America/New_York", \
@@ -367,7 +387,7 @@ class TestConfigPropagation:
         sys.path.insert(0, str(isolated_stack.root / "lib"))
         from stack.secrets import TomlSecretStore
 
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
         env_before = docker_env("stack-test")
         old_secret = env_before.get("TEST_SECRET")
         assert old_secret, "TEST_SECRET should exist after first up"
@@ -376,7 +396,7 @@ class TestConfigPropagation:
         secrets = TomlSecretStore(isolated_stack.root / ".stack" / "secrets.toml")
         secrets.set("test", "TEST_SECRET", "changed-value-123")
 
-        isolated_stack.run("up", "test")
+        isolated_stack.run_ok("up", "test")
 
         env_after = docker_env("stack-test")
         assert env_after.get("TEST_SECRET") == "changed-value-123", \

--- a/tests/framework/test_hook_secrets.py
+++ b/tests/framework/test_hook_secrets.py
@@ -4,8 +4,6 @@ No mocking. Creates a real Stack with real files, writes real secrets,
 and verifies the hook context can find them through the actual lookup path.
 """
 
-import tomllib
-from pathlib import Path
 
 
 def _make_stack(tmp_path):

--- a/tests/framework/test_hooks.py
+++ b/tests/framework/test_hooks.py
@@ -5,7 +5,6 @@ The framework resolves hooks by name, builds a ctx for Python hooks,
 and passes env vars to shell hooks.
 """
 
-from pathlib import Path
 
 
 class TestHookResolution:

--- a/tests/framework/test_ontology.py
+++ b/tests/framework/test_ontology.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from stack.ontology import Ontology, Topic, DocType
+from stack.ontology import Ontology
 
 
 # ─── Fixture ─────────────────────────────────────────────────────────────

--- a/tests/framework/test_prompt.py
+++ b/tests/framework/test_prompt.py
@@ -1,6 +1,7 @@
 """Prompt utilities: shared TUI primitives for hooks and installer."""
 
-from unittest.mock import patch, call
+import pytest
+from unittest.mock import patch
 
 
 class TestAsk:
@@ -37,11 +38,17 @@ class TestAsk:
         with patch("builtins.input", side_effect=EOFError):
             assert ask("Name") is None
 
-    def test_returns_none_on_interrupt(self):
+    def test_propagates_interrupt(self):
+        """Ctrl+C is not swallowed into None — it propagates so the
+        top-level handlers (__main__/cli/installer) can exit cleanly.
+        EOF is a closed stdin and returns None; an interrupt is the user
+        actively aborting and must reach those handlers.
+        """
         from stack.prompt import ask
 
         with patch("builtins.input", side_effect=KeyboardInterrupt):
-            assert ask("Name") is None
+            with pytest.raises(KeyboardInterrupt):
+                ask("Name")
 
     def test_prompt_has_chevron(self):
         from stack.prompt import ask

--- a/tests/framework/test_stack_lifecycle.py
+++ b/tests/framework/test_stack_lifecycle.py
@@ -5,9 +5,14 @@ hooks fire, secrets generate, env renders, and markers get written.
 No Docker — we test the framework logic, not container management.
 
 The Stack class coordinates:
-  up:      check deps → render env → on_install (first) → write .env → mark done
+  up:      check deps → render env → on_install (first) → write .env → on_start
   down:    on_stop
   destroy: on_stop → on_destroy → clear secrets → delete marker → delete data
+
+First-run setup is two-phase: up() runs on_install but does NOT promote the
+setup-done marker. The CLI calls run_on_install_success() after the health
+check passes, and that promotes the marker so later ups skip the first-run
+chain. Tests that need a "fully installed" stacklet must do the same.
 """
 
 import sys
@@ -134,19 +139,22 @@ class TestStackUp:
             },
         }})
         s.up("myapp")
+        s.run_on_install_success("myapp")  # promotes the marker, as the CLI does
         s.up("myapp")
         assert counter.read_text() == "1"
 
     def test_creates_setup_done_marker(self, tmp_path):
-        """After first up, the setup-done marker exists."""
+        """After first up + on_install_success, the setup-done marker exists."""
         s = _make_stack(tmp_path, {"myapp": {}})
         s.up("myapp")
+        s.run_on_install_success("myapp")
         assert (tmp_path / ".stack" / "myapp.setup-done").exists()
 
     def test_first_run_flag(self, tmp_path):
-        """First up returns first_run=True, second returns False."""
+        """First up returns first_run=True; once setup completes, the next is False."""
         s = _make_stack(tmp_path, {"myapp": {}})
         r1 = s.up("myapp")
+        s.run_on_install_success("myapp")  # promotes the marker, as the CLI does
         r2 = s.up("myapp")
         assert r1["first_run"] is True
         assert r2["first_run"] is False
@@ -188,6 +196,7 @@ class TestStackUpDependencies:
             "app": {"requires": ["base"]},
         })
         s.up("base")
+        s.run_on_install_success("base")  # base must be fully set up to satisfy requires
         result = s.up("app")
         assert result.get("ok"), f"Should pass: {result}"
 
@@ -212,6 +221,7 @@ class TestStackDown:
         """down doesn't remove the setup-done marker — up won't re-install."""
         s = _make_stack(tmp_path, {"myapp": {}})
         s.up("myapp")
+        s.run_on_install_success("myapp")
         s.down("myapp")
         assert (tmp_path / ".stack" / "myapp.setup-done").exists()
 
@@ -254,6 +264,7 @@ class TestStackDestroy:
     def test_removes_setup_done_marker(self, tmp_path):
         s = _make_stack(tmp_path, {"myapp": {}})
         s.up("myapp")
+        s.run_on_install_success("myapp")
         assert (tmp_path / ".stack" / "myapp.setup-done").exists()
 
         s.destroy("myapp")

--- a/tests/framework/test_uninstall.py
+++ b/tests/framework/test_uninstall.py
@@ -5,7 +5,6 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "lib"))
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ INSTANCE_DIR = REPO_ROOT
 sys.path.insert(0, str(REPO_ROOT / "lib"))
 
 from tests.integration.paperless import PaperlessAPI, cleanup_prefix
-from tests.integration.matrix import MatrixCreds, login
+from tests.integration.matrix import login
 from tests.integration.forgejo import ForgejoAPI, cleanup_mirror_files
 from tests.integration.bdd import BDDLog
 from tests.integration._seed_secrets import (

--- a/tests/integration/eval/conftest.py
+++ b/tests/integration/eval/conftest.py
@@ -22,7 +22,6 @@ stack.toml.
 
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 import urllib.error

--- a/tests/integration/eval/scoring.py
+++ b/tests/integration/eval/scoring.py
@@ -14,7 +14,6 @@ here.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable
 
 
 # ── Matchers (pure functions over actual + expected) ────────────────────

--- a/tests/integration/test_capture_memory_e2e.py
+++ b/tests/integration/test_capture_memory_e2e.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 
 from tests.integration.forgejo import ForgejoError
 from tests.integration.openai_stub import stub_classify

--- a/tests/integration/test_git_mirror_e2e.py
+++ b/tests/integration/test_git_mirror_e2e.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 
 from tests.integration.forgejo import ForgejoError
 from tests.integration.matrix import (
@@ -95,7 +94,7 @@ async def test_archivist_mirrors_classified_document_to_forgejo(
 
     bdd.given("the code (Forgejo) stacklet is reachable")
     assert code.ping(), "Forgejo API unreachable at http://localhost:42040"
-    bdd.ok(f"Forgejo /api/v1/version returned OK")
+    bdd.ok("Forgejo /api/v1/version returned OK")
 
     bdd.given("the #documents room exists and Homer has access")
     room_id = await wait_for_room(homer, DOCS_ROOM_ALIAS, timeout=90)

--- a/tests/integration/test_rig.py
+++ b/tests/integration/test_rig.py
@@ -9,7 +9,6 @@ If these fail, nothing else in this directory will work.
 
 from __future__ import annotations
 
-import pytest
 
 
 def test_paperless_responds(paperless):

--- a/tests/stacklets/test_archivist_duplicate.py
+++ b/tests/stacklets/test_archivist_duplicate.py
@@ -10,7 +10,6 @@ misleading 'OCR failed' message.
 import sys
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "lib"))

--- a/tests/stacklets/test_archivist_matching.py
+++ b/tests/stacklets/test_archivist_matching.py
@@ -7,7 +7,6 @@ dependencies. Tests use Springfield-themed names throughout.
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "stacklets" / "docs" / "bot"))
 

--- a/tests/stacklets/test_capabilities.py
+++ b/tests/stacklets/test_capabilities.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "stacklets" / "docs" / "bot"))

--- a/tests/stacklets/test_memory_install_pipeline.py
+++ b/tests/stacklets/test_memory_install_pipeline.py
@@ -17,7 +17,6 @@ Three branches covered:
 
 from __future__ import annotations
 
-import base64
 import sys
 from pathlib import Path
 
@@ -32,7 +31,6 @@ from lib import (  # noqa: E402
     REPO_OWNER,
     install_memory_to_forgejo,
 )
-from stack.forgejo import ForgejoClient  # noqa: E402
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/stacklets/test_mirror_format.py
+++ b/tests/stacklets/test_mirror_format.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "stacklets" / "docs" / "bot"))

--- a/tests/stacklets/test_omlx_client.py
+++ b/tests/stacklets/test_omlx_client.py
@@ -1,16 +1,14 @@
 """Tests for the oMLX admin API client."""
 
-import json
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 # Add stacklets/ai to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "stacklets" / "ai"))
 
-from omlx import OMLXClient, ModelInfo, DownloadTask, is_omlx, repo_id_to_model_id
+from omlx import OMLXClient, DownloadTask, repo_id_to_model_id
 
 
 class TestRepoIdToModelId:

--- a/tests/stacklets/test_pdf_analysis.py
+++ b/tests/stacklets/test_pdf_analysis.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from PIL import Image, ImageDraw
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "stacklets" / "docs" / "bot"))
@@ -36,8 +35,8 @@ def _make_pdf(pages: int = 1, *, text: str = "page", producer: str = "") -> byte
     from pypdf import PdfWriter
 
     writer = PdfWriter()
-    for i in range(pages):
-        page = writer.add_blank_page(width=300, height=400)
+    for _ in range(pages):
+        writer.add_blank_page(width=300, height=400)
         # Add text so the page has a text layer
         # (Pillow's PDF writer doesn't add text; pypdf's blank page
         # also has no text, so we need a different approach for
@@ -54,10 +53,10 @@ def _make_pdf_with_text(text: str = "hello world") -> bytes:
 
     This produces a PDF where ``page.extract_text()`` returns the
     supplied text, so ``has_text_layer`` returns True."""
-    from pypdf import PdfWriter, PageObject
+    from pypdf import PdfWriter
 
     writer = PdfWriter()
-    page = writer.add_blank_page(width=300, height=400)
+    writer.add_blank_page(width=300, height=400)
     # pypdf doesn't easily let us inject text content, so we'll use
     # a different approach: create a minimal PDF with a text object.
     # For testing purposes, we'll just use a real PDF file.

--- a/tests/stacklets/test_pdf_render.py
+++ b/tests/stacklets/test_pdf_render.py
@@ -6,7 +6,6 @@ import io
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "stacklets" / "docs" / "bot"))

--- a/tests/stacklets/test_pipeline.py
+++ b/tests/stacklets/test_pipeline.py
@@ -19,7 +19,6 @@ sys.path.insert(0, str(_REPO_ROOT / "lib"))
 sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "docs" / "bot"))
 
 from pipeline import (  # noqa: E402
-    EnrichResult,
     LLMModelNotFoundError,
     LLMTimeoutError,
     LLMUnavailableError,
@@ -1285,7 +1284,6 @@ class TestSummaryWrite:
 # patch `_request` to return whatever a fake backend would, and assert
 # on the content shape the Classifier would have sent on the wire.
 
-import json as _json  # noqa: E402
 
 from capabilities import ModelCapabilities  # noqa: E402
 from pipeline import Classifier, ImageAttachment  # noqa: E402

--- a/tests/stacklets/test_text_utils.py
+++ b/tests/stacklets/test_text_utils.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "stacklets" / "docs" / "bot"))


### PR DESCRIPTION
Adds ruff and gets to a clean ruff check ., with a pre-commit hook so lint can't creep back in. Reaching green surfaced a few pre-existing failures, fixed here too.
  All suites green afterward (tests/stacklets 788, tests/framework 293, test_config_to_container 17 on real Docker).

  Ruff

  - Default ruleset (E4/E7/E9/F), target-version = py311. Line-length (E5) intentionally off — the code favours long narrative docstrings.
  - Per-file ignores for the two legitimate patterns it flags: sys.path bootstrapping in stacklet/test entrypoints (E402) and the CLI's deliberate one-line argparse
  setup (E702).
  - Cleared every finding: F401/F541/E401 auto-fixed; F821/F841/E741/E731 by hand. __all__ on the stack package documents its public API (and clears the re-export
  F401s).

  Pre-commit hook

  - hooks/pre-commit runs uvx ruff check on staged .py files. Enable per clone with git config core.hooksPath hooks; --no-verify bypasses. (No CI yet, so this is the
  gate.)

  Fixes surfaced along the way

  - from __future__ above the module docstring in 7 lib/stack files silently nulled their __doc__ — reordered (docstring first, future import right after).
  - _refresh_core crash — up raised Stacklet 'core' not found when a core project from another stack shared the Docker daemon (e.g. tests against the host). Now skips
  unless this stack ships a core stacklet.
  - Prompt-interrupt test expected ask() to return None on Ctrl+C, but ask() propagates by design (three top-level handlers catch it) — the stale test was aborting the
  entire framework suite. Rewritten to assert propagation.
  - Lifecycle tests updated to the two-phase setup flow: up() runs on_install, run_on_install_success() promotes the setup-done marker.
  - config-to-container tests now surface stdout/stderr on failure instead of a bare assert 1 == 0.