### PR TITLE
feat: family wiki, demo family-docs, and burst-safe bot delivery

### DIFF
--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -695,6 +695,13 @@ def handle_up(stck, args):
     from .prompt import TEAL
     cli = CLI(stck)
 
+    # --no-voice is the flag form of STACK_AI_NO_VOICE=1. The ai stacklet's
+    # on_start reads this env var to drop the Piper TTS container (and
+    # on_install skips the Whisper build). Other stacklets don't read it, so
+    # setting it here for `up all` is harmless.
+    if getattr(args, "no_voice", False):
+        os.environ["STACK_AI_NO_VOICE"] = "1"
+
     if args.stacklet == "all":
         print(f"\n  Bringing up {TEAL}all installed stacklets{RESET}...\n",
               file=sys.stderr)
@@ -1298,6 +1305,8 @@ def main():
     sub.add_parser("version")
 
     p = sub.add_parser("up"); p.add_argument("stacklet")
+    p.add_argument("--no-voice", action="store_true",
+                   help="(ai) start without the voice container (TTS + Whisper); sets STACK_AI_NO_VOICE=1")
     p = sub.add_parser("down"); p.add_argument("stacklet")
     p = sub.add_parser("destroy"); p.add_argument("stacklet"); p.add_argument("--yes", action="store_true")
     p = sub.add_parser("restart"); p.add_argument("stacklet")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,16 @@ test = [
     "trafilatura>=1.12,<3.0",
 ]
 
+# Host-side tooling for generating the demo family-document set
+# (tools/family-docs). Not needed to run the stack — only to render the
+# example PDFs/images. reportlab lays out the native-text PDFs (clean
+# text layer for the classifier); Pillow draws the scanned-look images.
+demo = [
+    "reportlab>=4",
+    "Pillow>=10",
+    "pyyaml",
+]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 # Pipeline-quality evals (real model, real Paperless, slow) are opt-in via

--- a/stacklets/core/bot-runner/microbot.py
+++ b/stacklets/core/bot-runner/microbot.py
@@ -17,7 +17,7 @@ The base class then handles:
   - Initial sync that skips old messages (bots don't replay history)
   - Auto-accept room invitations
   - The sync loop with error recovery
-  - Message dedup via per-room cursor (at-most-once delivery)
+  - Reliable, burst-safe delivery by draining the room timeline
 
 Session persistence: each bot stores its access token and device ID in
 a JSON file at {session_dir}/{name}.session.json. On restart, the bot
@@ -25,18 +25,27 @@ restores the session instead of creating a new login — this prevents
 the "unknown device" problem where other clients can't encrypt for a
 bot that logs in with a new device every time.
 
-Message cursor: Matrix is used as a message bus — bots may be restarted
-at any time (e.g. when a new stacklet is installed and core is refreshed).
-Each bot keeps a per-room timestamp cursor on disk. Callbacks registered
-via add_event_callback() only fire for messages newer than the cursor.
-The cursor is advanced before the callback runs, so if the callback
-triggers a container restart (stacker running "stack up"), the message
-won't be replayed. This gives at-most-once delivery — safe for commands
-and document processing where replay would cause duplicates.
+Delivery model — Synapse is the queue: the room timeline is a durable,
+ordered log; we treat it as the work queue rather than maintaining a
+separate one. The live `sync()` is only a doorbell — it keeps the bot
+present and tells us the room advanced. The actual work is read by
+`_drain()`, which pages the timeline forward from a durable per-room
+cursor via `room_messages` and dispatches each event to its handler in
+order. Reading the timeline directly (instead of relying on the live
+sync payload) means a burst can never be lost to a "limited" (gappy)
+sync — every event since the cursor is still on the timeline.
+
+The cursor (a per-room server_timestamp on disk) advances only *after*
+a handler returns, so a crash mid-processing replays the event rather
+than skipping it: at-least-once delivery. Handlers must therefore be
+idempotent — keyed on a stable id, every write an upsert — so a replay
+is a no-op. (The timestamp cursor has a same-millisecond edge; a later
+revision moves the cursor to the Matrix read marker / event id.)
 """
 
 import asyncio
 import json
+import time
 from pathlib import Path
 
 import aiohttp
@@ -48,6 +57,8 @@ from nio import (
     InviteMemberEvent,
     LoginResponse,
     MegolmEvent,
+    MessageDirection,
+    RoomMessagesResponse,
 )
 
 from room_context import RoomContext, context_for
@@ -79,6 +90,10 @@ class MicroBot:
         self.session_file = self._session_dir / f"{self.name}.session.json"
         self._cursor_file = self._session_dir / f"{self.name}-cursor"
         self._cursors = self._load_cursors()
+        # (event_type_or_tuple, wrapped_handler) pairs. The drain dispatches
+        # to these; we do not register them with nio, because the live sync
+        # is only a doorbell — delivery happens in `_drain`.
+        self._handlers: list[tuple] = []
         self._client: AsyncClient | None = None
         # Lazily-created shared aiohttp session for non-nio HTTP (media
         # download, and subclasses' own API calls). Owned by the
@@ -177,12 +192,16 @@ class MicroBot:
         # ── Subclass callbacks ───────────────────────────────────────
         self.register_callbacks(self._client)
 
-        # ── Sync loop ────────────────────────────────────────────────
+        # ── Sync + drain loop ─────────────────────────────────────────
+        # `sync()` is the doorbell (long-poll: returns on activity or after
+        # the timeout); `_drain()` does the work, reading the timeline from
+        # the durable cursor so nothing is lost to a limited sync.
         logger.info("[{}] Running", self.name)
         while self._running:
             try:
                 await self._client.sync(timeout=30000)
                 self._trust_all_devices()
+                await self._drain()
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -240,41 +259,29 @@ class MicroBot:
     def add_event_callback(self, callback, event_type):
         """Register an event callback with the standard framework wrap.
 
-        The wrap does three things every bot wants:
+        The wrap does two things every bot wants:
 
-          1. **Dedup** — only fires for messages newer than the per-room
-             cursor; the cursor advances before the callback runs, so a
-             callback that triggers a restart can't replay the message.
-             At-most-once delivery.
-          2. **Typing indicator** — shows that the bot is working from
-             the moment the cursor advances until the handler returns
-             (or fails). This is the family's only signal that the bot
-             saw the message at all.
-          3. **Timeout + error response** — runs the callback under
+          1. **Typing indicator** — a typing-off is guaranteed in
+             `finally`. It does NOT auto-set typing-on; handlers control
+             when the indicator appears, because the right moment depends
+             on whether they post an intermediate confirmation first
+             (which clears the indicator on Element's side).
+          2. **Timeout + error response** — runs the callback under
              ``HANDLER_TIMEOUT_SECONDS`` and, on timeout *or* any
              unhandled exception, posts a user-facing notice into the
              room via ``_send_error``. A silently-failing bot is worse
              than a bot that says "sorry, try again."
 
-        Handlers don't need their own try/except or typing management;
-        the framework owns both. Subclasses customize the error wording
-        by overriding ``_format_handler_error``.
+        The handler is not registered with nio; it is stored and invoked
+        by `_drain` in timeline order. Dedup and cursor advancement live
+        there — the drain only dispatches events past the cursor and
+        advances it *after* the handler returns (at-least-once), so
+        handlers must be idempotent. Subclasses customize the error
+        wording by overriding ``_format_handler_error``.
         """
         async def wrapper(room, event):
             if event.sender == self.user_id:
                 return
-            ts = getattr(event, "server_timestamp", 0)
-            if ts <= self._cursors.get(room.room_id, 0):
-                return
-            self._advance_cursor(room.room_id, ts)
-
-            # From here on, the bot owns this event. The framework
-            # guarantees a typing-off in `finally` (and posts an error
-            # notice if the handler raises or runs over budget), but
-            # it does NOT auto-set typing-on. Handlers control when the
-            # indicator appears, because the right moment depends on
-            # whether they post an intermediate confirmation message
-            # first (which clears the indicator on Element's side).
             try:
                 await asyncio.wait_for(
                     callback(room, event),
@@ -295,7 +302,75 @@ class MicroBot:
             finally:
                 await self._set_typing(room.room_id, on=False)
 
-        self._client.add_event_callback(wrapper, event_type)
+        # Stored for the drain, not registered with nio: the live sync is
+        # only a doorbell, delivery happens in `_drain`.
+        self._handlers.append((event_type, wrapper))
+
+    # ── Drain: the timeline is the queue ──────────────────────────────────
+    #
+    # Each cycle we read everything past the per-room cursor straight off
+    # the timeline via `room_messages` and dispatch it in order. Reading the
+    # timeline (rather than trusting the live sync payload) is gap-free: a
+    # burst that outran a "limited" sync is still fully on the timeline, so
+    # nothing is dropped under load.
+
+    DRAIN_PAGE_SIZE = 50
+    MAX_DRAIN_PAGES = 40  # safety cap: up to ~2000 backlogged events per room
+
+    async def _drain(self) -> None:
+        """Process new events in every joined room, in timeline order."""
+        if not self._handlers or self._client is None:
+            return
+        for room_id in list(self._client.rooms.keys()):
+            try:
+                await self._drain_room(room_id)
+            except Exception as e:
+                logger.warning("[{}] drain error in {}: {}", self.name, room_id, e)
+
+    async def _drain_room(self, room_id: str) -> None:
+        # First sight of a room: anchor the cursor at "now" so we don't
+        # replay its whole history (the old "skip old messages" behavior).
+        if room_id not in self._cursors:
+            self._advance_cursor(room_id, int(time.time() * 1000))
+            return
+
+        cursor = self._cursors[room_id]
+
+        # Page backward from the live sync position, collecting events newer
+        # than the cursor, until we cross it. Then process oldest-first.
+        pending: list = []
+        start = self._client.next_batch
+        for _ in range(self.MAX_DRAIN_PAGES):
+            resp = await self._client.room_messages(
+                room_id, start=start, direction=MessageDirection.back,
+                limit=self.DRAIN_PAGE_SIZE,
+            )
+            if not isinstance(resp, RoomMessagesResponse) or not resp.chunk:
+                break
+            crossed = False
+            for event in resp.chunk:  # newest -> oldest
+                if getattr(event, "server_timestamp", 0) <= cursor:
+                    crossed = True
+                    break
+                pending.append(event)
+            if crossed or not resp.end or resp.end == start:
+                break
+            start = resp.end
+
+        for event in sorted(pending, key=lambda e: getattr(e, "server_timestamp", 0)):
+            await self._dispatch(room_id, event)
+            # Advance only after the handler returns: a crash mid-handler
+            # replays the event (at-least-once), it is never skipped.
+            self._advance_cursor(room_id, getattr(event, "server_timestamp", cursor))
+
+    async def _dispatch(self, room_id: str, event) -> None:
+        """Invoke every handler whose registered type matches the event."""
+        room = self._client.rooms.get(room_id)
+        if room is None:
+            return
+        for event_type, handler in self._handlers:
+            if isinstance(event, event_type):
+                await handler(room, event)
 
     # ── Typing + error response ──────────────────────────────────────────
     #

--- a/stacklets/docs/bot/git_mirror.py
+++ b/stacklets/docs/bot/git_mirror.py
@@ -58,23 +58,17 @@ from loguru import logger
 from stack.forgejo import ForgejoClient, ForgejoError
 
 
-# The shared family knowledge vault. The memory stacklet creates,
-# seeds, and READMEs the repo; the archivist writes Markdown under
-# entity-rooted paths (see module docstring). If the archivist boots
-# before memory is installed, the description here is used as the
-# create-time fallback — memory's install pipeline overwrites it
-# later (and they say the same thing).
+# The shared family knowledge vault. The memory stacklet creates and
+# seeds the org + repo (description, README, ontology, facts); the
+# archivist only writes Markdown under entity-rooted paths (see module
+# docstring), and skips mirroring entirely if memory hasn't provisioned
+# the repo yet.
 REPO_NAME = "memory"
-REPO_DESCRIPTION = (
-    "The family's curated knowledge — ontology, facts, and wiki. "
-    "Hand-edit any file here; the commit log is the learning history."
-)
 
 BOT_USERNAME = "archivist-bot"
 BOT_EMAIL = "archivist-bot@local"
 TOKEN_NAME = "archivist-git-mirror"
-TOKEN_SCOPES = ["write:repository", "read:repository", "read:user", "write:organization"]
-ORG_DESCRIPTION = "Your family's Forgejo — documents, knowledge, and shared repos."
+TOKEN_SCOPES = ["write:repository", "read:repository", "read:user"]
 
 
 @dataclass
@@ -132,11 +126,16 @@ class GitMirror:
     # ── Setup (idempotent, lazy) ─────────────────────────────────────────
 
     async def ensure_setup(self) -> bool:
-        """Ensure archivist-bot user, token, repo, and collaborators exist.
+        """Ensure the archivist-bot can push to the memory-provisioned repo.
+
+        Sets up docs' own resources — the archivist-bot user, its push
+        token, and the bot's membership in the family org Owners team.
+        Creation of the org, repo, and seeds belongs to the memory
+        stacklet; if memory hasn't provisioned the repo yet, this skips.
 
         Returns True if setup succeeded (or was already done), False if
-        Forgejo is unreachable. Subsequent calls short-circuit once
-        `_setup_done` is set.
+        Forgejo is unreachable or the repo isn't provisioned yet.
+        Subsequent calls short-circuit once `_setup_done` is set.
         """
         if self._setup_done:
             return True
@@ -172,20 +171,25 @@ class GitMirror:
                 logger.warning("[git-mirror] Could not issue token: {}", e)
                 return False
 
-        client.token = self._creds.token
-
-        # ── Org + team membership ────────────────────────────────────
-        # Orgs are the right home for family-wide repos (documents now,
-        # brain/calendar later). Admins see every org repo on their
-        # dashboard without per-repo watches.
-        try:
-            await asyncio.to_thread(
-                client.create_org, self.org_name, ORG_DESCRIPTION,
+        # The memory stacklet owns creation of the family org, the
+        # family/memory repo, and its seeds. If memory hasn't provisioned
+        # the repo yet there is nowhere to mirror — skip best-effort and
+        # let the next document retry once memory is up. The document
+        # still files into Paperless either way.
+        repo = await asyncio.to_thread(client.get_repo, self.org_name, REPO_NAME)
+        if repo is None:
+            logger.info(
+                "[git-mirror] {}/{} not provisioned by the memory stacklet yet; "
+                "skipping mirror",
+                self.org_name, REPO_NAME,
             )
-        except ForgejoError as e:
-            logger.warning("[git-mirror] Could not ensure org {}: {}", self.org_name, e)
             return False
 
+        # ── Team membership ──────────────────────────────────────────
+        # Grant the bot push access via the org Owners team. Org/team ops
+        # run as the admin (which owns the org through memory's creation),
+        # not the bot token. Admins are re-added so the repo shows on
+        # their dashboard.
         try:
             owners_team_id = await asyncio.to_thread(
                 client.get_owners_team_id, self.org_name,
@@ -201,33 +205,10 @@ class GitMirror:
             except ForgejoError as e:
                 logger.warning("[git-mirror] Could not add {} to Owners: {}", member, e)
 
-        try:
-            await asyncio.to_thread(
-                client.create_repo, self.org_name, REPO_NAME,
-                description=REPO_DESCRIPTION, private=True, owner_is_org=True,
-            )
-        except ForgejoError as e:
-            logger.warning("[git-mirror] Could not ensure repo: {}", e)
-            return False
-
-        # `create_repo` is idempotent on existing repos, so the description
-        # sync is a separate step for deployments that already have the
-        # repo with an older description. Admin-basic auth because the
-        # bot's token isn't scoped to repo settings.
-        admin_client = ForgejoClient(
-            url=self.code_url,
-            admin_user=self.admin_user, admin_password=self.admin_password,
-        )
-        try:
-            await asyncio.to_thread(
-                admin_client.update_repo, self.org_name, REPO_NAME,
-                description=REPO_DESCRIPTION,
-            )
-        except ForgejoError as e:
-            logger.warning("[git-mirror] Could not sync repo description: {}", e)
-
-        # README and vault top-level files (documents/, ontology.toml,
-        # facts.toml) are seeded by the memory stacklet, not here.
+        # The repo itself, its description, README, and the seed files
+        # (documents/, ontology.toml, facts.toml) are all created and
+        # owned by the memory stacklet. The archivist only writes Markdown
+        # under the shared bucket into the already-provisioned repo.
 
         self._setup_done = True
         logger.info("[git-mirror] Setup complete: {}/{}", self.org_name, REPO_NAME)

--- a/stacklets/memory/Dockerfile
+++ b/stacklets/memory/Dockerfile
@@ -40,11 +40,18 @@ RUN git clone --depth 1 --branch "${QUARTZ_TAG}" https://github.com/jackyzha0/qu
 COPY quartz/quartz.config.ts ./quartz.config.ts
 COPY quartz/quartz.layout.ts ./quartz.layout.ts
 
+# The entrypoint keeps the vault in sync (background git pull loop) and
+# then serves it with Quartz. See quartz/entrypoint.sh.
+COPY quartz/entrypoint.sh /usr/local/bin/garden-entrypoint.sh
+RUN chmod +x /usr/local/bin/garden-entrypoint.sh
+
 # Quartz's preview server defaults to port 8080. Node's
 # `server.listen(port)` with no host binds 0.0.0.0, so the port
 # publishes cleanly to the Docker network without an explicit
 # `--bind` flag (which Quartz v4 doesn't expose).
 EXPOSE 8080
 
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["npx", "quartz", "build", "--serve", "--directory", "/vault", "--port", "8080"]
+# `-g` so a stop signal reaches the whole process group — both Quartz
+# and the background vault-sync loop — not just Quartz.
+ENTRYPOINT ["/sbin/tini", "-g", "--"]
+CMD ["/usr/local/bin/garden-entrypoint.sh"]

--- a/stacklets/memory/Dockerfile
+++ b/stacklets/memory/Dockerfile
@@ -1,0 +1,47 @@
+# Dockerfile — memory garden (Quartz v4)
+#
+# The garden is a thin shell around an upstream Quartz checkout. We
+# clone the Quartz repo at a pinned tag, install its node_modules,
+# and overlay our config files. The container's job at runtime is
+# `npx quartz build --serve`, which builds the site once and then
+# watches the bind-mounted vault and rebuilds on change.
+#
+# Quartz expects `quartz.config.ts` and `quartz.layout.ts` at the
+# repo root — the COPY layer overwrites the ones shipped in the
+# upstream tag with our own.
+
+FROM node:22-alpine
+
+# Quartz v4 — pinned. Bump by hand after eyeballing the upstream
+# changelog at https://github.com/jackyzha0/quartz/releases. There
+# is no upstream Docker image to track, so Watchtower is a no-op
+# here; this string is the version surface.
+ARG QUARTZ_TAG=v4.5.2
+
+# `git` clones Quartz at build time. `tini` reaps zombies left by
+# Quartz's child build process under `--serve`, which forks a
+# bundler on every rebuild. Without it, defunct processes pile up.
+RUN apk add --no-cache git tini
+
+WORKDIR /app
+
+# Clone shallow at the pinned tag and install dependencies. The
+# repo is the runtime; we do not eject it. `npm ci` uses the
+# upstream lockfile so the dep tree is reproducible across builds.
+RUN git clone --depth 1 --branch "${QUARTZ_TAG}" https://github.com/jackyzha0/quartz.git . \
+ && npm ci
+
+# Overlay our config on top of the upstream defaults. `quartz/*.ts`
+# in this stacklet directory is the source of truth for site title,
+# theme, plugins, and the "edit on Forgejo" link template.
+COPY quartz/quartz.config.ts ./quartz.config.ts
+COPY quartz/quartz.layout.ts ./quartz.layout.ts
+
+# Quartz's preview server defaults to port 8080. Node's
+# `server.listen(port)` with no host binds 0.0.0.0, so the port
+# publishes cleanly to the Docker network without an explicit
+# `--bind` flag (which Quartz v4 doesn't expose).
+EXPOSE 8080
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["npx", "quartz", "build", "--serve", "--directory", "/vault", "--port", "8080"]

--- a/stacklets/memory/Dockerfile
+++ b/stacklets/memory/Dockerfile
@@ -21,7 +21,10 @@ ARG QUARTZ_TAG=v4.5.2
 # `git` clones Quartz at build time. `tini` reaps zombies left by
 # Quartz's child build process under `--serve`, which forks a
 # bundler on every rebuild. Without it, defunct processes pile up.
-RUN apk add --no-cache git tini
+# `coreutils` gives us GNU `env`: Quartz's CLI shebang uses
+# `#!/usr/bin/env -S node ...`, and BusyBox's `env` (Alpine's default)
+# doesn't understand `-S`, so the container crash-loops without it.
+RUN apk add --no-cache git tini coreutils
 
 WORKDIR /app
 

--- a/stacklets/memory/Dockerfile
+++ b/stacklets/memory/Dockerfile
@@ -1,6 +1,6 @@
-# Dockerfile — memory garden (Quartz v4)
+# Dockerfile — family wiki (Quartz v4)
 #
-# The garden is a thin shell around an upstream Quartz checkout. We
+# The wiki is a thin shell around an upstream Quartz checkout. We
 # clone the Quartz repo at a pinned tag, install its node_modules,
 # and overlay our config files. The container's job at runtime is
 # `npx quartz build --serve`, which builds the site once and then
@@ -42,8 +42,8 @@ COPY quartz/quartz.layout.ts ./quartz.layout.ts
 
 # The entrypoint keeps the vault in sync (background git pull loop) and
 # then serves it with Quartz. See quartz/entrypoint.sh.
-COPY quartz/entrypoint.sh /usr/local/bin/garden-entrypoint.sh
-RUN chmod +x /usr/local/bin/garden-entrypoint.sh
+COPY quartz/entrypoint.sh /usr/local/bin/wiki-entrypoint.sh
+RUN chmod +x /usr/local/bin/wiki-entrypoint.sh
 
 # Quartz's preview server defaults to port 8080. Node's
 # `server.listen(port)` with no host binds 0.0.0.0, so the port
@@ -54,4 +54,4 @@ EXPOSE 8080
 # `-g` so a stop signal reaches the whole process group — both Quartz
 # and the background vault-sync loop — not just Quartz.
 ENTRYPOINT ["/sbin/tini", "-g", "--"]
-CMD ["/usr/local/bin/garden-entrypoint.sh"]
+CMD ["/usr/local/bin/wiki-entrypoint.sh"]

--- a/stacklets/memory/caddy.snippet
+++ b/stacklets/memory/caddy.snippet
@@ -1,0 +1,14 @@
+# stacklets/memory/caddy.snippet
+#
+# One route. The memory garden — Quartz rendering the family vault —
+# lives at memory.{$FAMSTACK_DOMAIN}. Caddy runs on the stack network
+# so the backend is the container name; the in-container port is
+# Quartz's preview server default (8080), not the published host port.
+#
+# No auth here, matching the rest of the family-facing stacklets
+# (photos, docs, messages). The LAN is the perimeter. Add `basicauth`
+# inside this block if you ever want to gate the vault separately.
+
+memory.{$FAMSTACK_DOMAIN} {
+    reverse_proxy stack-memory-garden:8080
+}

--- a/stacklets/memory/caddy.snippet
+++ b/stacklets/memory/caddy.snippet
@@ -1,7 +1,7 @@
 # stacklets/memory/caddy.snippet
 #
-# One route. The memory garden — Quartz rendering the family vault —
-# lives at memory.{$FAMSTACK_DOMAIN}. Caddy runs on the stack network
+# One route. The family wiki — Quartz rendering the family vault —
+# lives at wiki.{$FAMSTACK_DOMAIN}. Caddy runs on the stack network
 # so the backend is the container name; the in-container port is
 # Quartz's preview server default (8080), not the published host port.
 #
@@ -9,6 +9,6 @@
 # (photos, docs, messages). The LAN is the perimeter. Add `basicauth`
 # inside this block if you ever want to gate the vault separately.
 
-memory.{$FAMSTACK_DOMAIN} {
-    reverse_proxy stack-memory-garden:8080
+wiki.{$FAMSTACK_DOMAIN} {
+    reverse_proxy stack-memory-wiki:8080
 }

--- a/stacklets/memory/docker-compose.yml
+++ b/stacklets/memory/docker-compose.yml
@@ -1,27 +1,27 @@
-# stacklets/memory/docker-compose.yml — the memory garden
+# stacklets/memory/docker-compose.yml — the family wiki
 #
-# One service. The "garden" is a Quartz v4 site that renders the
+# One service. The "wiki" is a Quartz v4 site that renders the
 # family memory vault as a browsable wiki: graph view, backlinks,
 # full-text search, mobile-friendly. The container runs `quartz
 # build --serve`, which watches the bind-mounted vault and rebuilds
 # whenever the hooks pull new commits in from Forgejo.
 #
-# The vault is mounted read-write so the garden can keep its working
+# The vault is mounted read-write so the wiki can keep its working
 # copy in sync with Forgejo (a background `git pull` loop in the
 # entrypoint). Edits still happen in Forgejo, which stays the canonical
-# source of truth; the garden only ever fast-forwards. The image is
+# source of truth; the wiki only ever fast-forwards. The image is
 # built locally from the sibling Dockerfile and Watchtower is told to
 # ignore it (there's no upstream image to track).
 
 name: stack-memory
 
 services:
-  stack-memory-garden:
-    container_name: stack-memory-garden
+  stack-memory-wiki:
+    container_name: stack-memory-wiki
     build:
       context: .
       dockerfile: Dockerfile
-    image: stack-memory-garden:local
+    image: stack-memory-wiki:local
     # Locally-built image — nothing for Watchtower to pull. The Quartz
     # version is pinned in the Dockerfile and bumped by hand.
     labels:
@@ -30,16 +30,16 @@ services:
       - stack
     # Mounted read-write so the entrypoint can fast-forward the working
     # copy from Forgejo (git pull). Edits still round-trip through
-    # Forgejo so they land as commits; the garden never writes its own.
+    # Forgejo so they land as commits; the wiki never writes its own.
     volumes:
       - ${MEMORY_VAULT_DIR}:/vault
     environment:
       # Used by quartz.config.ts to build "edit on Forgejo" links and
       # absolute URLs. Resolved by the runtime from stack.toml.
       CODE_URL: ${CODE_URL}
-      GARDEN_HOST: ${GARDEN_HOST}
-      GARDEN_IP: ${GARDEN_IP}
-      GARDEN_PORT: "42070"
+      WIKI_HOST: ${WIKI_HOST}
+      WIKI_IP: ${WIKI_IP}
+      WIKI_PORT: "42070"
       # How often the background loop pulls family/memory from Forgejo.
       VAULT_SYNC_INTERVAL: "20"
     ports:

--- a/stacklets/memory/docker-compose.yml
+++ b/stacklets/memory/docker-compose.yml
@@ -6,10 +6,12 @@
 # build --serve`, which watches the bind-mounted vault and rebuilds
 # whenever the hooks pull new commits in from Forgejo.
 #
-# Read path only. The vault is mounted read-only — edits go through
-# Forgejo, which is the canonical source of truth. The image is
-# built locally from the sibling Dockerfile and Watchtower is told
-# to ignore it (there's no upstream image to track).
+# The vault is mounted read-write so the garden can keep its working
+# copy in sync with Forgejo (a background `git pull` loop in the
+# entrypoint). Edits still happen in Forgejo, which stays the canonical
+# source of truth; the garden only ever fast-forwards. The image is
+# built locally from the sibling Dockerfile and Watchtower is told to
+# ignore it (there's no upstream image to track).
 
 name: stack-memory
 
@@ -26,10 +28,11 @@ services:
       - "com.centurylinklabs.watchtower.enable=false"
     networks:
       - stack
-    # Vault is mounted read-only: the garden never writes back. Every
-    # change must round-trip through Forgejo so it lands as a commit.
+    # Mounted read-write so the entrypoint can fast-forward the working
+    # copy from Forgejo (git pull). Edits still round-trip through
+    # Forgejo so they land as commits; the garden never writes its own.
     volumes:
-      - ${MEMORY_VAULT_DIR}:/vault:ro
+      - ${MEMORY_VAULT_DIR}:/vault
     environment:
       # Used by quartz.config.ts to build "edit on Forgejo" links and
       # absolute URLs. Resolved by the runtime from stack.toml.
@@ -37,6 +40,8 @@ services:
       GARDEN_HOST: ${GARDEN_HOST}
       GARDEN_IP: ${GARDEN_IP}
       GARDEN_PORT: "42070"
+      # How often the background loop pulls family/memory from Forgejo.
+      VAULT_SYNC_INTERVAL: "20"
     ports:
       # Container's Quartz preview server listens on 8080; we publish
       # on the stacklet's declared port (42070). PORT_BIND_IP is set

--- a/stacklets/memory/docker-compose.yml
+++ b/stacklets/memory/docker-compose.yml
@@ -1,0 +1,50 @@
+# stacklets/memory/docker-compose.yml — the memory garden
+#
+# One service. The "garden" is a Quartz v4 site that renders the
+# family memory vault as a browsable wiki: graph view, backlinks,
+# full-text search, mobile-friendly. The container runs `quartz
+# build --serve`, which watches the bind-mounted vault and rebuilds
+# whenever the hooks pull new commits in from Forgejo.
+#
+# Read path only. The vault is mounted read-only — edits go through
+# Forgejo, which is the canonical source of truth. The image is
+# built locally from the sibling Dockerfile and Watchtower is told
+# to ignore it (there's no upstream image to track).
+
+name: stack-memory
+
+services:
+  stack-memory-garden:
+    container_name: stack-memory-garden
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: stack-memory-garden:local
+    # Locally-built image — nothing for Watchtower to pull. The Quartz
+    # version is pinned in the Dockerfile and bumped by hand.
+    labels:
+      - "com.centurylinklabs.watchtower.enable=false"
+    networks:
+      - stack
+    # Vault is mounted read-only: the garden never writes back. Every
+    # change must round-trip through Forgejo so it lands as a commit.
+    volumes:
+      - ${MEMORY_VAULT_DIR}:/vault:ro
+    environment:
+      # Used by quartz.config.ts to build "edit on Forgejo" links and
+      # absolute URLs. Resolved by the runtime from stack.toml.
+      CODE_URL: ${CODE_URL}
+      GARDEN_HOST: ${GARDEN_HOST}
+      GARDEN_IP: ${GARDEN_IP}
+      GARDEN_PORT: "42070"
+    ports:
+      # Container's Quartz preview server listens on 8080; we publish
+      # on the stacklet's declared port (42070). PORT_BIND_IP is set
+      # by the runtime — 0.0.0.0 in port mode, 127.0.0.1 in domain mode
+      # so Caddy is the only path in.
+      - "${PORT_BIND_IP:-127.0.0.1}:42070:8080"
+    restart: unless-stopped
+
+networks:
+  stack:
+    external: true

--- a/stacklets/memory/quartz/entrypoint.sh
+++ b/stacklets/memory/quartz/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# entrypoint.sh — keep the vault in sync from Forgejo, then serve it.
+#
+# Quartz `--serve` watches /vault and rebuilds on change, but the working
+# copy only advances when we pull. A background loop pulls family/memory
+# on a short interval, so a new commit — an archivist mirror, a seed
+# push, or a hand-edit in the Forgejo web UI — shows up within
+# VAULT_SYNC_INTERVAL seconds and Quartz rebuilds it for free. A Forgejo
+# push webhook could replace this loop later; polling keeps it
+# dependency-free and is cheap (the rebuild is sub-second).
+set -e
+
+INTERVAL="${VAULT_SYNC_INTERVAL:-20}"
+
+# The working copy is cloned on the host and bind-mounted here, so git
+# sees a different owner than the container user. Trust it explicitly,
+# otherwise git refuses to operate on "dubious ownership".
+git config --global --add safe.directory /vault
+
+# Background sync, kept as cheap as possible. Each tick compares the
+# local HEAD against the remote with `git ls-remote` — a single
+# lightweight ref query, no object transfer, no working-tree touch — and
+# only pulls when the remote has actually moved. So an idle tick (the
+# common case) costs one tiny request and never triggers a rebuild; the
+# fetch + fast-forward happens only when there is genuinely a new commit.
+#
+# Never fatal: if the clone isn't ready yet (first boot) or Forgejo is
+# briefly unreachable, the tick is skipped and retried next time while
+# the site keeps serving what is already on disk.
+(
+  while true; do
+    sleep "$INTERVAL"
+    local_head=$(git -C /vault rev-parse HEAD 2>/dev/null) || continue
+    remote_head=$(git -C /vault ls-remote origin HEAD 2>/dev/null | cut -f1)
+    if [ -n "$remote_head" ] && [ "$local_head" != "$remote_head" ]; then
+      git -C /vault pull --quiet --ff-only 2>/dev/null || true
+    fi
+  done
+) &
+
+# Quartz in the foreground; its file watcher turns each pulled change
+# into a rebuild. Port 8080 is the in-container port Caddy and the
+# compose port mapping target.
+exec npx quartz build --serve --directory /vault --port 8080

--- a/stacklets/memory/quartz/quartz.config.ts
+++ b/stacklets/memory/quartz/quartz.config.ts
@@ -1,0 +1,114 @@
+/**
+ * quartz.config.ts — memory garden
+ *
+ * Overlays the upstream Quartz v4 config with the bits that matter
+ * for famstack: site title, edit-on-Forgejo origin, no analytics,
+ * faster builds. Everything not touched here intentionally tracks
+ * upstream defaults so a Quartz bump only needs eyes on the diff.
+ *
+ * The container runs `npx quartz build --serve` on every start, so
+ * `process.env.*` reads here happen at startup — env changes in
+ * `stacklet.toml` take effect on the next `stack up memory`.
+ */
+
+import { QuartzConfig } from "./quartz/cfg"
+import * as Plugin from "./quartz/plugins"
+
+// Runtime env. `GARDEN_HOST` is "memory.<domain>" in domain mode and
+// the empty-domain rendering "memory." in port mode — we treat the
+// trailing-dot form as missing and fall back to the LAN IP so
+// absolute URLs in the sitemap stay reachable in either mode.
+const gardenHost = process.env.GARDEN_HOST?.replace(/^https?:\/\//, "") || ""
+const gardenIp = process.env.GARDEN_IP || ""
+const gardenPort = process.env.GARDEN_PORT || "42070"
+const haveRealHost = gardenHost && !gardenHost.endsWith(".")
+const baseUrl = haveRealHost ? gardenHost : `${gardenIp || "localhost"}:${gardenPort}`
+
+const config: QuartzConfig = {
+  configuration: {
+    pageTitle: "Family Memory",
+    pageTitleSuffix: "",
+    enableSPA: true,
+    enablePopovers: true,
+    // No analytics — this is a private family site, the upstream
+    // Plausible default would leak page views to a third party.
+    analytics: null,
+    locale: "en-US",
+    baseUrl,
+    // Skip git internals and Obsidian config dirs. The vault is a
+    // real git clone, not a stripped checkout, so `.git` matters.
+    ignorePatterns: [".git", ".obsidian", "private", "templates"],
+    defaultDateType: "modified",
+    theme: {
+      fontOrigin: "googleFonts",
+      cdnCaching: true,
+      typography: {
+        header: "Schibsted Grotesk",
+        body: "Source Sans Pro",
+        code: "IBM Plex Mono",
+      },
+      colors: {
+        lightMode: {
+          light: "#faf8f8",
+          lightgray: "#e5e5e5",
+          gray: "#b8b8b8",
+          darkgray: "#4e4e4e",
+          dark: "#2b2b2b",
+          secondary: "#284b63",
+          tertiary: "#84a59d",
+          highlight: "rgba(143, 159, 169, 0.15)",
+          textHighlight: "#fff23688",
+        },
+        darkMode: {
+          light: "#161618",
+          lightgray: "#393639",
+          gray: "#646464",
+          darkgray: "#d4d4d4",
+          dark: "#ebebec",
+          secondary: "#7b97aa",
+          tertiary: "#84a59d",
+          highlight: "rgba(143, 159, 169, 0.15)",
+          textHighlight: "#b3aa0288",
+        },
+      },
+    },
+  },
+  plugins: {
+    transformers: [
+      Plugin.FrontMatter(),
+      // The vault is a git repo — let git timestamps win over
+      // filesystem mtime so a fresh clone shows real commit dates.
+      Plugin.CreatedModifiedDate({
+        priority: ["frontmatter", "git", "filesystem"],
+      }),
+      Plugin.SyntaxHighlighting({
+        theme: { light: "github-light", dark: "github-dark" },
+        keepBackground: false,
+      }),
+      Plugin.ObsidianFlavoredMarkdown({ enableInHtmlEmbed: false }),
+      Plugin.GitHubFlavoredMarkdown(),
+      Plugin.TableOfContents(),
+      Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
+      Plugin.Description(),
+      Plugin.Latex({ renderEngine: "katex" }),
+    ],
+    filters: [Plugin.RemoveDrafts()],
+    emitters: [
+      Plugin.AliasRedirects(),
+      Plugin.ComponentResources(),
+      Plugin.ContentPage(),
+      Plugin.FolderPage(),
+      Plugin.TagPage(),
+      Plugin.ContentIndex({ enableSiteMap: true, enableRSS: true }),
+      Plugin.Assets(),
+      Plugin.Static(),
+      Plugin.Favicon(),
+      Plugin.NotFoundPage(),
+      // CustomOgImages does a heavy per-page render. Skipped for the
+      // garden — every container start rebuilds the whole site and
+      // OG cards aren't useful for a LAN-only wiki.
+    ],
+  },
+}
+
+export default config

--- a/stacklets/memory/quartz/quartz.config.ts
+++ b/stacklets/memory/quartz/quartz.config.ts
@@ -1,5 +1,5 @@
 /**
- * quartz.config.ts — memory garden
+ * quartz.config.ts — family wiki
  *
  * Overlays the upstream Quartz v4 config with the bits that matter
  * for famstack: site title, edit-on-Forgejo origin, no analytics,
@@ -14,15 +14,15 @@
 import { QuartzConfig } from "./quartz/cfg"
 import * as Plugin from "./quartz/plugins"
 
-// Runtime env. `GARDEN_HOST` is "memory.<domain>" in domain mode and
-// the empty-domain rendering "memory." in port mode — we treat the
+// Runtime env. `WIKI_HOST` is "wiki.<domain>" in domain mode and
+// the empty-domain rendering "wiki." in port mode — we treat the
 // trailing-dot form as missing and fall back to the LAN IP so
 // absolute URLs in the sitemap stay reachable in either mode.
-const gardenHost = process.env.GARDEN_HOST?.replace(/^https?:\/\//, "") || ""
-const gardenIp = process.env.GARDEN_IP || ""
-const gardenPort = process.env.GARDEN_PORT || "42070"
-const haveRealHost = gardenHost && !gardenHost.endsWith(".")
-const baseUrl = haveRealHost ? gardenHost : `${gardenIp || "localhost"}:${gardenPort}`
+const wikiHost = process.env.WIKI_HOST?.replace(/^https?:\/\//, "") || ""
+const wikiIp = process.env.WIKI_IP || ""
+const wikiPort = process.env.WIKI_PORT || "42070"
+const haveRealHost = wikiHost && !wikiHost.endsWith(".")
+const baseUrl = haveRealHost ? wikiHost : `${wikiIp || "localhost"}:${wikiPort}`
 
 const config: QuartzConfig = {
   configuration: {
@@ -105,7 +105,7 @@ const config: QuartzConfig = {
       Plugin.Favicon(),
       Plugin.NotFoundPage(),
       // CustomOgImages does a heavy per-page render. Skipped for the
-      // garden — every container start rebuilds the whole site and
+      // wiki — every container start rebuilds the whole site and
       // OG cards aren't useful for a LAN-only wiki.
     ],
   },

--- a/stacklets/memory/quartz/quartz.layout.ts
+++ b/stacklets/memory/quartz/quartz.layout.ts
@@ -1,0 +1,84 @@
+/**
+ * quartz.layout.ts — memory garden
+ *
+ * Tracks the upstream v4 layout (graph + backlinks + search) with
+ * one change: the footer's links table points at the Forgejo
+ * `family/memory` repo, so every page surfaces the path back to
+ * the canonical source of truth.
+ */
+
+import { PageLayout, SharedLayout } from "./quartz/cfg"
+import * as Component from "./quartz/components"
+
+// `CODE_URL` is set in the container env from {code_url} — the
+// user-facing Forgejo URL. Empty falls back to a `#` placeholder so
+// the footer still renders even if env wiring drifts.
+const codeUrl = process.env.CODE_URL || ""
+const repoUrl = codeUrl ? `${codeUrl.replace(/\/$/, "")}/family/memory` : "#"
+
+export const sharedPageComponents: SharedLayout = {
+  head: Component.Head(),
+  header: [],
+  afterBody: [],
+  footer: Component.Footer({
+    links: {
+      "Edit on Forgejo": repoUrl,
+    },
+  }),
+}
+
+// Single-page layout (one note): keep the upstream sidebar with
+// search + dark mode toggle on the left, graph + ToC + backlinks
+// on the right. This is the layout that makes the vault feel like
+// a wiki rather than a folder dump.
+export const defaultContentPageLayout: PageLayout = {
+  beforeBody: [
+    Component.ConditionalRender({
+      component: Component.Breadcrumbs(),
+      condition: (page) => page.fileData.slug !== "index",
+    }),
+    Component.ArticleTitle(),
+    Component.ContentMeta(),
+    Component.TagList(),
+  ],
+  left: [
+    Component.PageTitle(),
+    Component.MobileOnly(Component.Spacer()),
+    Component.Flex({
+      components: [
+        { Component: Component.Search(), grow: true },
+        { Component: Component.Darkmode() },
+        { Component: Component.ReaderMode() },
+      ],
+    }),
+    Component.Explorer(),
+  ],
+  right: [
+    Component.Graph(),
+    Component.DesktopOnly(Component.TableOfContents()),
+    Component.Backlinks(),
+  ],
+}
+
+// List page (folder / tag index). Same sidebar shape, no graph on
+// the right — list pages don't have meaningful in-vault links to
+// graph.
+export const defaultListPageLayout: PageLayout = {
+  beforeBody: [
+    Component.Breadcrumbs(),
+    Component.ArticleTitle(),
+    Component.ContentMeta(),
+  ],
+  left: [
+    Component.PageTitle(),
+    Component.MobileOnly(Component.Spacer()),
+    Component.Flex({
+      components: [
+        { Component: Component.Search(), grow: true },
+        { Component: Component.Darkmode() },
+      ],
+    }),
+    Component.Explorer(),
+  ],
+  right: [],
+}

--- a/stacklets/memory/quartz/quartz.layout.ts
+++ b/stacklets/memory/quartz/quartz.layout.ts
@@ -1,5 +1,5 @@
 /**
- * quartz.layout.ts — memory garden
+ * quartz.layout.ts — family wiki
  *
  * Tracks the upstream v4 layout (graph + backlinks + search) with
  * one change: the footer's links table points at the Forgejo

--- a/stacklets/memory/seeds/index.md
+++ b/stacklets/memory/seeds/index.md
@@ -1,0 +1,15 @@
+---
+title: Family Memory
+---
+
+# Family Memory
+
+Welcome to your family's memory, a living wiki built from the documents
+you file and the notes you save. It runs on your own server, and it is
+entirely yours.
+
+Use the **search** box at the top left to find anything, or browse the
+folders in the sidebar. Each page links back to where it came from.
+
+To add or edit a page, open the **family/memory** repository in Forgejo.
+Every change is saved as a version you can always look back on.

--- a/stacklets/memory/stacklet.toml
+++ b/stacklets/memory/stacklet.toml
@@ -5,30 +5,44 @@
 # the commit log doubles as the learning history: every fact added,
 # every wiki edit, every reclassification is a diff you can revert.
 #
-# Today memory is a host stacklet with no container. It ships seeds and
-# a few hooks. Bots and CLIs talk to its lib in-process; reads and writes
-# round-trip through Forgejo so there is one source of truth.
+# Memory is a host stacklet that *also* runs one container: the garden,
+# a Quartz site that renders the vault as a browsable, mobile-friendly
+# wiki. The hooks still own the data plane (clone, pull, push); the
+# container is a derived, read-only view that watches the bind-mounted
+# working copy and rebuilds on change. There is one source of truth
+# (Forgejo) — the garden is just a nicer pair of eyes on it.
 #
-# A service (e.g. a deriver bot that consumes structured Matrix events
-# and synthesises wiki pages) may join later. The stacklet shape is
-# ready for that — just add hooks/on_start_ready.py and a service
-# definition when needed.
+# Edits still happen in Forgejo: the garden renders pages with an
+# "edit on Forgejo" link, so every change lands as a real commit.
 
 id          = "memory"
 name        = "Memory"
 description = "Persistent knowledge — ontology, facts, and wiki — backed by Forgejo"
-version     = "0.3.0"
+version     = "0.4.0"
 category    = "infrastructure"
 type        = "host"
 requires    = ["code"]
 
+# The garden container is built locally from the Dockerfile in this
+# directory — there is no upstream image to pull. `build = true` tells
+# the runtime to `docker compose build` on every `stack up`, so config
+# tweaks (`quartz/*.ts`) land without manual image management.
+build = true
+
+# LAN port for the garden's Quartz preview server. Sits at the end of
+# the 42xxx range used by other stacklets so future infra ports stay
+# easy to scan.
+port = 42070
+
 hints = [
-    "Memory lives in the Forgejo `memory` repo — edit ontology.toml or wiki/*.md in the web UI to grow it",
+    "Read the family memory at {url}",
+    "Edit pages in Forgejo (`family/memory` repo) — every save is a commit",
 ]
 
-# Memory has no container of its own — hooks run on the host and talk
-# to Forgejo over HTTP. These env vars are what `on_install_success.py`
-# reads to find the code stacklet and authenticate as the tech admin.
+# Host-side env vars are read by the install / start hooks (they run on
+# the host and talk to Forgejo over HTTP). Container-side env vars are
+# read by the garden through `env_file: .env`. Both surfaces share this
+# table — names that don't apply to a given surface are simply ignored.
 [env.defaults]
 CODE_URL       = "{code_url}"
 ADMIN_USER     = "{admin_username}"
@@ -38,3 +52,14 @@ ADMIN_PASSWORD = "{admin_password}"
 # marge, ...) live at <vault>/<localpart>/. Sourced from stack.toml
 # [core] shared_bucket, defaults to "family".
 SHARED_BUCKET  = "{shared_bucket}"
+
+# Bind-mount source for the garden container. Resolves to the same
+# working copy that the hooks clone into — `memory.lib.vault_path_for`
+# also returns this path, so there is exactly one vault on disk.
+MEMORY_VAULT_DIR = "{data_dir}/memory/vault"
+
+# Public hostname the garden renders into absolute URLs (sitemap,
+# social cards, etc). Empty domain (port mode) falls back to the
+# auto-detected LAN IP via `{ip}` so the site stays reachable.
+GARDEN_HOST = "memory.{domain}"
+GARDEN_IP   = "{ip}"

--- a/stacklets/memory/stacklet.toml
+++ b/stacklets/memory/stacklet.toml
@@ -5,14 +5,14 @@
 # the commit log doubles as the learning history: every fact added,
 # every wiki edit, every reclassification is a diff you can revert.
 #
-# Memory is a host stacklet that *also* runs one container: the garden,
+# Memory is a host stacklet that *also* runs one container: the wiki,
 # a Quartz site that renders the vault as a browsable, mobile-friendly
 # wiki. The hooks still own the data plane (clone, pull, push); the
 # container is a derived, read-only view that watches the bind-mounted
 # working copy and rebuilds on change. There is one source of truth
-# (Forgejo) — the garden is just a nicer pair of eyes on it.
+# (Forgejo) — the wiki is just a nicer pair of eyes on it.
 #
-# Edits still happen in Forgejo: the garden renders pages with an
+# Edits still happen in Forgejo: the wiki renders pages with an
 # "edit on Forgejo" link, so every change lands as a real commit.
 
 id          = "memory"
@@ -23,25 +23,25 @@ category    = "infrastructure"
 type        = "host"
 requires    = ["code"]
 
-# The garden container is built locally from the Dockerfile in this
+# The wiki container is built locally from the Dockerfile in this
 # directory — there is no upstream image to pull. `build = true` tells
 # the runtime to `docker compose build` on every `stack up`, so config
 # tweaks (`quartz/*.ts`) land without manual image management.
 build = true
 
-# LAN port for the garden's Quartz preview server. Sits at the end of
+# LAN port for the wiki's Quartz preview server. Sits at the end of
 # the 42xxx range used by other stacklets so future infra ports stay
 # easy to scan.
 port = 42070
 
 hints = [
-    "Read the family memory at {url}",
+    "Read the family wiki at {url}",
     "Edit pages in Forgejo (`family/memory` repo) — every save is a commit",
 ]
 
 # Host-side env vars are read by the install / start hooks (they run on
 # the host and talk to Forgejo over HTTP). Container-side env vars are
-# read by the garden through `env_file: .env`. Both surfaces share this
+# read by the wiki through `env_file: .env`. Both surfaces share this
 # table — names that don't apply to a given surface are simply ignored.
 [env.defaults]
 CODE_URL       = "{code_url}"
@@ -53,13 +53,13 @@ ADMIN_PASSWORD = "{admin_password}"
 # [core] shared_bucket, defaults to "family".
 SHARED_BUCKET  = "{shared_bucket}"
 
-# Bind-mount source for the garden container. Resolves to the same
+# Bind-mount source for the wiki container. Resolves to the same
 # working copy that the hooks clone into — `memory.lib.vault_path_for`
 # also returns this path, so there is exactly one vault on disk.
 MEMORY_VAULT_DIR = "{data_dir}/memory/vault"
 
-# Public hostname the garden renders into absolute URLs (sitemap,
+# Public hostname the wiki renders into absolute URLs (sitemap,
 # social cards, etc). Empty domain (port mode) falls back to the
 # auto-detected LAN IP via `{ip}` so the site stays reachable.
-GARDEN_HOST = "memory.{domain}"
-GARDEN_IP   = "{ip}"
+WIKI_HOST = "wiki.{domain}"
+WIKI_IP   = "{ip}"

--- a/stacklets/messages/cli/_matrix.py
+++ b/stacklets/messages/cli/_matrix.py
@@ -295,3 +295,60 @@ class MatrixClient:
         if status == 200:
             return True, resp.get("event_id", "sent")
         return False, resp.get("error", "unknown error")
+
+    def join(self, room):
+        """Join a room by alias or ID as the logged-in user. Idempotent —
+        Synapse returns 200 if you are already a member."""
+        target = room if room.startswith("!") else self._full_room(room)
+        encoded = urllib.request.quote(target)
+        status, _ = _post(
+            self._url(f"/_matrix/client/v3/join/{encoded}"), {}, token=self.token,
+        )
+        return status == 200
+
+    def upload_media(self, data, content_type, filename):
+        """Upload raw bytes to the Matrix media repo; return the mxc:// URI.
+
+        Not routed through `_api` because that JSON-encodes the body — a
+        media upload POSTs the file bytes verbatim with the file's own
+        content type. Returns None on failure.
+        """
+        url = self._url(
+            f"/_matrix/media/v3/upload?filename={urllib.request.quote(filename)}"
+        )
+        req = urllib.request.Request(
+            url, data=data, method="POST",
+            headers={"Content-Type": content_type,
+                     "Authorization": f"Bearer {self.token}"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60, context=_SSL) as resp:
+                return json.loads(resp.read().decode()).get("content_uri")
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+            return None
+
+    def send_file(self, room, mxc_uri, filename, mime, *, msgtype="m.file", size=0):
+        """Post a file/image message referencing an already-uploaded mxc URI.
+
+        `msgtype` is "m.file" for documents or "m.image" for pictures —
+        the archivist keys its handling on this. Returns (ok, detail).
+        """
+        room_id = room if room.startswith("!") else self.resolve_room(room)
+        if not room_id:
+            return False, f"Room '{room}' not found"
+
+        txn = f"{int(time.time() * 1000)}_{random.randint(0, 0xFFFFFFFF):08x}"
+        body = {
+            "msgtype": msgtype,
+            "body": filename,
+            "url": mxc_uri,
+            "info": {"mimetype": mime, "size": size},
+        }
+        status, resp = _put(
+            self._url(f"/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn}"),
+            body,
+            token=self.token,
+        )
+        if status == 200:
+            return True, resp.get("event_id", "sent")
+        return False, resp.get("error", "unknown error")

--- a/stacklets/messages/cli/upload.py
+++ b/stacklets/messages/cli/upload.py
@@ -1,0 +1,124 @@
+"""
+stack messages upload <room> <path> [--as <user>] — post a file to a room
+
+Uploads a local file (PDF, image, anything) to a Matrix room as a file or
+image message. This is the file counterpart to `stack messages send`, and
+the building block for ingesting documents the way a family member would:
+the archivist watches the documents room and files whatever lands there.
+
+By default the file is posted as stacker-bot (the system account). Pass
+`--as <user>` to post as a family member instead, e.g.
+
+    stack messages upload documents payslip.pdf --as homer
+
+The user's password is read from the secrets store (the same place the
+account was created), so the sender shows up correctly in the timeline and
+the archivist's "received from <name>" reply. Images (.png/.jpg) are sent
+as m.image; everything else as m.file.
+"""
+
+HELP = "Upload a file to a chat room"
+
+import sys
+from pathlib import Path
+
+_here = Path(__file__).parent
+sys.path.insert(0, str(_here))
+from _matrix import MatrixClient
+
+# Extension → (mime type, Matrix msgtype). Images go as m.image so the
+# archivist takes its vision path; everything else is m.file.
+_MIME = {
+    ".pdf": ("application/pdf", "m.file"),
+    ".png": ("image/png", "m.image"),
+    ".jpg": ("image/jpeg", "m.image"),
+    ".jpeg": ("image/jpeg", "m.image"),
+    ".webp": ("image/webp", "m.image"),
+    ".gif": ("image/gif", "m.image"),
+    ".txt": ("text/plain", "m.file"),
+}
+
+
+def _parse_argv(argv):
+    """Pull (room, path, sender) out of argv. sender is None unless --as."""
+    sender = None
+    rest = []
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--as":
+            if i + 1 >= len(argv):
+                return None, None, None, "--as needs a username"
+            sender = argv[i + 1]
+            i += 2
+            continue
+        rest.append(argv[i])
+        i += 1
+    if len(rest) < 2:
+        return None, None, None, 'Usage: stack messages upload <room> <path> [--as <user>]'
+    return rest[0], rest[1], sender, None
+
+
+def _resolve_login(sender, secrets):
+    """(username, password) for the sender. --as <user> reads
+    global__USER_<NAME>_PASSWORD; the default is stacker-bot."""
+    if sender:
+        key = f"global__USER_{sender.upper()}_PASSWORD"
+        password = secrets.get(key, "")
+        if not password:
+            return None, None, f"No password for '{sender}' in secrets ({key})"
+        return sender, password, None
+    bot_pass = (secrets.get("core__STACKER_BOT_PASSWORD")
+                or secrets.get("messages__STACKER_BOT_PASSWORD", ""))
+    if not bot_pass:
+        return None, None, "stacker-bot not set up. Run 'stack up core' first."
+    return "stacker-bot", bot_pass, None
+
+
+def run(args, stacklet, config):
+    if not config["is_healthy"]():
+        return {"error": "Messages is not running — start it with 'stack up messages'"}
+
+    # sys.argv: ['stack', 'messages', 'upload', <room>, <path>, ...]
+    room, path_str, sender, err = _parse_argv(sys.argv[3:])
+    if err:
+        return {"error": err}
+
+    path = Path(path_str)
+    if not path.is_file():
+        return {"error": f"File not found: {path}"}
+
+    mime, msgtype = _MIME.get(path.suffix.lower(), ("application/octet-stream", "m.file"))
+
+    instance_dir = config.get("instance_dir", config.get("repo_root", "."))
+    stack_cfg = config.get("stack", {})
+    secrets = config.get("secrets", {})
+    server_name = stack_cfg.get("messages", {}).get("server_name", "home")
+
+    username, password, err = _resolve_login(sender, secrets)
+    if err:
+        return {"error": err}
+
+    manifest = config.get("manifest", {})
+    synapse_port = manifest.get("ports", {}).get("synapse", 42031)
+    base_url = f"http://localhost:{synapse_port}"
+
+    client = MatrixClient(base_url, server_name, instance_dir)
+    if not client.login(username, password):
+        return {"error": f"{username} can't log in — check the password in secrets."}
+
+    # Best-effort join so a family member who isn't yet in the room can
+    # still post. Harmless if already a member.
+    client.join(room)
+
+    data = path.read_bytes()
+    mxc = client.upload_media(data, mime, path.name)
+    if not mxc:
+        return {"error": f"Media upload failed for {path.name}"}
+
+    ok, detail = client.send_file(
+        room, mxc, path.name, mime, msgtype=msgtype, size=len(data),
+    )
+    if ok:
+        return {"ok": True, "room": room, "as": username,
+                "file": path.name, "event_id": detail}
+    return {"error": f"Failed to post file: {detail}"}

--- a/stacklets/messages/hooks/on_install.sh
+++ b/stacklets/messages/hooks/on_install.sh
@@ -117,8 +117,14 @@ config = {
     "url_preview_enabled": True,
     "url_preview_ip_range_blacklist": [],
 
-    # Keep everything forever — it's your own server
+    # Messages and media are kept forever — it's your own server.
+    # (retention disabled; media_retention left unset = Synapse never purges media)
     "retention": {"enabled": False},
+
+    # Redactions ARE honored: deleting a message eventually purges the
+    # original content from the DB. We widen Synapse's 7d default to 30d so
+    # an accidental delete has a month to be noticed before it's gone for good.
+    "redaction_retention_period": "30d",
 
     # Voice/video calls — STUN helps devices find each other.
     # Works for LAN calls out of the box. For calls across networks,

--- a/tests/framework/test_ai_on_start.py
+++ b/tests/framework/test_ai_on_start.py
@@ -1,0 +1,59 @@
+"""ai on_start hook: STACK_AI_NO_VOICE gates the voice compose profile.
+
+This is the behavior that `stack up ai --no-voice` (and the bare
+STACK_AI_NO_VOICE=1 env var) relies on: when set, on_start clears the
+"voice" compose profile so docker skips the Piper TTS container. With a
+configured provider the hook does no docker or network work, so this runs
+fast and offline.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO / "lib"))
+
+
+def _load_on_start():
+    # on_start.py lives under stacklets/ai/hooks/, not in a package.
+    path = REPO / "stacklets" / "ai" / "hooks" / "on_start.py"
+    spec = importlib.util.spec_from_file_location("ai_on_start", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ctx(make_stack, env):
+    from stack.hooks import StackContext
+
+    stck = make_stack()
+    stck._set_cfg("ai", "provider", "managed")  # so on_start doesn't bail early
+    return StackContext(stck, "ai", env)
+
+
+@pytest.fixture(autouse=True)
+def _restore_no_voice():
+    old = os.environ.get("STACK_AI_NO_VOICE")
+    yield
+    if old is None:
+        os.environ.pop("STACK_AI_NO_VOICE", None)
+    else:
+        os.environ["STACK_AI_NO_VOICE"] = old
+
+
+def test_no_voice_clears_compose_profile(make_stack):
+    os.environ["STACK_AI_NO_VOICE"] = "1"
+    env = {"COMPOSE_PROFILES": "voice"}
+    _load_on_start().run(_ctx(make_stack, env))
+    assert env["COMPOSE_PROFILES"] == ""
+
+
+def test_voice_profile_kept_by_default(make_stack):
+    os.environ.pop("STACK_AI_NO_VOICE", None)
+    env = {"COMPOSE_PROFILES": "voice"}
+    _load_on_start().run(_ctx(make_stack, env))
+    assert env["COMPOSE_PROFILES"] == "voice"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -333,8 +333,30 @@ def code(test_stack) -> ForgejoAPI:
     )
 
 
+@pytest.fixture(scope="session")
+def memory_repo(code) -> None:
+    """Provision the family/memory repo the way the memory stacklet does.
+
+    The archivist mirror writes into this repo but no longer creates it —
+    the memory stacklet owns org, repo, and seed creation. This invokes
+    memory's own provisioning lib (no Quartz container needed) so the e2e
+    exercises the real ownership split: memory creates, archivist consumes.
+    """
+    mem_dir = REPO_ROOT / "stacklets" / "memory"
+    if str(mem_dir) not in sys.path:
+        sys.path.insert(0, str(mem_dir))
+    from stack.forgejo import ForgejoClient
+    import lib as memory_lib
+
+    client = ForgejoClient(
+        url=code.url, admin_user=code.admin_user, admin_password=code.admin_password,
+    )
+    memory_lib.ensure_memory_repo(client)
+    memory_lib.install_seeds(client)
+
+
 @pytest.fixture
-def mirror_scope(code, scope) -> Scope:
+def mirror_scope(code, memory_repo, scope) -> Scope:
     """Scope bound to mirror cleanup — on teardown, every file in the
     `memory` repo whose frontmatter title starts with scope.uid is
     deleted. The repo + bot user + seeds survive between tests."""

--- a/tests/stacklets/test_microbot.py
+++ b/tests/stacklets/test_microbot.py
@@ -44,9 +44,20 @@ class FakeClient:
         # key yields a response whose `.event` is None (parent not found).
         self.parent_events: dict[str, object] = {}
         self.get_event_raises: BaseException | None = None
+        # Drain surface: the timeline (newest-first), the rooms map, and a
+        # sync token. room_messages returns the whole timeline in one page.
+        self.next_batch = "END"
+        self.rooms: dict = {}
+        self.timeline: list = []
 
     def add_event_callback(self, cb, event_type):
         self.callbacks.append((cb, event_type))
+
+    async def room_messages(self, room_id, start, direction, limit):
+        from nio import RoomMessagesResponse
+        return RoomMessagesResponse(
+            room_id=room_id, chunk=list(self.timeline), start=start, end=None,
+        )
 
     async def room_typing(self, room_id, typing_state, timeout):
         if self.typing_raises is not None:
@@ -87,8 +98,10 @@ def _build_bot(tmp_path, *, handler) -> tuple[MicroBot, FakeClient]:
         session_dir=str(tmp_path),
     )
     bot._client = FakeClient()
-    bot.add_event_callback(handler, "RoomMessageText")
-    bot._wrapper = bot._client.callbacks[0][0]
+    # `object` matches any synthetic event in the drain's isinstance check;
+    # the wrapper-contract tests invoke bot._wrapper directly and ignore it.
+    bot.add_event_callback(handler, object)
+    bot._wrapper = bot._handlers[0][1]
     return bot, bot._client
 
 
@@ -172,24 +185,70 @@ class TestSkipCases:
         assert ran == []
         assert client.typing_calls == []
 
+
+# ── Drain: the timeline is the queue ────────────────────────────────────────
+
+
+class TestDrain:
+    """The drain is the delivery path: it reads the timeline past the
+    per-room cursor and dispatches oldest-first, advancing the cursor
+    after each handler returns (at-least-once). Dedup and ordering live
+    here now, not in the wrapper."""
+
     @pytest.mark.asyncio
-    async def test_replay_event_skipped(self, tmp_path):
-        ran = []
+    async def test_dispatches_past_cursor_oldest_first_and_advances(self, tmp_path):
+        seen = []
 
         async def handler(room, event):
-            ran.append(True)
+            seen.append(event.server_timestamp)
 
         bot, client = _build_bot(tmp_path, handler=handler)
-        # First event advances the cursor.
-        await bot._wrapper(_room(), _event(ts=5))
-        # Older / equal timestamp must be dropped.
-        await bot._wrapper(_room(), _event(ts=5))
-        await bot._wrapper(_room(), _event(ts=4))
+        room = _room()
+        client.rooms = {room.room_id: room}
+        bot._cursors[room.room_id] = 5
+        # Timeline newest-first; only ts > 5 runs, and oldest-first.
+        client.timeline = [_event(ts=7), _event(ts=6), _event(ts=5), _event(ts=4)]
 
-        assert ran == [True]  # only the first ran
-        # Framework only clears typing on the one event that actually
-        # ran — replay-skipped events return before reaching the wrap.
-        assert client.typing_calls == [("!r:server", False)]
+        await bot._drain()
+
+        assert seen == [6, 7]
+        assert bot._cursors[room.room_id] == 7
+
+    @pytest.mark.asyncio
+    async def test_own_messages_skipped_but_cursor_advances(self, tmp_path):
+        seen = []
+
+        async def handler(room, event):
+            seen.append(event.server_timestamp)
+
+        bot, client = _build_bot(tmp_path, handler=handler)
+        room = _room()
+        client.rooms = {room.room_id: room}
+        bot._cursors[room.room_id] = 0
+        client.timeline = [_event(ts=10, sender="@test-bot:server")]
+
+        await bot._drain()
+
+        assert seen == []                        # the bot's own message does nothing
+        assert bot._cursors[room.room_id] == 10  # but the cursor moves past it
+
+    @pytest.mark.asyncio
+    async def test_first_sight_room_anchors_without_replaying_history(self, tmp_path):
+        seen = []
+
+        async def handler(room, event):
+            seen.append(event.server_timestamp)
+
+        bot, client = _build_bot(tmp_path, handler=handler)
+        room = _room()
+        client.rooms = {room.room_id: room}
+        client.timeline = [_event(ts=100), _event(ts=99)]
+        assert room.room_id not in bot._cursors
+
+        await bot._drain()
+
+        assert seen == []                       # history is not replayed
+        assert bot._cursors[room.room_id] > 0   # cursor anchored at ~now
 
 
 # ── Timeout ──────────────────────────────────────────────────────────────

--- a/tools/family-docs/.gitignore
+++ b/tools/family-docs/.gitignore
@@ -1,0 +1,2 @@
+# Rendered artifacts are disposable — the specs are the source of truth.
+out/

--- a/tools/family-docs/README.md
+++ b/tools/family-docs/README.md
@@ -1,0 +1,154 @@
+# family-docs
+
+A generator for a demo set of family documents, set in the Simpsons
+world. It renders realistic PDFs and images (pay slips, invoices,
+contracts, receipts, birth certificates, a kid's crayon drawing) that
+you can feed into a famstack instance to populate Paperless and the
+memory wiki for screenshots, screencasts, and end-to-end testing.
+
+The **specs are the source of truth** (plain YAML, one file per
+document). The rendered files are disposable artifacts you regenerate.
+
+## Quick start
+
+```sh
+# render every English document into out/en/
+uv run --extra demo python tools/family-docs/generate.py
+
+# list the set without rendering
+uv run --extra demo python tools/family-docs/generate.py --list
+
+# render a subset (substring match on the spec name)
+uv run --extra demo python tools/family-docs/generate.py --only receipt
+uv run --extra demo python tools/family-docs/generate.py --only car-insurance
+```
+
+Output lands in `out/<locale>/` (gitignored). Filing those documents
+into a running stack is a separate step (they are uploaded into the
+Matrix `#documents` room so the archivist files them the same way a
+family member would).
+
+## How it works
+
+```
+specs/en/*.yaml   →   generate.py   →   renderers.py   →   out/en/*.{pdf,png}
+   (you edit)          (discovery)       (reportlab /        (disposable)
+                                          Pillow)
+```
+
+`generate.py` reads each spec, dispatches it to a renderer based on the
+spec's `render` field, and writes the result. `renderers.py` is the only
+module that touches reportlab and Pillow, so adding a new output format
+is a new function there, not a change to every spec.
+
+Dependencies live in the `demo` extra in `pyproject.toml`
+(`reportlab`, `Pillow`, `pyyaml`). They are host-side tooling only and
+are **not** needed to run the stack.
+
+## Adding a document
+
+Drop a new `specs/en/<name>.yaml`. Re-run the generator. That's it.
+
+Every spec has a `render` field that selects the look, an optional
+`filename` (defaults to `<name>.pdf`), and an optional `expected` block
+that documents the classification you'd expect the archivist to produce
+(it is also handy as future eval ground truth; it is not rendered).
+
+### `render: pdf` — clean native-text business document
+
+One block-based layout expresses letters, invoices, pay slips,
+statements, report cards, contracts, prescriptions, and recipes. The
+text layer is real, so the classifier reads actual text.
+
+```yaml
+render: pdf
+filename: example.pdf
+accent: "#1b5e20"           # brand colour for the letterhead + table header
+letterhead:
+  name: Issuer Name
+  lines: [Street, "City, ST 00000"]
+recipient:                  # optional
+  name: Homer J. Simpson
+  lines: ["742 Evergreen Terrace", "Springfield, OR 97401"]
+title: Document Title
+meta:                       # optional key/value box, top right
+  Reference: ABC-123
+  Date: 01 Jan 2026
+blocks:                     # the body, rendered in order
+  - p: "A paragraph of text."
+  - heading: A Section Heading
+  - bullets: ["first point", "second point"]
+  - table:
+      columns: [Description, Amount]
+      align: [L, R]         # optional; default first col L, rest R
+      rows:
+        - ["Line item", "10.00"]
+      total: ["Total", "10.00"]   # optional bold total row
+  - signature: {name: Jane Doe, role: Registrar}
+  - spacer: 12              # optional vertical gap in points
+footer: "Small print at the bottom."
+```
+
+The PDF layout paginates automatically, so a long contract (many
+`heading` + `p` blocks) flows onto multiple pages.
+
+### `render: receipt` — narrow thermal receipt (image)
+
+```yaml
+render: receipt
+filename: shop-receipt.png
+store: STORE NAME
+lines: ["Address line", "Cashier: ..."]
+date: "02 Apr 2026  18:42"
+items:
+  - ["Item name", "1.49"]   # price is the line total
+total: "1.49"
+paid: "Cash"                # "$" is added only to numeric values
+footer: "Thank you!"
+```
+
+### `render: certificate` — aged, scanned-looking certificate (image)
+
+For the older generation's documents (sepia paper, serif title,
+typewriter form fields, inked seal, cursive signature).
+
+```yaml
+render: certificate
+filename: birth-certificate.png
+authority: "Springfield County, State of Oregon, Office of Vital Records"
+title: "Certificate of Birth"
+register_no: "1956-00417"
+seal_text: "VITAL RECORDS"
+fields:                     # rendered as labelled, underlined form rows
+  Name of Child: "Homer Jay Simpson"
+  Date of Birth: "May 12, 1956"
+registrar: "C. Montgomery"  # rendered in a cursive hand
+```
+
+### `render: drawing` — a child's crayon drawing (image)
+
+Mostly visual (exercises the vision path); only the title and caption
+carry text.
+
+```yaml
+render: drawing
+filename: kid-drawing.png
+title: MY FAMLY
+caption: "by Bart Simpson, age 10"
+```
+
+## Adding a language
+
+The German-locale set would live in `specs/de/`. Create the folder,
+translate the spec content (the renderers are language-agnostic), and
+render with `--locale de`. Keep the same filenames across locales so the
+two sets stay easy to compare.
+
+## Notes
+
+- Fonts are loaded from stock macOS faces with a fallback to Pillow's
+  default, so the image renderers degrade to "plain" rather than
+  crashing if a face is missing.
+- Amounts are checked for arithmetic: line items should sum to their
+  stated total. Keep them consistent when editing.
+- Keep written content free of em dashes, to match the project's style.

--- a/tools/family-docs/README.md
+++ b/tools/family-docs/README.md
@@ -45,6 +45,43 @@ Dependencies live in the `demo` extra in `pyproject.toml`
 (`reportlab`, `Pillow`, `pyyaml`). They are host-side tooling only and
 are **not** needed to run the stack.
 
+## Filing them into a running stack
+
+`ingest.py` files the rendered documents into a running instance by
+posting each one into the Matrix `documents` room as the family member
+who would plausibly have uploaded it. The archivist watches that room,
+so each document takes the exact path a real family uses: upload to
+Matrix, then OCR, classify, and mirror into the memory wiki. Matrix
+stays the single ledger; nothing here writes to Paperless directly.
+
+```sh
+# bring the stack up first
+stack up messages docs
+
+# preview who posts what (no network)
+python tools/family-docs/ingest.py --dry-run
+
+# file them for real (spaced out so the archivist keeps up)
+python tools/family-docs/ingest.py
+python tools/family-docs/ingest.py --delay 12   # slower, to watch in Element
+```
+
+Only Homer, Marge, Bart and Lisa have Matrix accounts, so documents that
+belong to Maggie or the household are posted by Marge, the same as in
+real life. The sender mapping lives at the top of `ingest.py`; edit it
+to taste.
+
+Under the hood `ingest.py` drives `stack messages upload`, a general
+primitive added alongside `stack messages send`:
+
+```sh
+stack messages upload documents path/to/file.pdf --as homer
+```
+
+It uploads any file to a room (as a family member with `--as`, or as
+stacker-bot by default), reading the user's password from the secrets
+store. Images go as `m.image`; everything else as `m.file`.
+
 ## Adding a document
 
 Drop a new `specs/en/<name>.yaml`. Re-run the generator. That's it.

--- a/tools/family-docs/generate.py
+++ b/tools/family-docs/generate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""generate.py — render the demo family-document set from specs.
+
+    uv run --extra demo python tools/family-docs/generate.py
+    uv run --extra demo python tools/family-docs/generate.py --list
+    uv run --extra demo python tools/family-docs/generate.py --only payslip
+
+Reads ``specs/<locale>/*.yaml`` and writes rendered PDFs/PNGs to
+``out/<locale>/``. The output directory is gitignored — the specs are
+the source of truth, the rendered files are disposable artifacts you
+regenerate (and then feed into the stack via the Matrix ingestion step).
+
+Adding a document is "drop one YAML in specs/<locale>/"; see README.md
+for the spec schema. Adding a language is "create specs/<locale>/".
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+
+import renderers  # noqa: E402  (needs the sys.path insert above)
+
+
+def _specs_dir(locale: str) -> Path:
+    return HERE / "specs" / locale
+
+
+def _load_specs(locale: str, only: str | None) -> list[tuple[Path, dict]]:
+    """Load every spec for ``locale`` (optionally filtered by ``only``)."""
+    specs_dir = _specs_dir(locale)
+    if not specs_dir.is_dir():
+        sys.exit(f"no specs for locale {locale!r} — expected {specs_dir}")
+    out = []
+    for path in sorted(specs_dir.glob("*.yaml")):
+        if only and only not in path.stem:
+            continue
+        spec = yaml.safe_load(path.read_text())
+        spec.setdefault("filename", f"{path.stem}.pdf")
+        out.append((path, spec))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Render the demo family-document set.")
+    ap.add_argument("--locale", default="en", help="spec locale subfolder (default: en)")
+    ap.add_argument("--only", help="render only specs whose name contains this substring")
+    ap.add_argument("--out", help="output directory (default: out/<locale>)")
+    ap.add_argument("--list", action="store_true", help="list specs and exit")
+    args = ap.parse_args(argv)
+
+    specs = _load_specs(args.locale, args.only)
+    if not specs:
+        sys.exit("no matching specs")
+
+    if args.list:
+        for path, spec in specs:
+            exp = spec.get("expected", {})
+            tail = f"  [{exp.get('document_type', '?')}]" if exp else ""
+            print(f"  {path.stem:<28} {spec.get('render', '?'):<8} → {spec['filename']}{tail}")
+        return 0
+
+    out_dir = Path(args.out) if args.out else HERE / "out" / args.locale
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rendered = 0
+    for path, spec in specs:
+        try:
+            filename, data = renderers.render(spec)
+        except Exception as e:  # one bad spec shouldn't sink the batch
+            print(f"  ✗ {path.name}: {e}", file=sys.stderr)
+            continue
+        (out_dir / filename).write_bytes(data)
+        print(f"  ✓ {filename:<34} {len(data) // 1024:>4} KB")
+        rendered += 1
+
+    print(f"\n{rendered}/{len(specs)} documents → {out_dir}")
+    return 0 if rendered == len(specs) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/family-docs/ingest.py
+++ b/tools/family-docs/ingest.py
@@ -89,8 +89,20 @@ def main(argv: list[str]) -> int:
     if not files:
         sys.exit("no documents to ingest")
 
+    senders = sorted({SENDERS.get(p.stem, DEFAULT_SENDER) for p in files})
+
     print(f"{'(dry run) ' if args.dry_run else ''}filing {len(files)} documents "
-          f"into '{args.room}':\n")
+          f"into '{args.room}' as {', '.join(senders)}:\n")
+
+    if not args.dry_run:
+        # Family members must be a member of the room to post into it.
+        # Force-join the senders once up front (idempotent) via the
+        # sanctioned admin command, so an upload never fails with
+        # "user not in room".
+        subprocess.run(
+            [str(STACK), "messages", "join", args.room, *senders],
+            cwd=REPO_ROOT,
+        )
 
     failures = 0
     for i, path in enumerate(files):

--- a/tools/family-docs/ingest.py
+++ b/tools/family-docs/ingest.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""ingest.py — file the rendered demo documents into a running stack.
+
+Posts each rendered document into the Matrix `documents` room as the
+family member who would plausibly have uploaded it, by driving the real
+`stack messages upload` CLI. The archivist watches that room, so each
+document flows through the exact path a family uses: upload to Matrix ->
+OCR -> classify -> mirror to the memory wiki. Matrix stays the ledger;
+nothing here talks to Paperless or the pipeline directly.
+
+    # see what would be posted, by whom (no network)
+    python tools/family-docs/ingest.py --dry-run
+
+    # actually file them into the running instance
+    python tools/family-docs/ingest.py
+
+    # slower, to watch each one land in Element
+    python tools/family-docs/ingest.py --delay 12
+
+Requires the stack to be up (`stack up messages docs`) and the family
+accounts to exist with passwords in the secrets store. Only Homer,
+Marge, Bart and Lisa have accounts; documents that belong to Maggie (or
+the household) are uploaded by Marge, the same as in real life.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+STACK = REPO_ROOT / "stack"
+
+# Who uploads what. Personal documents come from their owner; household,
+# baby, and school paperwork come from Marge, who runs the household.
+# Bart proudly posts his own drawing; Lisa, her straight-A report card.
+SENDERS = {
+    "homer-payslip": "homer",
+    "homer-employment-contract": "homer",
+    "homer-car-insurance-policy": "homer",
+    "homer-bank-statement": "homer",
+    "homer-prescription": "homer",
+    "homer-tax-assessment": "homer",
+    "homer-birth-certificate": "homer",
+    "springfield-mortgage-agreement": "homer",
+    "slh-vet-invoice": "homer",
+    "kwik-e-mart-receipt": "homer",
+    "moes-tavern-tab": "homer",
+    "texxon-gas-receipt": "homer",
+    "springfield-power-electricity-bill": "marge",
+    "marge-hospital-invoice": "marge",
+    "marge-recipe-card": "marge",
+    "marge-birth-certificate": "marge",
+    "maggie-vaccination-record": "marge",
+    "maggie-birth-certificate": "marge",
+    "lisa-birth-certificate": "marge",
+    "bart-birth-certificate": "marge",
+    "bart-behavior-letter": "marge",
+    "pta-meeting-minutes": "marge",
+    "lisa-report-card": "lisa",
+    "bart-drawing": "bart",
+    "krusty-burger-receipt": "bart",
+}
+DEFAULT_SENDER = "marge"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="File rendered demo documents via Matrix.")
+    ap.add_argument("--locale", default="en", help="which out/<locale> to ingest (default: en)")
+    ap.add_argument("--room", default="documents", help="target Matrix room (default: documents)")
+    ap.add_argument("--delay", type=float, default=6.0,
+                    help="seconds to wait between uploads (default: 6)")
+    ap.add_argument("--only", help="ingest only files whose name contains this substring")
+    ap.add_argument("--dry-run", action="store_true", help="print the plan, post nothing")
+    args = ap.parse_args(argv)
+
+    out_dir = HERE / "out" / args.locale
+    if not out_dir.is_dir():
+        sys.exit(f"no rendered documents at {out_dir} — run generate.py first")
+
+    files = sorted(p for p in out_dir.iterdir()
+                   if p.suffix.lower() in (".pdf", ".png", ".jpg", ".jpeg"))
+    if args.only:
+        files = [p for p in files if args.only in p.stem]
+    if not files:
+        sys.exit("no documents to ingest")
+
+    print(f"{'(dry run) ' if args.dry_run else ''}filing {len(files)} documents "
+          f"into '{args.room}':\n")
+
+    failures = 0
+    for i, path in enumerate(files):
+        sender = SENDERS.get(path.stem, DEFAULT_SENDER)
+        print(f"  {sender:>6}  →  {path.name}")
+        if args.dry_run:
+            continue
+        result = subprocess.run(
+            [str(STACK), "messages", "upload", args.room, str(path), "--as", sender],
+            cwd=REPO_ROOT,
+        )
+        if result.returncode != 0:
+            failures += 1
+            print(f"          ! upload failed for {path.name}")
+        # Space uploads out so the archivist files them one at a time and
+        # the timeline stays ordered. Skip the wait after the last one.
+        if args.delay and i < len(files) - 1:
+            time.sleep(args.delay)
+
+    if args.dry_run:
+        print(f"\n(dry run) {len(files)} documents would be filed. "
+              f"Re-run without --dry-run to post them.")
+        return 0
+    print(f"\n{len(files) - failures}/{len(files)} documents filed into '{args.room}'.")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/family-docs/renderers.py
+++ b/tools/family-docs/renderers.py
@@ -1,0 +1,540 @@
+"""renderers.py — turn one document spec into a file (PDF or PNG bytes).
+
+Specs are plain data (see specs/*.yaml). This module is the only place
+that touches reportlab and Pillow, so adding a new output format means
+adding a function here, not changing every spec.
+
+Three rendering paths, picked by the spec's top-level ``render`` field:
+
+    pdf       A native-text PDF via reportlab. One block-based layout
+              expresses letters, invoices, pay slips, statements, report
+              cards, contracts, prescriptions and recipes — by composing
+              a letterhead, an optional recipient + meta header, a list
+              of content blocks (paragraph / heading / table / bullets /
+              signature) and a footer. The text layer is real, so the
+              archivist's classifier reads actual text rather than OCR
+              guesses.
+
+    receipt   A narrow thermal-receipt PNG via Pillow (monospaced, a
+              little sensor noise, a slight skew). Lands on the scanned
+              image / OCR path the way a phone photo of a receipt would.
+
+    drawing   A child's crayon drawing PNG via Pillow. Exercises the
+              vision path and the "Memory" tag — there's barely any text
+              to OCR, so classification leans on the image itself.
+
+Every renderer returns ``(filename, data: bytes)``. The ``expected``
+block some specs carry is documentation (and future eval ground truth);
+it is ignored here.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+# ── Fonts ────────────────────────────────────────────────────────────────
+#
+# Pillow needs a font file on disk; it ships none. We probe a short list
+# of faces that exist on a stock macOS install and fall back to Pillow's
+# bundled bitmap font so a missing face degrades to "plain" rather than
+# crashing. reportlab brings its own Type-1 fonts, so the PDF path needs
+# none of this.
+
+from PIL import Image, ImageDraw, ImageFont
+
+_MONO_FACES = [
+    "/System/Library/Fonts/Menlo.ttc",
+    "/System/Library/Fonts/Supplemental/Courier New.ttf",
+]
+_CRAYON_FACES = [
+    "/System/Library/Fonts/Supplemental/Chalkduster.ttf",
+    "/System/Library/Fonts/MarkerFelt.ttc",
+    "/System/Library/Fonts/Supplemental/Comic Sans MS.ttf",
+]
+_SANS_FACES = [
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+]
+_SERIF_FACES = [
+    "/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+    "/System/Library/Fonts/Times.ttc",
+    "/System/Library/Fonts/Supplemental/Georgia.ttf",
+]
+_DECO_FACES = [
+    "/System/Library/Fonts/Supplemental/Didot.ttc",
+    "/System/Library/Fonts/Supplemental/Bodoni 72.ttc",
+    "/System/Library/Fonts/Supplemental/Baskerville.ttc",
+]
+_SCRIPT_FACES = [
+    "/System/Library/Fonts/SnellRoundhand.ttc",
+    "/System/Library/Fonts/Supplemental/Zapfino.ttf",
+]
+
+
+def _font(candidates: list[str], size: int) -> ImageFont.FreeTypeFont:
+    """First loadable face from ``candidates`` at ``size``, else default."""
+    for path in candidates:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default(size=size)
+
+
+# ── Dispatch ───────────────────────────────────────────────────────────────
+
+
+def render(spec: dict) -> tuple[str, bytes]:
+    """Render ``spec`` to ``(filename, bytes)``; raise on unknown kind."""
+    kind = spec.get("render")
+    renderer = {
+        "pdf": render_pdf,
+        "receipt": render_receipt,
+        "drawing": render_drawing,
+        "certificate": render_certificate,
+    }.get(kind)
+    if renderer is None:
+        raise ValueError(f"unknown render kind {kind!r} in {spec.get('filename', '?')}")
+    return spec["filename"], renderer(spec)
+
+
+# ── PDF (reportlab) ──────────────────────────────────────────────────────
+
+
+def render_pdf(spec: dict) -> bytes:
+    """Compose a one-page business document from the spec's blocks."""
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_RIGHT
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import inch
+    from reportlab.platypus import (
+        HRFlowable,
+        ListFlowable,
+        ListItem,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    accent = colors.HexColor(spec.get("accent", "#2b3a4a"))
+    muted = colors.HexColor("#6b7280")
+
+    base = getSampleStyleSheet()["Normal"]
+    body = ParagraphStyle("body", parent=base, fontName="Helvetica",
+                          fontSize=10, leading=14)
+    small = ParagraphStyle("small", parent=body, fontSize=8, textColor=muted, leading=11)
+    small_r = ParagraphStyle("small_r", parent=small, alignment=TA_RIGHT)
+    head_name = ParagraphStyle("head_name", parent=body, fontName="Helvetica-Bold",
+                               fontSize=17, textColor=accent, leading=20)
+    title = ParagraphStyle("title", parent=body, fontName="Helvetica-Bold",
+                           fontSize=14, spaceBefore=14, spaceAfter=8)
+    heading = ParagraphStyle("heading", parent=body, fontName="Helvetica-Bold",
+                             fontSize=11, textColor=accent, spaceBefore=10, spaceAfter=4)
+
+    def esc(text) -> str:
+        return (str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+    story: list = []
+
+    # Letterhead: issuer name + address, then an accent rule.
+    lh = spec.get("letterhead", {})
+    if lh:
+        story.append(Paragraph(esc(lh.get("name", "")), head_name))
+        for line in lh.get("lines", []):
+            story.append(Paragraph(esc(line), small))
+        story.append(Spacer(1, 4))
+        story.append(HRFlowable(width="100%", thickness=1.4, color=accent,
+                                spaceBefore=2, spaceAfter=10))
+
+    # Header row: recipient on the left, the meta key/value box on the right.
+    recipient = spec.get("recipient")
+    meta = spec.get("meta")
+    if recipient or meta:
+        left_cell = []
+        if recipient:
+            left_cell.append(Paragraph("<b>To</b>", small))
+            left_cell.append(Paragraph(esc(recipient.get("name", "")), body))
+            for line in recipient.get("lines", []):
+                left_cell.append(Paragraph(esc(line), small))
+        right_cell = []
+        for key, value in (meta or {}).items():
+            right_cell.append(Paragraph(f"<b>{esc(key)}</b>  {esc(value)}", small_r))
+        header = Table([[left_cell, right_cell]], colWidths=[3.4 * inch, 3.1 * inch])
+        header.setStyle(TableStyle([
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+        ]))
+        story.append(header)
+
+    if spec.get("title"):
+        story.append(Paragraph(esc(spec["title"]), title))
+
+    for block in spec.get("blocks", []):
+        if "p" in block:
+            story.append(Paragraph(esc(block["p"]), body))
+            story.append(Spacer(1, 6))
+        elif "heading" in block:
+            story.append(Paragraph(esc(block["heading"]), heading))
+        elif "bullets" in block:
+            items = [ListItem(Paragraph(esc(b), body), leftIndent=10)
+                     for b in block["bullets"]]
+            story.append(ListFlowable(items, bulletType="bullet", start="•",
+                                      leftIndent=12))
+            story.append(Spacer(1, 6))
+        elif "table" in block:
+            story.append(_pdf_table(block["table"], body, accent, muted, esc))
+            story.append(Spacer(1, 6))
+        elif "signature" in block:
+            sig = block["signature"]
+            story.append(Spacer(1, 18))
+            story.append(Paragraph(f"_______________________", small))
+            story.append(Paragraph(f"<b>{esc(sig.get('name', ''))}</b>", body))
+            if sig.get("role"):
+                story.append(Paragraph(esc(sig["role"]), small))
+        elif "spacer" in block:
+            story.append(Spacer(1, float(block["spacer"])))
+
+    if spec.get("footer"):
+        story.append(Spacer(1, 16))
+        story.append(HRFlowable(width="100%", thickness=0.5, color=muted,
+                                spaceBefore=2, spaceAfter=4))
+        story.append(Paragraph(esc(spec["footer"]), small))
+
+    buf = BytesIO()
+    doc = SimpleDocTemplate(
+        buf, pagesize=LETTER,
+        leftMargin=0.9 * inch, rightMargin=0.9 * inch,
+        topMargin=0.8 * inch, bottomMargin=0.8 * inch,
+        title=spec.get("title", ""), author=lh.get("name", "famstack demo"),
+    )
+    doc.build(story)
+    return buf.getvalue()
+
+
+def _pdf_table(t: dict, body, accent, muted, esc):
+    """A reportlab Table with a header row, optional total row, and
+    sensible alignment (first column left, the rest right unless the
+    spec overrides per-column with ``align``)."""
+    from reportlab.lib import colors
+    from reportlab.platypus import Table, TableStyle
+
+    columns = t["columns"]
+    rows = t.get("rows", [])
+    total = t.get("total")
+    n = len(columns)
+    align = t.get("align") or (["L"] + ["R"] * (n - 1))
+
+    data = [[esc(c) for c in columns]]
+    data += [[esc(c) for c in row] for row in rows]
+    if total:
+        data.append([esc(c) for c in total])
+
+    style = [
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 9.5),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("BACKGROUND", (0, 0), (-1, 0), accent),
+        ("ROWBACKGROUNDS", (0, 1), (-1, len(rows)), [colors.white, colors.HexColor("#f3f5f7")]),
+        ("LINEBELOW", (0, 0), (-1, 0), 0.5, accent),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]
+    for col, a in enumerate(align):
+        style.append(("ALIGN", (col, 0), (col, -1),
+                      {"L": "LEFT", "R": "RIGHT", "C": "CENTER"}[a]))
+    if total:
+        last = len(data) - 1
+        style += [
+            ("FONTNAME", (0, last), (-1, last), "Helvetica-Bold"),
+            ("LINEABOVE", (0, last), (-1, last), 0.8, muted),
+            ("BACKGROUND", (0, last), (-1, last), colors.HexColor("#eef1f4")),
+        ]
+
+    table = Table(data, repeatRows=1)
+    table.setStyle(TableStyle(style))
+    table.hAlign = "LEFT"  # sit against the left margin like a real document
+    return table
+
+
+# ── Receipt (Pillow) ─────────────────────────────────────────────────────
+
+
+def render_receipt(spec: dict) -> bytes:
+    """A narrow monospaced thermal receipt with light scan artifacts."""
+    import random
+
+    W = 520
+    pad = 28
+    mono = _font(_MONO_FACES, 19)
+    mono_b = _font(_MONO_FACES, 22)
+    small = _font(_MONO_FACES, 15)
+
+    # Lay the text out as lines first so we can size the canvas to fit.
+    store = spec.get("store", "")
+    addr = spec.get("lines", [])
+    items = spec.get("items", [])
+    total = spec.get("total")
+    paid = spec.get("paid")
+    date = spec.get("date", "")
+    footer = spec.get("footer", "")
+
+    def money(value) -> str:
+        # Prefix "$" only on numeric amounts — "Cash" stays "Cash".
+        s = str(value)
+        if s.startswith("$"):
+            return s
+        try:
+            float(s.replace(",", "").lstrip("-"))
+        except ValueError:
+            return s
+        return f"${s}"
+
+    def money_line(label: str, amount) -> str:
+        amount = money(amount)
+        gap = max(1, 30 - len(label) - len(amount))
+        return f"{label}{' ' * gap}{amount}"
+
+    # Compose body lines (centered header handled separately).
+    body_lines: list[tuple[str, ImageFont.FreeTypeFont]] = []
+    for line in addr:
+        body_lines.append((line, small))
+    body_lines.append(("", small))
+    if date:
+        body_lines.append((f"{date}", small))
+    body_lines.append(("-" * 30, mono))
+    for name, price in items:
+        body_lines.append((money_line(name, price), mono))
+    body_lines.append(("-" * 30, mono))
+    if total is not None:
+        body_lines.append((money_line("TOTAL", total), mono_b))
+    if paid:
+        body_lines.append((money_line("PAID", paid), mono))
+    body_lines.append(("", small))
+
+    line_h = 26
+    height = pad * 2 + 40 + line_h * (len(body_lines) + 2)
+    img = Image.new("RGB", (W, height), "#fdfdfb")
+    draw = ImageDraw.Draw(img)
+
+    y = pad
+    # Store name, centered and bold.
+    w = draw.textlength(store, font=mono_b)
+    draw.text(((W - w) / 2, y), store, font=mono_b, fill="#111111")
+    y += 36
+    for text, font in body_lines:
+        if set(text) <= {"-", " "} or text == "":
+            draw.text((pad, y), text, font=font, fill="#444444")
+        else:
+            draw.text((pad, y), text, font=font, fill="#111111")
+        y += line_h
+    if footer:
+        w = draw.textlength(footer, font=small)
+        draw.text(((W - w) / 2, y), footer, font=small, fill="#333333")
+
+    # Scan artifacts: faint speckle noise + a tiny rotation so it reads
+    # like a phone photo, not a clean render.
+    rng = random.Random(spec.get("filename", store))
+    px = img.load()
+    for _ in range(int(W * height * 0.015)):
+        x, yy = rng.randrange(W), rng.randrange(height)
+        v = rng.randint(190, 240)
+        px[x, yy] = (v, v, v)
+    img = img.rotate(rng.uniform(-1.2, 1.2), expand=True, fillcolor="#fdfdfb")
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ── Certificate (Pillow) ─────────────────────────────────────────────────
+
+
+def render_certificate(spec: dict) -> bytes:
+    """An aged, scanned-looking official certificate.
+
+    Cream paper, a serif/decorative title, typewriter form fields with
+    underlines, an inked circular seal and a cursive registrar
+    signature, finished with speckle and a slight skew. This is the look
+    for the older generation's documents — the ones that predate clean
+    digital PDFs and would have been photographed or scanned.
+    """
+    import math
+    import random
+
+    W, H = 920, 1260
+    paper = (243, 231, 201)
+    ink = (58, 42, 24)
+    faded = (122, 59, 46)
+    img = Image.new("RGB", (W, H), paper)
+    draw = ImageDraw.Draw(img)
+    rng = random.Random(spec.get("filename", "cert"))
+
+    deco = _font(_DECO_FACES, 56)
+    serif_sm = _font(_SERIF_FACES, 18)
+    label = _font(_SERIF_FACES, 19)
+    typewriter = _font(_MONO_FACES, 23)
+    script = _font(_SCRIPT_FACES, 40)
+
+    # Double-rule border inset from the edge.
+    for inset, width in ((28, 4), (40, 2)):
+        draw.rectangle([inset, inset, W - inset, H - inset], outline=ink, width=width)
+
+    cx = W // 2
+    y = 86
+
+    def centered(text, font, fill, yy):
+        w = draw.textlength(text, font=font)
+        draw.text((cx - w / 2, yy), text, font=font, fill=fill)
+
+    centered(spec.get("authority", ""), serif_sm, ink, y)
+    y += 36
+    centered(spec.get("title", "Certificate of Birth"), deco, ink, y)
+    y += 88
+    draw.line([(120, y), (W - 120, y)], fill=ink, width=2)
+    y += 36
+
+    if spec.get("register_no"):
+        draw.text((W - 300, 72), f"No. {spec['register_no']}", font=serif_sm, fill=faded)
+
+    # Form fields: serif label, typewriter value, an underline beneath.
+    left = 130
+    for key, value in spec.get("fields", {}).items():
+        draw.text((left, y), f"{key}:", font=label, fill=ink)
+        vx = left + 250
+        draw.text((vx, y + 1), str(value), font=typewriter, fill=(35, 48, 58))
+        draw.line([(vx, y + 32), (W - 150, y + 32)], fill=(185, 168, 127), width=1)
+        y += 60
+
+    # Inked seal — a faded stamp on its own layer, rotated and composited.
+    seal = Image.new("RGBA", (250, 250), (0, 0, 0, 0))
+    sd = ImageDraw.Draw(seal)
+    ink_a = faded + (160,)
+    sd.ellipse([8, 8, 242, 242], outline=ink_a, width=5)
+    sd.ellipse([30, 30, 220, 220], outline=ink_a, width=2)
+    star = []
+    for k in range(10):
+        ang = -math.pi / 2 + k * math.pi / 5
+        r = 34 if k % 2 == 0 else 15
+        star.append((125 + math.cos(ang) * r, 125 + math.sin(ang) * r))
+    sd.polygon(star, fill=ink_a)
+    sf = _font(_SERIF_FACES, 16)
+    for text, yy in ((spec.get("seal_text", "OFFICIAL SEAL").upper(), 60),
+                     ("SPRINGFIELD COUNTY", 178)):
+        w = sd.textlength(text, font=sf)
+        sd.text((125 - w / 2, yy), text, font=sf, fill=ink_a)
+    seal = seal.rotate(-13, expand=True, resample=Image.BICUBIC)
+    img.paste(seal, (150, H - 360), seal)
+
+    # Cursive registrar signature over a ruled line.
+    if spec.get("registrar"):
+        sy = H - 290
+        draw.text((W - 440, sy), spec["registrar"], font=script, fill=(29, 43, 82))
+        draw.line([(W - 450, sy + 64), (W - 140, sy + 64)], fill=ink, width=1)
+        draw.text((W - 450, sy + 70), "Registrar of Vital Records", font=serif_sm, fill=ink)
+
+    # Aging: warm speckle, then a slight skew so it reads as scanned.
+    px = img.load()
+    for _ in range(int(W * H * 0.012)):
+        x, yy = rng.randrange(W), rng.randrange(H)
+        v = rng.randint(150, 205)
+        px[x, yy] = (v, int(v * 0.92), int(v * 0.78))
+    img = img.rotate(rng.uniform(-1.1, 1.1), expand=True, fillcolor=paper)
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ── Drawing (Pillow) ─────────────────────────────────────────────────────
+
+
+def render_drawing(spec: dict) -> bytes:
+    """A child's crayon drawing: a wobbly family scene + a caption."""
+    import math
+    import random
+
+    W, H = 1000, 760
+    img = Image.new("RGB", (W, H), "#fffef7")
+    draw = ImageDraw.Draw(img)
+    rng = random.Random(spec.get("filename", "drawing"))
+
+    crayon = _font(_CRAYON_FACES, 64)
+    crayon_s = _font(_CRAYON_FACES, 34)
+
+    def wobble_line(x1, y1, x2, y2, fill, width=7):
+        # A hand-drawn stroke: subdivide and jitter the midpoints.
+        pts = [(x1, y1)]
+        steps = 6
+        for i in range(1, steps):
+            t = i / steps
+            x = x1 + (x2 - x1) * t + rng.uniform(-4, 4)
+            y = y1 + (y2 - y1) * t + rng.uniform(-4, 4)
+            pts.append((x, y))
+        pts.append((x2, y2))
+        draw.line(pts, fill=fill, width=width, joint="curve")
+
+    def person(cx, cy, scale, body_color, skin="#ffd9a0"):
+        # Head
+        r = int(26 * scale)
+        draw.ellipse([cx - r, cy - r, cx + r, cy + r], outline="#3a3a3a",
+                     width=6, fill=skin)
+        # Eyes + smile
+        draw.ellipse([cx - r // 2, cy - 6, cx - r // 2 + 6, cy], fill="#3a3a3a")
+        draw.ellipse([cx + r // 2 - 6, cy - 6, cx + r // 2, cy], fill="#3a3a3a")
+        draw.arc([cx - r // 2, cy, cx + r // 2, cy + r // 2], 20, 160,
+                 fill="#3a3a3a", width=4)
+        # Body
+        wobble_line(cx, cy + r, cx, cy + r + int(90 * scale), body_color, 14)
+        # Arms + legs
+        wobble_line(cx, cy + r + 24, cx - int(46 * scale), cy + r + int(60 * scale), body_color)
+        wobble_line(cx, cy + r + 24, cx + int(46 * scale), cy + r + int(60 * scale), body_color)
+        wobble_line(cx, cy + r + int(90 * scale), cx - int(34 * scale), cy + r + int(150 * scale), body_color)
+        wobble_line(cx, cy + r + int(90 * scale), cx + int(34 * scale), cy + r + int(150 * scale), body_color)
+
+    # Sky strip + green ground, the universal child-drawing background.
+    draw.rectangle([0, 0, W, 130], fill="#cdeafe")
+    draw.rectangle([0, H - 110, W, H], fill="#bfe6a6")
+    # Sun
+    sun = (W - 130, 100)
+    draw.ellipse([sun[0] - 50, sun[1] - 50, sun[0] + 50, sun[1] + 50], fill="#ffe14d")
+    for k in range(12):
+        a = k * math.pi / 6
+        wobble_line(sun[0] + math.cos(a) * 55, sun[1] + math.sin(a) * 55,
+                    sun[0] + math.cos(a) * 85, sun[1] + math.sin(a) * 85, "#ffcf2d", 5)
+
+    # House
+    draw.rectangle([120, 380, 360, 600], outline="#8a5a2b", width=7, fill="#f6c89a")
+    draw.polygon([(110, 380), (240, 290), (370, 380)], outline="#a33", width=7, fill="#e26d6d")
+    draw.rectangle([210, 500, 270, 600], outline="#8a5a2b", width=6, fill="#b9763e")
+
+    # The family, left to right, big to small (very Simpsons).
+    person(520, 360, 1.5, "#2e7d32")   # tall one
+    person(640, 380, 1.4, "#1565c0")
+    person(740, 410, 1.0, "#e65100")
+    person(820, 420, 0.9, "#6a1b9a")
+    person(890, 440, 0.6, "#c2185b")   # baby
+
+    title = spec.get("title", "")
+    caption = spec.get("caption", "")
+    if title:
+        w = draw.textlength(title, font=crayon)
+        draw.text(((W - w) / 2, 30), title, font=crayon, fill="#d84315")
+    if caption:
+        # Shrink the caption until it fits the width, so a long line
+        # doesn't run off the right edge.
+        size = 34
+        cap_font = crayon_s
+        while size > 18 and draw.textlength(caption, font=cap_font) > W - 80:
+            size -= 2
+            cap_font = _font(_CRAYON_FACES, size)
+        draw.text((40, H - 64), caption, font=cap_font, fill="#3949ab")
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/tools/family-docs/specs/en/bart-behavior-letter.yaml
+++ b/tools/family-docs/specs/en/bart-behavior-letter.yaml
@@ -1,0 +1,49 @@
+render: pdf
+filename: bart-behavior-letter.pdf
+accent: "#1565c0"
+
+letterhead:
+  name: Springfield Elementary School
+  lines:
+    - 19 Plympton Street
+    - Springfield, OR 97401
+    - "Principal: W. Seymour Skinner"
+
+recipient:
+  name: Mr. & Mrs. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Notice of Disciplinary Action
+
+meta:
+  Reference: "DISC-2026-0417"
+  Date: "17 Apr 2026"
+  Student: "Bart Simpson, Grade 4"
+
+blocks:
+  - p: "Dear Mr. and Mrs. Simpson,"
+  - p: "I am writing to inform you of a disciplinary matter involving your son, Bart. On the morning of 16 April, Bart was found to have written the same sentence 47 times on the chalkboard without authorisation, and to have released the class hamster during the fire drill."
+  - p: "As a consequence, Bart will serve detention each afternoon this week from 3:00 to 4:00 PM. We ask that you discuss the importance of classroom conduct with him at home."
+  - heading: Summary of Incidents
+  - table:
+      columns: [Date, Incident, Action]
+      align: [L, L, L]
+      rows:
+        - ["16 Apr", "Unauthorised chalkboard use", "Detention (1 day)"]
+        - ["16 Apr", "Release of class hamster", "Detention (4 days)"]
+        - ["12 Apr", "Skateboarding in hallway", "Verbal warning"]
+  - p: "Please sign and return the attached slip by Friday. Thank you for your cooperation."
+  - signature:
+      name: W. Seymour Skinner
+      role: Principal, Springfield Elementary
+
+footer: "Springfield Elementary School · A demo document for famstack."
+
+expected:
+  document_type: Letter
+  topics: [Education, Child]
+  persons: [Bart]
+  correspondent: Springfield Elementary School
+  date: "2026-04-17"

--- a/tools/family-docs/specs/en/bart-birth-certificate.yaml
+++ b/tools/family-docs/specs/en/bart-birth-certificate.yaml
@@ -1,0 +1,41 @@
+render: pdf
+filename: bart-birth-certificate.pdf
+accent: "#455a64"
+
+letterhead:
+  name: "State of Oregon · Springfield County"
+  lines:
+    - Office of Vital Records
+    - 1 Government Plaza, Springfield, OR 97401
+
+title: Certificate of Live Birth
+
+meta:
+  Certificate No.: "BC-2016-10421"
+  Date Issued: "05 Apr 2016"
+
+blocks:
+  - p: "This certifies that the birth described below was registered with the Springfield County Office of Vital Records and is a true record on file."
+  - table:
+      columns: [Field, Detail]
+      align: [L, L]
+      rows:
+        - ["Name of child", "Bartholomew JoJo Simpson"]
+        - ["Sex", "Male"]
+        - ["Date of birth", "01 April 2016"]
+        - ["Time of birth", "06:30"]
+        - ["Place of birth", "Springfield General Hospital"]
+        - ["Father", "Homer J. Simpson"]
+        - ["Mother", "Marjorie Simpson (née Bouvier)"]
+  - signature:
+      name: County Registrar
+      role: Springfield County Office of Vital Records
+
+footer: "State of Oregon · Certificate of Live Birth · A demo document for famstack."
+
+expected:
+  document_type: Certificate
+  topics: [Personal Record, Child]
+  persons: [Bart]
+  correspondent: Springfield County Office of Vital Records
+  date: "2016-04-01"

--- a/tools/family-docs/specs/en/bart-drawing.yaml
+++ b/tools/family-docs/specs/en/bart-drawing.yaml
@@ -1,0 +1,12 @@
+render: drawing
+filename: bart-drawing.png
+
+title: MY FAMLY
+caption: "by Bart Simpson, age 10, Springfield Elementary Grade 4"
+
+expected:
+  document_type: Letter
+  topics: [Memory, Child]
+  persons: [Bart]
+  correspondent: null
+  date: "2026-04-20"

--- a/tools/family-docs/specs/en/homer-bank-statement.yaml
+++ b/tools/family-docs/specs/en/homer-bank-statement.yaml
@@ -1,0 +1,48 @@
+render: pdf
+filename: homer-bank-statement.pdf
+accent: "#0d47a1"
+
+letterhead:
+  name: Bank of Springfield
+  lines:
+    - 1 Money Street
+    - Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Account Statement
+
+meta:
+  Account: "Checking ****4471"
+  Period: "01-31 Mar 2026"
+  Opening Balance: "$612.40"
+  Closing Balance: "$2,900.65"
+
+blocks:
+  - p: "Below is a summary of activity on your checking account for the period shown. Please review your transactions and report any discrepancies within 30 days."
+  - heading: Transactions
+  - table:
+      columns: [Date, Description, Amount]
+      align: [L, L, R]
+      rows:
+        - ["02 Mar", "Kwik-E-Mart", "-21.15"]
+        - ["05 Mar", "Moe's Tavern", "-43.50"]
+        - ["12 Mar", "Springfield Power & Light", "-138.20"]
+        - ["28 Mar", "SNPP Payroll (net pay)", "+2,610.00"]
+        - ["29 Mar", "Krusty Burger", "-18.90"]
+        - ["30 Mar", "ATM withdrawal", "-100.00"]
+      total: ["Closing balance", "", "2,900.65"]
+  - p: "Thank you for banking with the Bank of Springfield. Embiggen your savings with our new Christmas Club account."
+
+footer: "Bank of Springfield · Member SFDIC · A demo document for famstack."
+
+expected:
+  document_type: Statement
+  topics: [Finance]
+  persons: [Homer]
+  correspondent: Bank of Springfield
+  date: "2026-03-31"

--- a/tools/family-docs/specs/en/homer-birth-certificate.yaml
+++ b/tools/family-docs/specs/en/homer-birth-certificate.yaml
@@ -1,0 +1,25 @@
+render: certificate
+filename: homer-birth-certificate.png
+
+authority: "Springfield County, State of Oregon, Office of Vital Records"
+title: "Certificate of Birth"
+register_no: "1956-00417"
+seal_text: "VITAL RECORDS"
+
+fields:
+  Name of Child: "Homer Jay Simpson"
+  Sex: "Male"
+  Date of Birth: "May 12, 1956"
+  Place of Birth: "Springfield General Hospital"
+  Father: "Abraham J. Simpson"
+  Mother: "Mona J. Simpson"
+  Date Registered: "May 15, 1956"
+
+registrar: "C. Montgomery"
+
+expected:
+  document_type: Certificate
+  topics: [Personal Record]
+  persons: [Homer]
+  correspondent: Springfield County Office of Vital Records
+  date: "1956-05-12"

--- a/tools/family-docs/specs/en/homer-car-insurance-policy.yaml
+++ b/tools/family-docs/specs/en/homer-car-insurance-policy.yaml
@@ -1,0 +1,96 @@
+render: pdf
+filename: homer-car-insurance-policy.pdf
+accent: "#b71c1c"
+
+letterhead:
+  name: Springfield Mutual Insurance Co.
+  lines:
+    - 100 Industry Way
+    - Springfield, OR 97401
+    - claims@springfieldmutual.example
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Auto Insurance Policy
+
+meta:
+  Policy No.: "AUTO-2026-44871"
+  Period: "01 Jan 2026 to 31 Dec 2026"
+  Vehicle: "Plymouth Junkerolla (pink)"
+  Plate: "OR-SIMPSN"
+
+blocks:
+  - p: "Thank you for insuring your vehicle with Springfield Mutual. This document sets out your coverage, limits and annual premium for the period shown above, followed by the full terms and conditions. Please keep it with your vehicle documents."
+  - heading: Coverage Summary
+  - table:
+      columns: [Coverage, Limit, Premium]
+      align: [L, R, R]
+      rows:
+        - ["Liability (bodily injury)", "100,000.00", "210.00"]
+        - ["Liability (property)", "50,000.00", "95.00"]
+        - ["Collision", "actual cash value", "180.00"]
+        - ["Comprehensive", "actual cash value", "120.00"]
+        - ["Roadside assistance", "included", "35.00"]
+      total: ["Total annual premium", "", "640.00"]
+
+  - heading: What Your Policy Covers
+  - p: "Subject to the limits above and the conditions below, this policy covers the following."
+  - heading: 1. Liability
+  - p: "If you cause an accident, we pay for other people's injuries up to $100,000 and damage to their property up to $50,000. This includes legal defence costs if you are sued as a result of a covered accident. Liability cover is required by Oregon law."
+  - heading: 2. Collision
+  - p: "We pay to repair or replace your vehicle if it is damaged in a collision with another vehicle or object, regardless of who is at fault, up to the actual cash value of the vehicle less your excess. This includes single-vehicle accidents such as hitting a tree, a fire hydrant, or the garage."
+  - heading: 3. Comprehensive
+  - p: "Comprehensive covers loss or damage to your vehicle that is not the result of a collision. Covered causes include:"
+  - bullets:
+      - "Theft of the vehicle or its parts, and attempted theft"
+      - "Fire, explosion, and lightning"
+      - "Vandalism and malicious damage"
+      - "Storm, hail, flood, and falling objects"
+      - "Broken glass and windscreen damage"
+      - "Collision with an animal (including deer and the occasional escaped zoo animal)"
+  - heading: 4. Roadside Assistance
+  - p: "Around-the-clock roadside help, included at no extra excess: towing to the nearest approved garage, jump-starts, lockout service, flat-tyre changes, and emergency fuel delivery (fuel charged separately)."
+
+  - heading: What Is Not Covered
+  - p: "This policy does not cover loss or damage arising from:"
+  - bullets:
+      - "Racing, speed trials, or any contest of speed"
+      - "Driving under the influence of alcohol or drugs, including after visiting Moe's Tavern"
+      - "Any driver not named on this policy, or driving without a valid licence"
+      - "Deliberate or intentional damage caused by you"
+      - "Ordinary wear and tear, rust, or mechanical or electrical breakdown"
+      - "Use of the vehicle for hire, delivery, or commercial purposes"
+      - "Carriage of hazardous or radioactive materials in the vehicle"
+
+  - heading: Your Excess
+  - p: "An excess of $500 applies to each collision or comprehensive claim and is deducted from any settlement. The excess is waived for glass-only repairs. No excess applies to roadside assistance."
+
+  - heading: Making a Claim
+  - bullets:
+      - "Report the incident to us within 30 days at claims@springfieldmutual.example, quoting your policy number."
+      - "Do not admit fault or agree to pay anything at the scene."
+      - "Obtain the other party's name, plate, and insurer where possible."
+      - "We will appoint an approved garage and pay the repairer directly, less your excess."
+
+  - heading: General Conditions
+  - bullets:
+      - "Named driver: Homer J. Simpson only. No other drivers are permitted."
+      - "You must tell us of any change to the vehicle, its use, or your address."
+      - "The vehicle must be roadworthy and hold a current registration."
+      - "Cover may be voided if information you gave us is found to be untrue."
+  - p: "This is a summary of cover. The full policy wording governs in the event of any dispute. To renew, cancel, or change your policy, contact Springfield Mutual at the address above."
+
+footer: "Springfield Mutual Insurance Co. · Auto Policy AUTO-2026-44871 · A demo document for famstack."
+
+expected:
+  document_type: Policy
+  topics: [Insurance, Vehicle]
+  persons: [Homer]
+  correspondent: Springfield Mutual Insurance Co.
+  date: "2026-01-01"
+  # Recall demo: "What does the car insurance cover?" should answer from
+  # the "What Your Policy Covers" and "What Is Not Covered" sections.

--- a/tools/family-docs/specs/en/homer-employment-contract.yaml
+++ b/tools/family-docs/specs/en/homer-employment-contract.yaml
@@ -1,0 +1,55 @@
+render: pdf
+filename: homer-employment-contract.pdf
+accent: "#1b5e20"
+
+letterhead:
+  name: Springfield Nuclear Power Plant
+  lines:
+    - Sector 7-G, Reactor Building 2
+    - Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Contract of Employment
+
+meta:
+  Contract No.: "EMP-1998-0007"
+  Effective: "08 Jun 1998"
+  Position: "Safety Inspector"
+  Department: "Sector 7-G"
+
+blocks:
+  - p: "This Contract of Employment is made between Springfield Nuclear Power Plant (the Employer) and Homer J. Simpson (the Employee), effective from the date shown above."
+  - heading: 1. Position and Duties
+  - p: "The Employee is engaged as Safety Inspector for Sector 7-G and shall perform all duties reasonably associated with that role, including but not limited to monitoring reactor output and not falling asleep at the console."
+  - heading: 2. Compensation
+  - table:
+      columns: [Component, Amount, Frequency]
+      align: [L, R, L]
+      rows:
+        - ["Base salary", "35,400.00", "per year"]
+        - ["Hazard allowance", "5,760.00", "per year"]
+        - ["Annual safety bonus", "1,000.00", "per year"]
+  - heading: 3. Hours and Leave
+  - bullets:
+      - "Standard hours: 40 per week, Monday to Friday."
+      - "Paid leave: 15 working days per year."
+      - "One (1) unpaid donut break per shift."
+  - heading: 4. Termination
+  - p: "Either party may terminate this contract with four (4) weeks written notice. The Employer reserves the right to summary dismissal for gross negligence resulting in a partial meltdown."
+  - signature:
+      name: Montgomery Burns
+      role: Owner, Springfield Nuclear Power Plant
+
+footer: "Springfield Nuclear Power Plant · Contract of Employment · A demo document for famstack."
+
+expected:
+  document_type: Contract
+  topics: [Employment, Legal]
+  persons: [Homer]
+  correspondent: Springfield Nuclear Power Plant
+  date: "1998-06-08"

--- a/tools/family-docs/specs/en/homer-payslip.yaml
+++ b/tools/family-docs/specs/en/homer-payslip.yaml
@@ -1,0 +1,53 @@
+render: pdf
+filename: homer-payslip.pdf
+accent: "#1b5e20"
+
+letterhead:
+  name: Springfield Nuclear Power Plant
+  lines:
+    - Sector 7-G, Reactor Building 2
+    - Springfield, OR 97401
+    - payroll@snpp.example
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: "Pay Statement: March 2026"
+
+meta:
+  Statement No.: "PAY-2026-03-0042"
+  Pay Period: "01-31 Mar 2026"
+  Employee ID: "SNPP-007"
+  Position: "Safety Inspector, Sector 7-G"
+
+blocks:
+  - p: "This statement summarises your gross pay, deductions and net pay for the period shown. Please retain it for your records and for your annual tax return."
+  - heading: Earnings & Deductions
+  - table:
+      columns: [Description, Hours, Amount]
+      align: [L, R, R]
+      rows:
+        - ["Base salary", "160.0", "2,950.00"]
+        - ["Hazard pay (radiation)", "160.0", "480.00"]
+        - ["Overtime", "6.0", "165.00"]
+        - ["Federal income tax", "", "-612.00"]
+        - ["Social security", "", "-220.00"]
+        - ["Health plan (Burns Mutual)", "", "-118.00"]
+        - ["Donut fund (voluntary)", "", "-35.00"]
+      total: ["Net pay", "", "2,610.00"]
+  - p: "Net pay has been transferred to your account at the Bank of Springfield ending 4471."
+  - signature:
+      name: Montgomery Burns
+      role: Owner, Springfield Nuclear Power Plant
+
+footer: "Springfield Nuclear Power Plant · Questions about your pay? Contact payroll@snpp.example · This is a demo document."
+
+expected:
+  document_type: Pay Slip
+  topics: [Income, Employment]
+  persons: [Homer]
+  correspondent: Springfield Nuclear Power Plant
+  date: "2026-03-31"

--- a/tools/family-docs/specs/en/homer-prescription.yaml
+++ b/tools/family-docs/specs/en/homer-prescription.yaml
@@ -1,0 +1,49 @@
+render: pdf
+filename: homer-prescription.pdf
+accent: "#00695c"
+
+letterhead:
+  name: Hibbert Family Practice
+  lines:
+    - Dr. Julius Hibbert, M.D.
+    - 55 Healthway Drive, Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Prescription
+
+meta:
+  Patient: "Homer J. Simpson"
+  Rx No.: "RX-2026-7781"
+  Date: "09 Apr 2026"
+
+blocks:
+  - p: "Following today's consultation regarding elevated cholesterol and recurring back strain, please take the following as directed."
+  - heading: Medication
+  - table:
+      columns: [Medication, Dosage, Qty, Directions]
+      align: [L, L, C, L]
+      rows:
+        - ["Lipitor", "20 mg", "30", "One tablet daily with food"]
+        - ["Ibuprofen", "400 mg", "20", "As needed for back pain"]
+  - heading: Advice
+  - bullets:
+      - "Reduce intake of donuts and Duff beer."
+      - "Walk to work at least twice a week."
+      - "Return in 6 weeks for a cholesterol re-check."
+  - signature:
+      name: Dr. Julius Hibbert, M.D.
+      role: Hibbert Family Practice
+
+footer: "Hibbert Family Practice · This prescription is a demo document for famstack."
+
+expected:
+  document_type: Prescription
+  topics: [Medical]
+  persons: [Homer]
+  correspondent: Dr. Julius Hibbert
+  date: "2026-04-09"

--- a/tools/family-docs/specs/en/homer-tax-assessment.yaml
+++ b/tools/family-docs/specs/en/homer-tax-assessment.yaml
@@ -1,0 +1,47 @@
+render: pdf
+filename: homer-tax-assessment.pdf
+accent: "#37474f"
+
+letterhead:
+  name: Springfield Department of Revenue
+  lines:
+    - Tax Assessment Division
+    - 1 Government Plaza, Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Notice of Tax Assessment
+
+meta:
+  Tax Year: "2025"
+  Assessment No.: "TA-2025-008812"
+  Taxpayer ID: "SSN ***-**-7440"
+  Issued: "30 Apr 2026"
+
+blocks:
+  - p: "This notice sets out your assessed income tax for the tax year shown. Please review the figures carefully. If you disagree, you may file an objection within 30 days of the issue date."
+  - heading: Assessment
+  - table:
+      columns: [Item, Amount]
+      align: [L, R]
+      rows:
+        - ["Assessed gross income", "42,160.00"]
+        - ["Allowable deductions", "-6,400.00"]
+        - ["Taxable income", "35,760.00"]
+        - ["Income tax due", "4,891.00"]
+        - ["Tax withheld by employer", "-5,180.00"]
+      total: ["Refund due to taxpayer", "289.00"]
+  - p: "A refund of $289.00 will be paid to your account on file at the Bank of Springfield within 21 days. No further action is required."
+
+footer: "Springfield Department of Revenue · Assessment TA-2025-008812 · A demo document for famstack."
+
+expected:
+  document_type: Tax Assessment
+  topics: [Tax, Tax Office]
+  persons: [Homer]
+  correspondent: Springfield Department of Revenue
+  date: "2026-04-30"

--- a/tools/family-docs/specs/en/krusty-burger-receipt.yaml
+++ b/tools/family-docs/specs/en/krusty-burger-receipt.yaml
@@ -1,0 +1,24 @@
+render: receipt
+filename: krusty-burger-receipt.png
+
+store: KRUSTY BURGER
+lines:
+  - "Springfield Mall, Food Court"
+  - "Order #0815"
+date: "29 Mar 2026  13:05"
+
+items:
+  - ["Krusty Meal (large)", "8.49"]
+  - ["Krusty Burger x2", "7.00"]
+  - ["Krusty Partial Fries", "2.49"]
+  - ["Buzz Cola refill", "0.92"]
+total: "18.90"
+paid: "Card ****4471"
+footer: "Hey hey! Collect all 12 Krusty cups!"
+
+expected:
+  document_type: Receipt
+  topics: [Shopping]
+  persons: [Homer]
+  correspondent: Krusty Burger
+  date: "2026-03-29"

--- a/tools/family-docs/specs/en/kwik-e-mart-receipt.yaml
+++ b/tools/family-docs/specs/en/kwik-e-mart-receipt.yaml
@@ -1,0 +1,26 @@
+render: receipt
+filename: kwik-e-mart-receipt.png
+
+store: KWIK-E-MART
+lines:
+  - "57 Mystery Lane, Springfield"
+  - "Mgr: Apu Nahasapeemapetilon"
+date: "02 Apr 2026  18:42"
+
+items:
+  - ["Squishee XL Blue", "1.49"]
+  - ["Duff Beer 6-pack", "7.99"]
+  - ["Pork rinds (jumbo)", "2.29"]
+  - ["Buzz Cola 2L", "1.89"]
+  - ["Frosted Krusty O's", "3.49"]
+  - ["Lottery scratcher x2", "4.00"]
+total: "21.15"
+paid: "Cash"
+footer: "Thank you, come again!"
+
+expected:
+  document_type: Receipt
+  topics: [Groceries, Shopping]
+  persons: [Homer]
+  correspondent: Kwik-E-Mart
+  date: "2026-04-02"

--- a/tools/family-docs/specs/en/lisa-birth-certificate.yaml
+++ b/tools/family-docs/specs/en/lisa-birth-certificate.yaml
@@ -1,0 +1,41 @@
+render: pdf
+filename: lisa-birth-certificate.pdf
+accent: "#455a64"
+
+letterhead:
+  name: "State of Oregon · Springfield County"
+  lines:
+    - Office of Vital Records
+    - 1 Government Plaza, Springfield, OR 97401
+
+title: Certificate of Live Birth
+
+meta:
+  Certificate No.: "BC-2018-11883"
+  Date Issued: "12 May 2018"
+
+blocks:
+  - p: "This certifies that the birth described below was registered with the Springfield County Office of Vital Records and is a true record on file."
+  - table:
+      columns: [Field, Detail]
+      align: [L, L]
+      rows:
+        - ["Name of child", "Lisa Marie Simpson"]
+        - ["Sex", "Female"]
+        - ["Date of birth", "09 May 2018"]
+        - ["Time of birth", "04:47"]
+        - ["Place of birth", "Springfield General Hospital"]
+        - ["Father", "Homer J. Simpson"]
+        - ["Mother", "Marjorie Simpson (née Bouvier)"]
+  - signature:
+      name: County Registrar
+      role: Springfield County Office of Vital Records
+
+footer: "State of Oregon · Certificate of Live Birth · A demo document for famstack."
+
+expected:
+  document_type: Certificate
+  topics: [Personal Record, Child]
+  persons: [Lisa]
+  correspondent: Springfield County Office of Vital Records
+  date: "2018-05-09"

--- a/tools/family-docs/specs/en/lisa-report-card.yaml
+++ b/tools/family-docs/specs/en/lisa-report-card.yaml
@@ -1,0 +1,51 @@
+render: pdf
+filename: lisa-report-card.pdf
+accent: "#1565c0"
+
+letterhead:
+  name: Springfield Elementary School
+  lines:
+    - 19 Plympton Street
+    - Springfield, OR 97401
+
+recipient:
+  name: Mr. & Mrs. Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Student Report Card
+
+meta:
+  Student: "Lisa Simpson"
+  Grade: "2"
+  Term: "Spring 2026"
+  Teacher: "Ms. Elizabeth Hoover"
+
+blocks:
+  - p: "This report summarises Lisa's academic progress and conduct for the Spring 2026 term. Grades are on an A to F scale."
+  - heading: Grades
+  - table:
+      columns: [Subject, Grade, Comment]
+      align: [L, C, L]
+      rows:
+        - ["Reading", "A+", "Reads far above grade level"]
+        - ["Mathematics", "A", "Excellent problem solving"]
+        - ["Science", "A+", "Built a working perpetual motion model"]
+        - ["Music", "A+", "Outstanding saxophone"]
+        - ["Physical Education", "B", "Participates, dislikes dodgeball"]
+        - ["Conduct", "A", "A model student"]
+  - heading: Teacher's Comment
+  - p: "Lisa continues to be the brightest student in her class and a joy to teach. She would benefit from being challenged further. Please encourage her to keep up the saxophone."
+  - signature:
+      name: Ms. Elizabeth Hoover
+      role: Grade 2 Teacher
+
+footer: "Springfield Elementary School · Spring 2026 Report Card · A demo document for famstack."
+
+expected:
+  document_type: Certificate
+  topics: [Education, Child]
+  persons: [Lisa]
+  correspondent: Springfield Elementary School
+  date: "2026-04-03"

--- a/tools/family-docs/specs/en/maggie-birth-certificate.yaml
+++ b/tools/family-docs/specs/en/maggie-birth-certificate.yaml
@@ -1,0 +1,41 @@
+render: pdf
+filename: maggie-birth-certificate.pdf
+accent: "#455a64"
+
+letterhead:
+  name: "State of Oregon · Springfield County"
+  lines:
+    - Office of Vital Records
+    - 1 Government Plaza, Springfield, OR 97401
+
+title: Certificate of Live Birth
+
+meta:
+  Certificate No.: "BC-2025-13207"
+  Date Issued: "18 Jan 2025"
+
+blocks:
+  - p: "This certifies that the birth described below was registered with the Springfield County Office of Vital Records and is a true record on file."
+  - table:
+      columns: [Field, Detail]
+      align: [L, L]
+      rows:
+        - ["Name of child", "Margaret Simpson"]
+        - ["Sex", "Female"]
+        - ["Date of birth", "14 January 2025"]
+        - ["Time of birth", "23:58"]
+        - ["Place of birth", "Springfield General Hospital"]
+        - ["Father", "Homer J. Simpson"]
+        - ["Mother", "Marjorie Simpson (née Bouvier)"]
+  - signature:
+      name: County Registrar
+      role: Springfield County Office of Vital Records
+
+footer: "State of Oregon · Certificate of Live Birth · A demo document for famstack."
+
+expected:
+  document_type: Certificate
+  topics: [Personal Record, Child]
+  persons: [Maggie]
+  correspondent: Springfield County Office of Vital Records
+  date: "2025-01-14"

--- a/tools/family-docs/specs/en/maggie-vaccination-record.yaml
+++ b/tools/family-docs/specs/en/maggie-vaccination-record.yaml
@@ -1,0 +1,48 @@
+render: pdf
+filename: maggie-vaccination-record.pdf
+accent: "#00695c"
+
+letterhead:
+  name: Hibbert Family Practice
+  lines:
+    - Dr. Julius Hibbert, M.D.
+    - 55 Healthway Drive, Springfield, OR 97401
+
+recipient:
+  name: Margaret "Maggie" Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Date of birth: 14 Jan 2025"
+
+title: Immunization Record
+
+meta:
+  Patient: "Maggie Simpson"
+  Record No.: "IMM-2026-0312"
+  Issued: "12 Mar 2026"
+
+blocks:
+  - p: "This is the official immunization record for the patient named above. Please retain it for school enrolment and travel."
+  - heading: Vaccinations Administered
+  - table:
+      columns: [Vaccine, Date, Lot, Provider]
+      align: [L, L, L, L]
+      rows:
+        - ["Hepatitis B", "16 Jan 2025", "HB-4471", "Dr. Hibbert"]
+        - ["DTaP (1st)", "20 Mar 2025", "DT-2210", "Dr. Hibbert"]
+        - ["MMR (1st)", "18 Jan 2026", "MM-8842", "Dr. Hibbert"]
+        - ["Polio (IPV)", "18 Jan 2026", "IPV-115", "Dr. Hibbert"]
+        - ["Varicella", "12 Mar 2026", "VAR-090", "Dr. Hibbert"]
+  - p: "Next due: DTaP booster at 18 months. The patient remains in excellent health and continues to enjoy her pacifier."
+  - signature:
+      name: Dr. Julius Hibbert, M.D.
+      role: Hibbert Family Practice
+
+footer: "Hibbert Family Practice · Immunization Record · A demo document for famstack."
+
+expected:
+  document_type: Certificate
+  topics: [Vaccination, Medical, Child]
+  persons: [Maggie]
+  correspondent: Dr. Julius Hibbert
+  date: "2026-03-12"

--- a/tools/family-docs/specs/en/marge-birth-certificate.yaml
+++ b/tools/family-docs/specs/en/marge-birth-certificate.yaml
@@ -1,0 +1,25 @@
+render: certificate
+filename: marge-birth-certificate.png
+
+authority: "Springfield County, State of Oregon, Office of Vital Records"
+title: "Certificate of Birth"
+register_no: "1956-00982"
+seal_text: "VITAL RECORDS"
+
+fields:
+  Name of Child: "Marjorie Jacqueline Bouvier"
+  Sex: "Female"
+  Date of Birth: "October 1, 1956"
+  Place of Birth: "Springfield General Hospital"
+  Father: "Clancy Bouvier"
+  Mother: "Jacqueline Bouvier"
+  Date Registered: "October 4, 1956"
+
+registrar: "C. Montgomery"
+
+expected:
+  document_type: Certificate
+  topics: [Personal Record]
+  persons: [Marge]
+  correspondent: Springfield County Office of Vital Records
+  date: "1956-10-01"

--- a/tools/family-docs/specs/en/marge-hospital-invoice.yaml
+++ b/tools/family-docs/specs/en/marge-hospital-invoice.yaml
@@ -1,0 +1,47 @@
+render: pdf
+filename: marge-hospital-invoice.pdf
+accent: "#7b1fa2"
+
+letterhead:
+  name: Springfield General Hospital
+  lines:
+    - 300 Mercy Boulevard
+    - Springfield, OR 97401
+    - billing@springfieldgeneral.example
+
+recipient:
+  name: Marge Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Invoice
+
+meta:
+  Invoice No.: "SGH-2026-5520"
+  Date: "22 Mar 2026"
+  Patient: "Marge Simpson"
+  Service Date: "18 Mar 2026"
+
+blocks:
+  - p: "Thank you for choosing Springfield General Hospital. The following charges relate to your recent outpatient visit."
+  - heading: Services
+  - table:
+      columns: [Description, Code, Amount]
+      align: [L, L, R]
+      rows:
+        - ["Outpatient consultation", "OPC-01", "180.00"]
+        - ["X-ray, left wrist", "RAD-22", "240.00"]
+        - ["Wrist splint", "SUP-09", "65.00"]
+        - ["Dispensary (pain relief)", "PHM-04", "22.00"]
+      total: ["Total", "", "507.00"]
+  - p: "Your insurer (Springfield Mutual) has been billed directly. Your estimated out-of-pocket portion after coverage is $76.05. Please do not pay until you receive your explanation of benefits."
+
+footer: "Springfield General Hospital · Invoice SGH-2026-5520 · A demo document for famstack."
+
+expected:
+  document_type: Invoice
+  topics: [Medical, Insurance]
+  persons: [Marge]
+  correspondent: Springfield General Hospital
+  date: "2026-03-22"

--- a/tools/family-docs/specs/en/marge-recipe-card.yaml
+++ b/tools/family-docs/specs/en/marge-recipe-card.yaml
@@ -1,0 +1,43 @@
+render: pdf
+filename: marge-recipe-card.pdf
+accent: "#ad1457"
+
+letterhead:
+  name: From the Kitchen of Marge Simpson
+  lines:
+    - "742 Evergreen Terrace, Springfield"
+
+title: Marge's Famous Pork Chops
+
+meta:
+  Serves: "5 (plus seconds for Homer)"
+  Prep: "15 min"
+  Cook: "25 min"
+
+blocks:
+  - p: "A Bouvier family recipe, passed down from Grandma Jacqueline. The secret is the apple-onion gravy. Bart will complain; serve anyway."
+  - heading: Ingredients
+  - bullets:
+      - "5 bone-in pork chops"
+      - "2 tbsp flour, salt and pepper"
+      - "2 tbsp butter"
+      - "1 onion, sliced"
+      - "1 apple, sliced"
+      - "1 cup chicken stock"
+      - "1 tsp mustard"
+  - heading: Method
+  - p: "1. Season the chops and dust lightly with flour."
+  - p: "2. Brown the chops in butter over medium-high heat, about 3 minutes a side. Set aside."
+  - p: "3. Soften the onion and apple in the same pan until golden."
+  - p: "4. Add stock and mustard, scrape the pan, and simmer to a gravy."
+  - p: "5. Return the chops, cover, and simmer 15 minutes until tender."
+  - p: "Serve with mashed potatoes. Hide one chop for later or there won't be any."
+
+footer: "A Bouvier family recipe · A demo document for famstack."
+
+expected:
+  document_type: Fact Sheet
+  topics: [Recipe]
+  persons: [Marge]
+  correspondent: null
+  date: null

--- a/tools/family-docs/specs/en/moes-tavern-tab.yaml
+++ b/tools/family-docs/specs/en/moes-tavern-tab.yaml
@@ -1,0 +1,26 @@
+render: receipt
+filename: moes-tavern-tab.png
+
+store: MOE'S TAVERN
+lines:
+  - "57 Walnut Street, Springfield"
+  - "Proprietor: Moe Szyslak"
+date: "05 Mar 2026  23:18"
+
+items:
+  - ["Duff draft x5", "17.50"]
+  - ["Flaming Moe x2", "12.00"]
+  - ["Duff pitcher", "9.00"]
+  - ["Pickled eggs", "2.50"]
+  - ["Beer nuts", "1.50"]
+  - ["Love Tester", "1.00"]
+total: "43.50"
+paid: "Tab (Homer S.)"
+footer: "No tab over $50. Don't tell Marge."
+
+expected:
+  document_type: Receipt
+  topics: [Shopping]
+  persons: [Homer]
+  correspondent: Moe's Tavern
+  date: "2026-03-05"

--- a/tools/family-docs/specs/en/pta-meeting-minutes.yaml
+++ b/tools/family-docs/specs/en/pta-meeting-minutes.yaml
@@ -1,0 +1,49 @@
+render: pdf
+filename: pta-meeting-minutes.pdf
+accent: "#1565c0"
+
+letterhead:
+  name: Springfield Elementary PTA
+  lines:
+    - Parent-Teacher Association
+    - 19 Plympton Street, Springfield, OR 97401
+
+title: Meeting Minutes
+
+meta:
+  Meeting: "Monthly PTA Meeting"
+  Date: "14 Apr 2026"
+  Location: "School Cafeteria"
+  Chair: "Marge Simpson"
+
+blocks:
+  - p: "The monthly meeting of the Springfield Elementary PTA was held on the date above. Present: M. Simpson (chair), Principal Skinner, Ms. Hoover, Ned Flanders, and eleven parents."
+  - heading: Discussion
+  - bullets:
+      - "Spring bake sale confirmed for 09 May to raise funds for new library books."
+      - "Cafeteria menu review: less grey, more vegetables requested."
+      - "Playground fence repair quote received from Springfield Hardware ($420)."
+      - "Proposal to ban skateboards in hallways passed (one objection, from B. Simpson's note)."
+  - heading: Action Items
+  - table:
+      columns: [Action, Owner, Due]
+      align: [L, L, L]
+      rows:
+        - ["Organise bake sale stalls and sign-up sheet", "Marge Simpson", "30 Apr 2026"]
+        - ["Approve fence repair and schedule work", "Principal Skinner", "22 Apr 2026"]
+        - ["Revise cafeteria menu with nutritionist", "Ms. Hoover", "06 May 2026"]
+        - ["Collect bake sale donations from families", "Ned Flanders", "07 May 2026"]
+        - ["Book the school hall for the sale", "Marge Simpson", "25 Apr 2026"]
+  - p: "Next meeting: 12 May 2026, 7:00 PM, in the cafeteria. Meeting adjourned at 8:15 PM."
+  - signature:
+      name: Marge Simpson
+      role: PTA Chair
+
+footer: "Springfield Elementary PTA · Minutes of 14 Apr 2026 · A demo document for famstack."
+
+expected:
+  document_type: Protocol
+  topics: [Education, Membership]
+  persons: [Marge]
+  correspondent: Springfield Elementary School
+  date: "2026-04-14"

--- a/tools/family-docs/specs/en/slh-vet-invoice.yaml
+++ b/tools/family-docs/specs/en/slh-vet-invoice.yaml
@@ -1,0 +1,46 @@
+render: pdf
+filename: slh-vet-invoice.pdf
+accent: "#4e342e"
+
+letterhead:
+  name: Springfield Animal Hospital
+  lines:
+    - 88 Paws Lane
+    - Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson
+  lines:
+    - "Owner of: Santa's Little Helper (Greyhound)"
+    - "742 Evergreen Terrace, Springfield, OR 97401"
+
+title: Veterinary Invoice
+
+meta:
+  Invoice No.: "VET-2026-0410"
+  Date: "10 Apr 2026"
+  Patient: "Santa's Little Helper"
+  Species: "Dog, Greyhound"
+
+blocks:
+  - p: "Thank you for bringing Santa's Little Helper in for his annual check-up. He is in good health, though slightly overfed on table scraps."
+  - heading: Services
+  - table:
+      columns: [Description, Amount]
+      align: [L, R]
+      rows:
+        - ["Annual wellness exam", "55.00"]
+        - ["Rabies vaccination", "32.00"]
+        - ["Flea & tick treatment", "28.00"]
+        - ["Nail trim", "15.00"]
+      total: ["Total due", "130.00"]
+  - p: "Recommendation: fewer leftovers, more walks. Next check-up due April 2027."
+
+footer: "Springfield Animal Hospital · Invoice VET-2026-0410 · A demo document for famstack."
+
+expected:
+  document_type: Invoice
+  topics: [Pet]
+  persons: [Homer]
+  correspondent: Springfield Animal Hospital
+  date: "2026-04-10"

--- a/tools/family-docs/specs/en/springfield-mortgage-agreement.yaml
+++ b/tools/family-docs/specs/en/springfield-mortgage-agreement.yaml
@@ -1,0 +1,75 @@
+render: pdf
+filename: springfield-mortgage-agreement.pdf
+accent: "#0d47a1"
+
+letterhead:
+  name: Bank of Springfield
+  lines:
+    - Mortgage & Lending Division
+    - 1 Money Street, Springfield, OR 97401
+
+recipient:
+  name: Homer J. Simpson & Marjorie Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Residential Mortgage Agreement
+
+meta:
+  Loan No.: "MTG-2009-00742"
+  Date: "15 Jun 2009"
+  Property: "742 Evergreen Terrace"
+  Principal: "$182,000.00"
+
+blocks:
+  - p: "This Residential Mortgage Agreement (the Agreement) is made between the Bank of Springfield (the Lender) and Homer J. Simpson and Marjorie Simpson, jointly and severally (the Borrower), in respect of the property at 742 Evergreen Terrace, Springfield, Oregon (the Property)."
+  - heading: 1. The Loan
+  - p: "The Lender agrees to advance to the Borrower the principal sum of one hundred eighty-two thousand dollars ($182,000.00) for the purpose of purchasing the Property. The Borrower acknowledges receipt of this sum and agrees to repay it together with interest in accordance with this Agreement."
+  - heading: 2. Interest
+  - p: "Interest shall accrue on the outstanding principal at a fixed annual rate of five and one quarter percent (5.25%), calculated monthly. The rate is fixed for the full term and is not subject to revision except as expressly provided in Clause 9."
+  - heading: 3. Repayment
+  - p: "The Borrower shall repay the loan by 360 equal monthly instalments of one thousand and five dollars and twelve cents ($1,005.12), payable on the first day of each month, commencing 01 July 2009 and ending 01 June 2039. Payments shall be made by direct debit from the Borrower's checking account ending 4471."
+  - table:
+      columns: [Term, Detail]
+      align: [L, L]
+      rows:
+        - ["Principal", "$182,000.00"]
+        - ["Annual interest rate", "5.25% fixed"]
+        - ["Term", "360 months (30 years)"]
+        - ["Monthly instalment", "$1,005.12"]
+        - ["First payment", "01 July 2009"]
+        - ["Final payment", "01 June 2039"]
+  - heading: 4. Security
+  - p: "As security for the loan, the Borrower grants the Lender a first charge over the Property. The Borrower shall not sell, transfer, or further encumber the Property without the Lender's prior written consent. The charge shall be discharged upon repayment in full of all sums owing under this Agreement."
+  - heading: 5. Borrower's Covenants
+  - bullets:
+      - "To keep the Property insured for its full reinstatement value at all times."
+      - "To maintain the Property in good repair and not to permit nuclear materials to be stored on the premises."
+      - "To pay all property taxes, utility charges, and assessments when due."
+      - "To occupy the Property as the Borrower's principal residence."
+      - "To notify the Lender promptly of any event materially affecting the value of the Property."
+  - heading: 6. Insurance
+  - p: "The Borrower shall maintain buildings insurance with a reputable insurer and shall name the Lender as an interested party. Evidence of cover shall be provided on request. If the Borrower fails to insure, the Lender may do so and add the cost to the loan balance."
+  - heading: 7. Default
+  - p: "The following constitute events of default: (a) failure to pay any instalment within fifteen (15) days of its due date; (b) breach of any covenant in Clause 5; (c) the Borrower becoming insolvent. On default, the Lender may, after giving notice, require immediate repayment of all sums owing and may exercise its power of sale over the Property."
+  - heading: 8. Early Repayment
+  - p: "The Borrower may repay all or part of the loan early. A partial prepayment shall be applied to the principal and shall not alter the due date of subsequent instalments. No early-repayment penalty applies to this fixed-rate loan."
+  - heading: 9. Variation
+  - p: "No variation of this Agreement is effective unless made in writing and signed by both parties. The interest rate may be varied only by written agreement or as required by law."
+  - heading: 10. Governing Law
+  - p: "This Agreement is governed by the laws of the State of Oregon. The parties submit to the exclusive jurisdiction of the courts of Springfield County."
+  - heading: 11. Acknowledgement
+  - p: "The Borrower confirms having read and understood this Agreement, having had the opportunity to take independent legal advice, and having freely entered into it. The Borrower further confirms that the figures above are correct and that the donut budget has been considered separately."
+  - signature:
+      name: C. Montgomery Burns (for the Lender)
+      role: Bank of Springfield, Mortgage & Lending Division
+
+footer: "Bank of Springfield · Residential Mortgage Agreement MTG-2009-00742 · A demo document for famstack."
+
+expected:
+  document_type: Contract
+  topics: [Housing, Finance, Legal]
+  persons: [Homer, Marge]
+  correspondent: Bank of Springfield
+  date: "2009-06-15"

--- a/tools/family-docs/specs/en/springfield-power-electricity-bill.yaml
+++ b/tools/family-docs/specs/en/springfield-power-electricity-bill.yaml
@@ -1,0 +1,47 @@
+render: pdf
+filename: springfield-power-electricity-bill.pdf
+accent: "#e65100"
+
+letterhead:
+  name: Springfield Power & Light
+  lines:
+    - 200 Burns Avenue
+    - Springfield, OR 97401
+    - "Customer service: 1-800-SPRINGFIELD"
+
+recipient:
+  name: Marge Simpson
+  lines:
+    - "742 Evergreen Terrace"
+    - "Springfield, OR 97401"
+
+title: Electricity Bill
+
+meta:
+  Account No.: "SPL-742-EVG"
+  Billing Period: "01-31 Mar 2026"
+  Meter No.: "M-0099821"
+  Due Date: "20 Apr 2026"
+
+blocks:
+  - p: "Your electricity usage for the billing period is summarised below. Your home used more than usual this month, likely due to extended television operation."
+  - heading: Charges
+  - table:
+      columns: [Description, Usage, Amount]
+      align: [L, R, R]
+      rows:
+        - ["Electricity (peak)", "640 kWh", "89.60"]
+        - ["Electricity (off-peak)", "310 kWh", "27.90"]
+        - ["Grid & meter fee", "", "14.50"]
+        - ["Renewable surcharge", "", "6.20"]
+      total: ["Total due", "", "138.20"]
+  - p: "Please pay by the due date to avoid a late fee. You can pay online or set up direct debit by quoting your account number."
+
+footer: "Springfield Power & Light · Powering Springfield since 1968 · A demo document for famstack."
+
+expected:
+  document_type: Invoice
+  topics: [Utility, Housing]
+  persons: [Marge]
+  correspondent: Springfield Power & Light
+  date: "2026-03-31"

--- a/tools/family-docs/specs/en/texxon-gas-receipt.yaml
+++ b/tools/family-docs/specs/en/texxon-gas-receipt.yaml
@@ -1,0 +1,23 @@
+render: receipt
+filename: texxon-gas-receipt.png
+
+store: TEXXON FUEL
+lines:
+  - "Route 401, Springfield"
+  - "Pump 3"
+date: "30 Mar 2026  08:12"
+
+items:
+  - ["Unleaded 12.4 gal", "44.64"]
+  - ["at $3.60 / gal", ""]
+  - ["Car wash", "8.00"]
+total: "52.64"
+paid: "Card ****4471"
+footer: "Thanks for fueling up at Texxon"
+
+expected:
+  document_type: Receipt
+  topics: [Vehicle]
+  persons: [Homer]
+  correspondent: Texxon
+  date: "2026-03-30"

--- a/uv.lock
+++ b/uv.lock
@@ -308,6 +308,11 @@ version = "0.2.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
+demo = [
+    { name = "pillow" },
+    { name = "pyyaml" },
+    { name = "reportlab" },
+]
 test = [
     { name = "aiohttp" },
     { name = "loguru" },
@@ -330,6 +335,7 @@ requires-dist = [
     { name = "loguru", marker = "extra == 'test'" },
     { name = "markdown", marker = "extra == 'test'" },
     { name = "matrix-nio", marker = "extra == 'test'", specifier = ">=0.25" },
+    { name = "pillow", marker = "extra == 'demo'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'test'", specifier = ">=10" },
     { name = "pypdf", marker = "extra == 'test'", specifier = ">=4.0" },
     { name = "pypdfium2", marker = "extra == 'test'", specifier = ">=4.0" },
@@ -337,10 +343,12 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21" },
     { name = "pytest-httpserver", marker = "extra == 'test'", specifier = ">=1.0" },
     { name = "python-frontmatter", marker = "extra == 'test'", specifier = ">=1.0" },
+    { name = "pyyaml", marker = "extra == 'demo'" },
     { name = "pyyaml", marker = "extra == 'test'" },
+    { name = "reportlab", marker = "extra == 'demo'", specifier = ">=4" },
     { name = "trafilatura", marker = "extra == 'test'", specifier = ">=1.12,<3.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["test", "demo"]
 
 [[package]]
 name = "frozenlist"
@@ -1446,6 +1454,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
     { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
     { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
   Turns the memory stacklet into a browsable family wiki, adds a demo document set to populate it, and hardens the bot transport so documents are never dropped under
    load.

   **Memory wiki**
   - The memory stacklet now also runs a Quartz container that serves the family vault as a mobile-friendly web wiki at `memory.{domain}` (graph, backlinks, full-text
    search). Read-only; edits go through Forgejo.
   - Self-updating: a cheap background loop checks the remote with `git ls-remote` (no object transfer, no rebuild) and fast-forwards only when `family/memory`
   actually moved. Quartz's watcher rebuilds the changed pages, so a filed document or a Forgejo edit shows up on its own, no manual pull.
   - Clean first run: the Quartz image installs `coreutils` (BusyBox `env` on Alpine lacks the `-S` flag its CLI shebang uses, which crash-looped the container), and
   the vault seeds an `index.md` home page so the site no longer 404s at the root.

   **Repo ownership**
   - The `family/memory` org, repo, and seeds are now created and owned solely by the memory stacklet. The docs archivist is a pure consumer: it ensures only its own
   bot user, token, and team membership, mirrors into the repo, and skips gracefully if memory has not provisioned it yet (the document still files into Paperless).

   **Demo family-docs** (`tools/family-docs/`)
   - A spec-driven generator for 25 Simpsons-world documents (pay slips, contracts, receipts, birth certificates, a kid's drawing, and more), rendered to PDF via
   reportlab and images via Pillow. The YAML specs are the source of truth; rendered output is gitignored.
   - `ingest.py` files them into the `documents` Matrix room as the family member who would have uploaded each, driving a new `stack messages upload` command. The
   archivist files them the normal way, so Matrix stays the single ledger.

   **Burst-safe bot delivery**
   - The transport treated the live sync as the delivery mechanism and ran each handler inline (~30s per document), blocking sync; under a burst Synapse returned a
   limited (gappy) sync and events behind the gap were silently dropped (4 of 25 in testing).
   - The room timeline is now the work queue: the live sync is a doorbell, and a drain reads events forward from a durable per-room cursor via `room_messages`
   (gap-free) and processes them in order, advancing the cursor only after a handler returns (at-least-once). Handlers are idempotent (Paperless dedups by content
   hash, the mirror upserts by `paperless_id`), so replays are no-ops.

   **Other**
   - `stack up ai --no-voice` starts the AI stacklet without the speech container.