### PR TITLE
feat(core): show the bot's read receipt

### DIFF
--- a/stacklets/core/bot-runner/microbot.py
+++ b/stacklets/core/bot-runner/microbot.py
@@ -39,8 +39,15 @@ The cursor (a per-room server_timestamp on disk) advances only *after*
 a handler returns, so a crash mid-processing replays the event rather
 than skipping it: at-least-once delivery. Handlers must therefore be
 idempotent — keyed on a stable id, every write an upsert — so a replay
-is a no-op. (The timestamp cursor has a same-millisecond edge; a later
-revision moves the cursor to the Matrix read marker / event id.)
+is a no-op. The timestamp cursor has a rare same-millisecond edge,
+accepted for now.
+
+The bot also sets the public `m.read` receipt to each processed event,
+so the room shows its "Seen by" progress in Element. That is purely
+cosmetic — the local cursor is the source of truth, so a failed receipt
+never affects what gets processed. (Using the Matrix `m.fully_read`
+marker *as* the cursor was tried and dropped: the account-data callback
+that reads it back didn't fire reliably, so the local cursor stays.)
 """
 
 import asyncio
@@ -362,6 +369,20 @@ class MicroBot:
             # Advance only after the handler returns: a crash mid-handler
             # replays the event (at-least-once), it is never skipped.
             self._advance_cursor(room_id, getattr(event, "server_timestamp", cursor))
+            # Move the public read receipt too, so the room shows the bot's
+            # "Seen by" progress. Purely cosmetic — the cursor above is the
+            # source of truth, so a failed receipt never affects delivery.
+            await self._set_read_receipt(room_id, getattr(event, "event_id", None))
+
+    async def _set_read_receipt(self, room_id: str, event_id: str | None) -> None:
+        """Best-effort public m.read receipt for the "Seen by" indicator."""
+        if not event_id:
+            return
+        try:
+            await self._client.update_receipt_marker(room_id, event_id)
+        except Exception as e:
+            logger.debug("[{}] read receipt update failed in {}: {}",
+                         self.name, room_id, e)
 
     async def _dispatch(self, room_id: str, event) -> None:
         """Invoke every handler whose registered type matches the event."""

--- a/tests/stacklets/test_microbot.py
+++ b/tests/stacklets/test_microbot.py
@@ -49,6 +49,8 @@ class FakeClient:
         self.next_batch = "END"
         self.rooms: dict = {}
         self.timeline: list = []
+        # (room_id, event_id) read receipts the drain set for the "Seen by".
+        self.receipts: list = []
 
     def add_event_callback(self, cb, event_type):
         self.callbacks.append((cb, event_type))
@@ -58,6 +60,10 @@ class FakeClient:
         return RoomMessagesResponse(
             room_id=room_id, chunk=list(self.timeline), start=start, end=None,
         )
+
+    async def update_receipt_marker(self, room_id, event_id, receipt_type=None, thread_id="main"):
+        self.receipts.append((room_id, event_id))
+        return SimpleNamespace()
 
     async def room_typing(self, room_id, typing_state, timeout):
         if self.typing_raises is not None:
@@ -105,11 +111,11 @@ def _build_bot(tmp_path, *, handler) -> tuple[MicroBot, FakeClient]:
     return bot, bot._client
 
 
-def _event(sender="@homer:server", ts=1_000_000):
+def _event(sender="@homer:server", ts=1_000_000, eid="$evt:server"):
     return SimpleNamespace(
         sender=sender,
         server_timestamp=ts,
-        event_id="$evt:server",
+        event_id=eid,
         source={"content": {}},
         body="hi",
     )
@@ -207,12 +213,17 @@ class TestDrain:
         client.rooms = {room.room_id: room}
         bot._cursors[room.room_id] = 5
         # Timeline newest-first; only ts > 5 runs, and oldest-first.
-        client.timeline = [_event(ts=7), _event(ts=6), _event(ts=5), _event(ts=4)]
+        client.timeline = [
+            _event(ts=7, eid="$e7"), _event(ts=6, eid="$e6"),
+            _event(ts=5, eid="$e5"), _event(ts=4, eid="$e4"),
+        ]
 
         await bot._drain()
 
         assert seen == [6, 7]
         assert bot._cursors[room.room_id] == 7
+        # The public read receipt followed to the last processed event.
+        assert client.receipts[-1] == (room.room_id, "$e7")
 
     @pytest.mark.asyncio
     async def test_own_messages_skipped_but_cursor_advances(self, tmp_path):


### PR DESCRIPTION
After processing each event the bot now sets the public m.read receipt to it, so the room shows the bot's "Seen by" progress in Element: A handy signal that it has worked through the backlog. It's best-effort and cosmetic: the local cursor stays the source of truth, so a failed receipt never changes what gets processed.

Using the Matrix m.fully_read marker *as* the cursor was explored on this branch and dropped. The account-data callback that reads the marker back on startup didn't fire reliably, which left the cursor ambiguous. The proven local timestamp cursor is kept; we use read markers only for the visible receipt.