### PR TITLE
feat: Archivist transcribes voice memos into notes

### DIFF
--- a/lib/stack/ai/client.py
+++ b/lib/stack/ai/client.py
@@ -1,22 +1,22 @@
-"""OpenAI-compatible LLM client for famstack stacklets.
+"""OpenAI-compatible AI capabilities for famstack stacklets.
 
 Container-only: this module imports the `openai` SDK, so it is **not**
 imported from `stack/__init__` or `stack.ai.__init__` — the host `./stack`
 CLI stays stdlib. Any stacklet's container code uses it directly:
 
-    from stack.ai.client import LLM
+    from stack.ai.client import LLM, Transcriber
     llm = LLM.from_env(namespace="archivist-bot")
     text = await llm.complete("classifier", prompt, json_mode=True)
 
-It wraps `AsyncOpenAI`, which speaks to any provider serving
-``/v1/chat/completions`` via `base_url` (oMLX, Ollama, vLLM, or a hosted
-OpenAI-compatible endpoint). We let the SDK own transport, retries,
-streaming, and tool-calling, and add only the three things it can't know:
+    transcriber = Transcriber.from_env(namespace="scribe-bot")
+    transcript = await transcriber.transcribe(audio_bytes, filename="voice.ogg")
 
-  1. famstack's role -> model router (`resolve_model`),
-  2. friendly, typed errors so the family sees "set up AI" not a stack
-     trace, and
-  3. a vision-capability probe + on-disk cache.
+Both classes wrap `AsyncOpenAI`, which speaks to any provider serving the
+OpenAI Audio + Chat APIs via `base_url`. They are deliberately separate
+classes because chat and speech-to-text live behind different services
+(``OPENAI_URL`` vs ``WHISPER_URL``) — folding them into one client would
+force a single base URL onto two unrelated endpoints. They do share the
+typed error hierarchy so callers can handle "AI is down" uniformly.
 """
 
 from __future__ import annotations
@@ -288,3 +288,105 @@ def _content_parts(prompt: str, images: list) -> list[dict]:
             "image_url": {"url": f"data:{img.mime};base64,{b64}"},
         })
     return parts
+
+
+# ── Transcription ────────────────────────────────────────────────────────
+#
+# Whisper-server (whisper.cpp) speaks the OpenAI ``/v1/audio/transcriptions``
+# shape, so the same SDK we use for chat handles speech-to-text. It lives
+# on a different base URL than the LLM, though — the AI stacklet runs the
+# LLM (oMLX) and whisper as two native services on different ports — so
+# this class owns its own AsyncOpenAI instance pointed at ``WHISPER_URL``.
+# Folding it into ``LLM`` would conflate two unrelated endpoints under one
+# client.
+
+# Whisper-server has exactly one model loaded; the SDK still requires a
+# ``model`` argument, so we send the canonical OpenAI name. The local
+# server ignores it and dispatches to whatever it loaded at startup.
+_DEFAULT_WHISPER_MODEL = "whisper-1"
+
+
+class Transcriber:
+    """OpenAI-compatible speech-to-text scoped to one stacklet.
+
+    ``namespace`` mirrors the role-prefix idea from ``LLM`` even though
+    whisper-server doesn't route by role today — recording it keeps the
+    door open for per-bot model routing (different whisper variants for
+    archivist vs scribe) without touching call sites later.
+    """
+
+    def __init__(self, client: AsyncOpenAI, *, namespace: str | None = None):
+        self._client = client
+        self.namespace = namespace
+
+    @classmethod
+    def from_env(cls, *, namespace: str | None = None,
+                 max_retries: int = 1) -> "Transcriber":
+        """Build from ``WHISPER_URL`` in the environment.
+
+        The bot-runner env renders ``WHISPER_URL`` as the full endpoint
+        (``…/v1/audio/transcriptions``) for the legacy raw-HTTP path; the
+        SDK appends ``/audio/transcriptions`` itself, so we strip a
+        trailing endpoint suffix the same way ``LLM.from_env`` strips
+        ``/chat/completions``. Either form just works.
+
+        Refuses to build a client when ``WHISPER_URL`` is empty: the SDK
+        would silently fall back to ``api.openai.com``, which for a
+        privacy-first family server is the wrong default to ever reach
+        by accident.
+        """
+        url = os.environ.get("WHISPER_URL", "").rstrip("/")
+        if url.endswith("/audio/transcriptions"):
+            url = url[: -len("/audio/transcriptions")]
+        if not url:
+            raise LLMUnavailableError(
+                "No whisper endpoint configured — set up AI with 'stack up ai'"
+            )
+        # Native whisper-server doesn't authenticate, but the SDK insists
+        # on *some* key — same trick as LLM.from_env.
+        key = os.environ.get("WHISPER_KEY", "") or "not-needed"
+        client = AsyncOpenAI(base_url=url, api_key=key, max_retries=max_retries)
+        return cls(client, namespace=namespace)
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
+                         model: str | None = None) -> str:
+        """Transcribe audio bytes to text, stripped of leading/trailing space.
+
+        ``filename`` lets the server pick a decoder by extension (whisper.cpp
+        sniffs the container from the filename). ``model`` is forwarded to
+        the SDK for OpenAI-compat servers that route by model name; the
+        native whisper-server ignores it.
+
+        SDK errors are translated to the same typed LLM errors ``LLM`` uses
+        so callers can ``except LLMError`` once for both surfaces.
+        """
+        try:
+            resp = await self._client.audio.transcriptions.create(
+                model=model or _DEFAULT_WHISPER_MODEL,
+                file=(filename, audio),
+                response_format="json",
+            )
+        except openai.APITimeoutError as e:
+            raise LLMTimeoutError(
+                "whisper — transcription timed out, try a shorter clip"
+            ) from e
+        except openai.AuthenticationError as e:
+            raise LLMUnavailableError(
+                "Whisper authentication failed — check [ai].whisper_key in stack.toml"
+            ) from e
+        except openai.APIConnectionError as e:
+            raise LLMUnavailableError(
+                "Whisper server unreachable — check 'stack status ai'"
+            ) from e
+        except openai.APIStatusError as e:
+            raise LLMUnavailableError(f"HTTP {e.status_code}: {str(e)[:200]}") from e
+
+        # The SDK returns a Transcription object whose `.text` mirrors
+        # whisper-server's `{"text": ...}` response. Strip incidental
+        # whitespace so callers don't have to.
+        text = getattr(resp, "text", "") or ""
+        return text.strip()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client. Owned by us via from_env()."""
+        await self._client.close()

--- a/lib/stack/ai/client.py
+++ b/lib/stack/ai/client.py
@@ -306,6 +306,36 @@ def _content_parts(prompt: str, images: list) -> list[dict]:
 _DEFAULT_WHISPER_MODEL = "whisper-1"
 
 
+# whisper.cpp output is raw: no punctuation, no capitalization, no
+# sentence breaks. The optional cleanup pass restores those without
+# changing what was said. The prompt is deliberately strict — content
+# drift would silently corrupt the family's note vault.
+#
+# We send the rules as a single user message because the framework LLM
+# client doesn't take a system role today; modern small models honour
+# these constraints reliably when the rules are imperative and the
+# input is the last thing in the prompt.
+_CLEANUP_ROLE = "transcript_cleanup"
+_CLEANUP_PROMPT = """\
+You are cleaning up a raw speech-to-text transcript that has no \
+punctuation, capitalization, or sentence breaks. Restore them in the \
+SAME language as the input.
+
+Rules you MUST follow:
+- Do not change, add, remove, or reorder any words.
+- Do not correct grammar or word choice.
+- Do not summarise, expand, rephrase, or translate.
+- Keep every word in the original language and original order.
+- Add ONLY: punctuation, capitalization, sentence breaks, paragraph breaks.
+
+Reply with ONLY the cleaned transcript. No preamble, no commentary, no \
+code fences, no quotes around the output.
+
+Raw transcript:
+{raw}
+"""
+
+
 class Transcriber:
     """OpenAI-compatible speech-to-text scoped to one stacklet.
 
@@ -349,7 +379,8 @@ class Transcriber:
         return cls(client, namespace=namespace)
 
     async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
-                         model: str | None = None) -> str:
+                         model: str | None = None,
+                         cleanup_with: "LLM | None" = None) -> str:
         """Transcribe audio bytes to text, stripped of leading/trailing space.
 
         ``filename`` lets the server pick a decoder by extension (whisper.cpp
@@ -357,8 +388,16 @@ class Transcriber:
         the SDK for OpenAI-compat servers that route by model name; the
         native whisper-server ignores it.
 
-        SDK errors are translated to the same typed LLM errors ``LLM`` uses
-        so callers can ``except LLMError`` once for both surfaces.
+        ``cleanup_with`` is an optional :class:`LLM` to polish the raw STT
+        output with punctuation and sentence breaks. When provided, the
+        result is the LLM-cleaned text; when omitted or the LLM call
+        fails, the raw transcript is returned unchanged. Cleanup is a
+        best-effort polish, never a hard requirement -- a voice memo
+        without punctuation still beats no transcript at all.
+
+        SDK errors from the STT call are translated to the same typed
+        LLM errors :class:`LLM` uses so callers can ``except LLMError``
+        once for both surfaces.
         """
         try:
             resp = await self._client.audio.transcriptions.create(
@@ -384,8 +423,30 @@ class Transcriber:
         # The SDK returns a Transcription object whose `.text` mirrors
         # whisper-server's `{"text": ...}` response. Strip incidental
         # whitespace so callers don't have to.
-        text = getattr(resp, "text", "") or ""
-        return text.strip()
+        raw = (getattr(resp, "text", "") or "").strip()
+        if not raw or cleanup_with is None:
+            return raw
+        return await self._cleanup(raw, cleanup_with)
+
+    @staticmethod
+    async def _cleanup(raw: str, llm: "LLM") -> str:
+        """Run the LLM-cleanup pass; fall back to raw on any failure.
+
+        Cleanup is best-effort: if the LLM is down or the model returns
+        empty output, the caller still gets a usable transcript. We log
+        a warning so the admin can see drift between raw and clean if
+        they ever want to investigate model quality.
+        """
+        try:
+            cleaned = await llm.complete(
+                _CLEANUP_ROLE, _CLEANUP_PROMPT.format(raw=raw),
+            )
+        except LLMError as e:
+            logger.warning("[transcriber] cleanup failed, returning raw: {}", e)
+            return raw
+        cleaned = (cleaned or "").strip()
+        # A model that returned nothing is no better than no model.
+        return cleaned or raw
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client. Owned by us via from_env()."""

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -1461,7 +1461,16 @@ class ArchivistBot(MicroBot):
         if o.status == "empty":
             return
         if o.status == "extract_failed":
-            await self._send(room_id, self.t("capture_failed"), reply_to)
+            # The reason qualifies what failed so the family doesn't hear
+            # "couldn't read that link" after sending a voice memo. Falls
+            # back to the original URL-shaped message for legacy callers.
+            failure_keys = {
+                "url": "capture_failed",
+                "transcription": "capture_failed_transcription",
+                "binary": "capture_failed_binary",
+            }
+            key = failure_keys.get(o.failure_reason or "", "capture_failed")
+            await self._send(room_id, self.t(key), reply_to)
             return
         if o.status == "no_mirror":
             await self._send(room_id, self.t("capture_no_mirror"), reply_to)

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -42,6 +42,7 @@ from nio import (
     RoomMessageMedia,
     RoomMessageImage,
     RoomMessageFile,
+    RoomMessageAudio,
     RoomMessageText,
 )
 
@@ -60,7 +61,7 @@ from pipeline import (
     PaperlessDuplicateError,
 )
 from stack import resolve_model
-from stack.ai.client import ModelCapabilities
+from stack.ai.client import LLMUnavailableError, ModelCapabilities, Transcriber
 
 # Make sibling stacklets importable. In the bot-runner container,
 # `/stacklets/` is mounted read-only and holds all stacklets; locally
@@ -141,7 +142,7 @@ def _llm_error_for_chat(
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
-SUPPORTED_MSGTYPES = {"m.file", "m.image"}
+SUPPORTED_MSGTYPES = {"m.file", "m.image", "m.audio"}
 
 SCAN_BEGIN = {"scan", "("}
 SCAN_END = {"done", "fertig", ")"}
@@ -175,6 +176,14 @@ _MIME_BY_EXT = {
     "tiff": "image/tiff", "tif": "image/tiff",
     "md": "text/markdown", "markdown": "text/markdown",
     "txt": "text/plain",
+    # Voice messages: Element and most Matrix clients upload Opus-in-OGG
+    # for the in-app voice recorder; mp3 / m4a / wav cover files attached
+    # from elsewhere. Element X uses .ogg specifically.
+    "ogg": "audio/ogg", "oga": "audio/ogg", "opus": "audio/ogg",
+    "mp3": "audio/mpeg",
+    "m4a": "audio/mp4", "mp4a": "audio/mp4",
+    "wav": "audio/wav",
+    "webm": "audio/webm",
 }
 
 
@@ -187,6 +196,8 @@ def _guess_mime(filename: str, msgtype: str) -> str:
         return _MIME_BY_EXT[ext]
     if msgtype == "m.image":
         return "image/jpeg"
+    if msgtype == "m.audio":
+        return "audio/ogg"
     return "application/octet-stream"
 
 
@@ -233,6 +244,10 @@ class ArchivistBot(MicroBot):
         self.code_public_url = os.environ.get("CODE_PUBLIC_URL", "")
         self.openai_url = os.environ.get("OPENAI_URL", "")
         self.openai_key = os.environ.get("OPENAI_KEY", "")
+        # Voice transcription endpoint. When unset (e.g. the AI stacklet
+        # isn't installed yet), the archivist still files PDFs/images; only
+        # the audio-capture path becomes a soft-skip with a friendly reply.
+        self.whisper_url = os.environ.get("WHISPER_URL", "")
         self.language = os.environ.get("LANGUAGE", "en")
         # Per-bot settings from stacklet.toml [bots.archivist.settings]
         self.classify_enabled = settings.get("classify", True)
@@ -299,6 +314,7 @@ class ArchivistBot(MicroBot):
         self._pipeline: DocumentPipeline | None = None
         self._search: SearchService | None = None
         self._capture: CapturePipeline | None = None
+        self._transcriber: Transcriber | None = None
         self._vault: VaultContext | None = None
         self._paperless_version: str = ""
 
@@ -306,7 +322,10 @@ class ArchivistBot(MicroBot):
         return _t(self.language, key, **kwargs)
 
     def register_callbacks(self, client: AsyncClient) -> None:
-        self.add_event_callback(self._on_file, (RoomMessageMedia, RoomMessageImage, RoomMessageFile))
+        self.add_event_callback(
+            self._on_file,
+            (RoomMessageMedia, RoomMessageImage, RoomMessageFile, RoomMessageAudio),
+        )
         self.add_event_callback(self._on_text, RoomMessageText)
 
     async def start(self) -> None:
@@ -387,6 +406,21 @@ class ArchivistBot(MicroBot):
             shared_bucket=self.shared_bucket,
             vault=self._vault,
         )
+        # Whisper speaks /v1/audio/transcriptions on its own port, so the
+        # Transcriber gets its own client. When WHISPER_URL is unset the
+        # archivist still works for PDFs/images; only the voice-capture
+        # branch in the pipeline soft-skips.
+        if self.whisper_url:
+            try:
+                self._transcriber = Transcriber.from_env(namespace=self.name)
+            except LLMUnavailableError as e:
+                logger.warning("[archivist] no transcription: {}", e)
+                self._transcriber = None
+        else:
+            logger.info(
+                "[archivist] WHISPER_URL unset — voice messages will soft-skip"
+            )
+
         self._capture = CapturePipeline(
             url_extractor=self._url_extractor,
             text_extractor=self._text_extractor,
@@ -399,6 +433,7 @@ class ArchivistBot(MicroBot):
             capture_keep_body=self.capture_keep_body,
             capture_tag_prompt_size=self.capture_tag_prompt_size,
             vision_max_pdf_pages=self.vision_max_pdf_pages,
+            transcriber=self._transcriber,
         )
         # Warm the vision-capability cache on every boot. Previously
         # this was kicked from on_first_sync, but MicroBot only runs
@@ -934,6 +969,8 @@ class ArchivistBot(MicroBot):
 
         if msgtype == "m.image":
             await self._send(room.room_id, self.t("received_photo", sender=sender_name), reply_to)
+        elif msgtype == "m.audio":
+            await self._send(room.room_id, self.t("received_voice", sender=sender_name), reply_to)
         else:
             await self._send(room.room_id, self.t("received_document", sender=sender_name), reply_to)
 
@@ -950,7 +987,11 @@ class ArchivistBot(MicroBot):
         # capture room: PDFs and images become visual bookmarks in the
         # sender's bucket; Matrix already stores the binary, so we link
         # to the mxc URL and don't re-archive the bytes.
-        if self._is_documents_room(ctx):
+        #
+        # Voice memos always take the capture path, even in #documents:
+        # a transcript belongs in the sender's own notes, not in Paperless
+        # alongside scanned invoices and IDs.
+        if self._is_documents_room(ctx) and msgtype != "m.audio":
             await self._process_document(
                 room.room_id, raw_filename, display_name, file_data, reply_to,
                 date_filed=self._event_date(event),

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -61,7 +61,12 @@ from pipeline import (
     PaperlessDuplicateError,
 )
 from stack import resolve_model
-from stack.ai.client import LLMUnavailableError, ModelCapabilities, Transcriber
+from stack.ai.client import (
+    LLMError,
+    LLMUnavailableError,
+    ModelCapabilities,
+    Transcriber,
+)
 
 # Make sibling stacklets importable. In the bot-runner container,
 # `/stacklets/` is mounted read-only and holds all stacklets; locally
@@ -974,11 +979,20 @@ class ArchivistBot(MicroBot):
         sender_name = event.sender.split(":")[0].replace("@", "").capitalize()
         reply_to = event.event_id
 
-        # Multi-page scan mode
+        # Multi-page scan / multi-message batch mode. PDFs and images
+        # take the existing page-accumulator path; voice memos take the
+        # transcription-and-accumulate path so a single `(` ... `)`
+        # session can collect either kind (or both, filed as separate
+        # captures on close).
         if event.sender in self._scan_sessions:
-            await self._handle_scan_page(
-                room.room_id, event, url, raw_filename, caption,
-            )
+            if msgtype == "m.audio":
+                await self._handle_voice_batch_message(
+                    room.room_id, event, url, raw_filename,
+                )
+            else:
+                await self._handle_scan_page(
+                    room.room_id, event, url, raw_filename, caption,
+                )
             return
 
         file_data = await self._download_media(url)
@@ -1130,7 +1144,8 @@ class ArchivistBot(MicroBot):
         elif (begin := _split_scan_command(query, SCAN_BEGIN))[0]:
             sender_name = event.sender.split(":")[0].replace("@", "").capitalize()
             self._scan_sessions[event.sender] = {
-                "files": [], "room_id": room.room_id, "caption": begin[1],
+                "files": [], "voice_inputs": [],
+                "room_id": room.room_id, "caption": begin[1],
             }
             await self._send(room.room_id, self.t("scan_started", sender=sender_name), reply_to)
 
@@ -1221,48 +1236,147 @@ class ArchivistBot(MicroBot):
         page_num = len(session["files"])
         await self._send(room_id, self.t("page_received", num=page_num), reply_to)
 
+    async def _handle_voice_batch_message(
+        self, room_id: str, event, url: str, raw_filename: str,
+    ):
+        """Transcribe a voice memo and stash it on the open batch session.
+
+        Mirrors _handle_scan_page: download, normalise input, append to
+        the session, ack the count. The transcript is computed eagerly
+        (with the LLM cleanup pass) so by the time `)` arrives we just
+        concatenate ready text -- no extra round-trip on close.
+        """
+        reply_to = event.event_id
+        if self._transcriber is None:
+            await self._send(
+                room_id, self.t("scan_voice_no_transcriber"), reply_to,
+            )
+            return
+        try:
+            audio = await self._download_media(url)
+        except Exception as e:
+            await self._send(
+                room_id, self.t("scan_voice_failed", error=str(e)), reply_to,
+            )
+            return
+        if not audio:
+            await self._send(
+                room_id, self.t("scan_voice_failed_matrix"), reply_to,
+            )
+            return
+
+        cleanup_llm = self._classifier.llm if self._classifier is not None else None
+        try:
+            transcript = await self._transcriber.transcribe(
+                audio, filename=raw_filename or "voice.ogg",
+                cleanup_with=cleanup_llm,
+            )
+        except LLMError as e:
+            logger.warning("[archivist] batch voice transcribe failed: {}", e)
+            await self._send(
+                room_id, self.t("scan_voice_failed", error=str(e)), reply_to,
+            )
+            return
+
+        if not transcript.strip():
+            await self._send(room_id, self.t("scan_voice_empty"), reply_to)
+            return
+
+        session = self._scan_sessions[event.sender]
+        session["voice_inputs"].append({
+            "transcript": transcript,
+            "mxc": url,
+            "event_id": event.event_id,
+        })
+        n = len(session["voice_inputs"])
+        await self._send(room_id, self.t("scan_voice_received", num=n), reply_to)
+
     async def _handle_scan_complete(
         self, room_id: str, sender: str, reply_to: str | None = None,
         *, date_filed: str | None = None,
     ):
         session = self._scan_sessions.pop(sender)
         files = session["files"]
+        voice_inputs = session.get("voice_inputs") or []
         caption = session.get("caption", "").strip()
         sender_name = sender.split(":")[0].replace("@", "").capitalize()
 
-        if not files:
+        # Nothing accumulated -- the user opened a session and closed it
+        # without sending anything. Treat as cancelled, same as today.
+        if not files and not voice_inputs:
             await self._send(room_id, self.t("scan_cancelled"), reply_to)
             return
 
-        if len(files) == 1:
-            filename, file_data = files[0]
-            display_name = _clean_filename(filename)
-            await self._send(room_id, self.t("scan_complete_single"), reply_to)
-            await self._process_document(
-                room_id, filename, display_name, file_data, reply_to,
-                date_filed=date_filed,
-                submitter_mxid=sender,
-                user_hint=caption or None,
+        # Files (PDFs / images) take the existing PDF combine path. A
+        # mixed batch files both: the PDF as a document and the voice
+        # memos as a separate note below, since the vault data model
+        # has one body per capture.
+        if files:
+            if len(files) == 1:
+                filename, file_data = files[0]
+                display_name = _clean_filename(filename)
+                await self._send(
+                    room_id, self.t("scan_complete_single"), reply_to,
+                )
+                await self._process_document(
+                    room_id, filename, display_name, file_data, reply_to,
+                    date_filed=date_filed,
+                    submitter_mxid=sender,
+                    user_hint=caption or None,
+                )
+            else:
+                page_count = len(files)
+                await self._send(
+                    room_id,
+                    self.t("scan_complete_multi", count=page_count),
+                    reply_to,
+                )
+                try:
+                    pdf_data = _combine_images_to_pdf(files)
+                except Exception as e:
+                    await self._send(
+                        room_id,
+                        self.t("scan_combine_failed", error=str(e)),
+                        reply_to,
+                    )
+                    return
+                filename = f"scan-{sender_name.lower()}-{page_count}p.pdf"
+                display_name = f"scan ({page_count} pages)"
+                await self._process_document(
+                    room_id, filename, display_name, pdf_data, reply_to,
+                    date_filed=date_filed,
+                    user_hint=caption or None,
+                    submitter_mxid=sender,
+                )
+
+        if voice_inputs:
+            await self._handle_voice_batch_complete(
+                room_id, sender, voice_inputs, reply_to,
             )
-            return
 
-        page_count = len(files)
-        await self._send(room_id, self.t("scan_complete_multi", count=page_count), reply_to)
+    async def _handle_voice_batch_complete(
+        self, room_id: str, sender: str, voice_inputs: list[dict],
+        reply_to: str | None,
+    ):
+        """File the accumulated voice memos as one combined note.
 
-        try:
-            pdf_data = _combine_images_to_pdf(files)
-        except Exception as e:
-            await self._send(room_id, self.t("scan_combine_failed", error=str(e)), reply_to)
-            return
-
-        filename = f"scan-{sender_name.lower()}-{page_count}p.pdf"
-        display_name = f"scan ({page_count} pages)"
-        await self._process_document(
-            room_id, filename, display_name, pdf_data, reply_to,
-            date_filed=date_filed,
-            user_hint=caption or None,
-            submitter_mxid=sender,
+        Each input already carries a cleaned transcript (the LLM pass
+        ran at message time), so this just hands the list to the
+        capture pipeline and renders the resulting reply. We post a
+        progress line first because the classify call is the slowest
+        step and the sender deserves to know we're working.
+        """
+        n = len(voice_inputs)
+        await self._send(
+            room_id, self.t("scan_voice_complete", count=n), reply_to,
         )
+        outcome = await self._capture.capture_voice_batch(
+            transcripts=[v["transcript"] for v in voice_inputs],
+            primary_mxc=voice_inputs[0].get("mxc"),
+            sender_mxid=sender,
+            capture_id=voice_inputs[0].get("event_id"),
+        )
+        await self._reply_for_capture(room_id, outcome, reply_to)
 
     # ── URL capture (knowledge rooms, DMs, per-person notes rooms) ───────
     #

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -418,7 +418,8 @@ class ArchivistBot(MicroBot):
                 self._transcriber = None
         else:
             logger.info(
-                "[archivist] WHISPER_URL unset — voice messages will soft-skip"
+                "[archivist] WHISPER_URL unset — voice messages will be ignored "
+                "(set up AI with 'stack up ai' to enable transcription)"
             )
 
         self._capture = CapturePipeline(
@@ -930,6 +931,17 @@ class ArchivistBot(MicroBot):
         if msgtype not in SUPPORTED_MSGTYPES:
             return
 
+        # Voice messages depend on the optional whisper service. When the
+        # transcriber wasn't wired (WHISPER_URL unset or whisper missing
+        # at boot), silently ignore audio so the bot still files PDFs and
+        # images normally; the startup log already warned the admin.
+        if msgtype == "m.audio" and self._transcriber is None:
+            logger.debug(
+                "[archivist] ignoring voice from {} (transcription disabled)",
+                event.sender,
+            )
+            return
+
         url = content.get("url", "")
         if not url or not url.startswith("mxc://"):
             return
@@ -1351,6 +1363,7 @@ class ArchivistBot(MicroBot):
                 source_title_hint=o.source_title_hint,
                 classification=o.classification,
                 link=o.display_link,
+                transcript=o.transcript,
             )
         metadata = (
             {"dev.famstack.event": o.envelope} if o.envelope else None

--- a/stacklets/docs/bot/archivist.py
+++ b/stacklets/docs/bot/archivist.py
@@ -422,6 +422,12 @@ class ArchivistBot(MicroBot):
                 "(set up AI with 'stack up ai' to enable transcription)"
             )
 
+        # The capture pipeline borrows the classifier's framework LLM for
+        # transcript cleanup -- punctuating raw whisper output with the
+        # model that's already running. When the classifier isn't built
+        # (AI not configured), cleanup soft-skips and the raw transcript
+        # falls through.
+        capture_llm = self._classifier.llm if self._classifier is not None else None
         self._capture = CapturePipeline(
             url_extractor=self._url_extractor,
             text_extractor=self._text_extractor,
@@ -435,6 +441,7 @@ class ArchivistBot(MicroBot):
             capture_tag_prompt_size=self.capture_tag_prompt_size,
             vision_max_pdf_pages=self.vision_max_pdf_pages,
             transcriber=self._transcriber,
+            llm=capture_llm,
         )
         # Warm the vision-capability cache on every boot. Previously
         # this was kicked from on_first_sync, but MicroBot only runs

--- a/stacklets/docs/bot/capture_pipeline.py
+++ b/stacklets/docs/bot/capture_pipeline.py
@@ -76,6 +76,11 @@ class CaptureOutcome:
     """What the pipeline produces; the orchestrator renders the reply.
 
     status: captured | reclassified | extract_failed | no_mirror | empty
+
+    ``transcript`` is populated for voice-memo captures so the reply
+    renderer can quote what was heard back to the sender -- the only
+    way a user can catch a bad transcription without opening the vault.
+    Empty for every other capture shape (PDFs, images, URLs, notes).
     """
 
     status: str
@@ -84,6 +89,7 @@ class CaptureOutcome:
     display_link: str = ""
     vault_path: str | None = None
     envelope: dict | None = None
+    transcript: str | None = None
 
 
 class CapturePipeline:
@@ -494,6 +500,13 @@ class CapturePipeline:
                 if user_hint:
                     envelope["data"]["user_hint"] = user_hint
 
+        # Voice captures echo the transcript back to the sender so they
+        # can spot a mistranscription without opening the vault. Other
+        # capture shapes (PDFs, images, URLs, notes) leave it None.
+        source_mime = getattr(source, "mime", None) or ""
+        is_audio_source = source_mime.startswith(AUDIO_MIME_PREFIX)
+        transcript = source.text if is_audio_source else None
+
         return CaptureOutcome(
             status="reclassified" if reclassified else "captured",
             classification=classification,
@@ -501,6 +514,7 @@ class CapturePipeline:
             display_link=display_link,
             vault_path=vault_path,
             envelope=envelope,
+            transcript=transcript,
         )
 
     async def _classify(

--- a/stacklets/docs/bot/capture_pipeline.py
+++ b/stacklets/docs/bot/capture_pipeline.py
@@ -81,6 +81,13 @@ class CaptureOutcome:
     renderer can quote what was heard back to the sender -- the only
     way a user can catch a bad transcription without opening the vault.
     Empty for every other capture shape (PDFs, images, URLs, notes).
+
+    ``failure_reason`` qualifies an ``extract_failed`` status with
+    where the failure originated: ``url`` (article body didn't extract),
+    ``transcription`` (whisper or the cleanup LLM gave up on a voice
+    memo), or ``binary`` (PDF/image couldn't be read). The reply layer
+    renders a different message per reason so the user isn't told
+    "couldn't read that link" when they sent a voice memo.
     """
 
     status: str
@@ -90,6 +97,7 @@ class CaptureOutcome:
     vault_path: str | None = None
     envelope: dict | None = None
     transcript: str | None = None
+    failure_reason: str | None = None
 
 
 class CapturePipeline:
@@ -143,7 +151,9 @@ class CapturePipeline:
         await notifier.status("capture_fetching", url=url)
         source = await self._url_extractor.extract(url)
         if source is None:
-            return CaptureOutcome(status="extract_failed")
+            return CaptureOutcome(
+                status="extract_failed", failure_reason="url",
+            )
         return await self._publish(
             source=source, kind="bookmark", sender_mxid=sender_mxid,
             display_link=url, actor=sender_mxid,
@@ -227,7 +237,8 @@ class CapturePipeline:
         wiki entry links back to the original binary -- we don't
         re-store the bytes; Matrix already has them.
         """
-        if mime and mime.startswith(AUDIO_MIME_PREFIX):
+        is_audio = bool(mime and mime.startswith(AUDIO_MIME_PREFIX))
+        if is_audio:
             source, images, kind = await self._source_from_audio(
                 file_data=file_data, mime=mime, filename=filename,
                 source_uri=source_uri,
@@ -238,7 +249,10 @@ class CapturePipeline:
                 source_uri=source_uri,
             )
         if source is None:
-            return CaptureOutcome(status="extract_failed")
+            return CaptureOutcome(
+                status="extract_failed",
+                failure_reason="transcription" if is_audio else "binary",
+            )
         return await self._publish(
             source=source, kind=kind, sender_mxid=sender_mxid,
             display_link=display_link or source_uri or filename,

--- a/stacklets/docs/bot/capture_pipeline.py
+++ b/stacklets/docs/bot/capture_pipeline.py
@@ -109,6 +109,7 @@ class CapturePipeline:
         capture_tag_prompt_size: int,
         vision_max_pdf_pages: int = DEFAULT_VISION_MAX_PDF_PAGES,
         transcriber=None,
+        llm=None,
     ):
         self._url_extractor = url_extractor
         self._text_extractor = text_extractor
@@ -124,6 +125,11 @@ class CapturePipeline:
         # Optional: when None, audio uploads soft-skip with extract_failed
         # so the bot tells the sender it can't transcribe right now.
         self._transcriber = transcriber
+        # Optional: when present, the transcriber uses it to polish raw
+        # whisper output (add punctuation + sentence breaks). The same
+        # LLM the classifier already runs on -- no extra HTTP client.
+        # Missing -> raw transcript falls through, never a hard failure.
+        self._llm = llm
 
     async def capture_url(
         self, *, url: str, sender_mxid: str, notifier: Notifier,
@@ -223,6 +229,7 @@ class CapturePipeline:
         try:
             transcript = await self._transcriber.transcribe(
                 file_data, filename=filename or "voice.ogg",
+                cleanup_with=self._llm,
             )
         except LLMError as e:
             # Same failure shape the LLM client uses for chat outages;

--- a/stacklets/docs/bot/capture_pipeline.py
+++ b/stacklets/docs/bot/capture_pipeline.py
@@ -167,6 +167,45 @@ class CapturePipeline:
             capture_id=capture_id,
         )
 
+    async def capture_voice_batch(
+        self, *,
+        transcripts: list[str],
+        primary_mxc: str | None,
+        sender_mxid: str,
+        capture_id: str | None = None,
+    ) -> CaptureOutcome:
+        """File N voice memos as a single combined note.
+
+        Used by the `( ... )` batch flow: each voice memo has already
+        been transcribed (and LLM-cleaned) on arrival, so this just
+        concatenates them with paragraph breaks and ships the result
+        through the standard publish path. ``primary_mxc`` is the
+        first memo's media URL -- the vault note links back to the
+        start of the conversation; other memos stay discoverable via
+        chat scrollback.
+
+        Marking the SourceContent as ``audio/ogg`` makes ``_publish``
+        echo the combined transcript in the capture reply, same as
+        single-memo captures, so the sender sees the whole batch's
+        text quoted back to them.
+        """
+        bodies = [t.strip() for t in transcripts if t and t.strip()]
+        if not bodies:
+            return CaptureOutcome(status="empty")
+        combined = "\n\n".join(bodies)
+        source = SourceContent(
+            text=combined,
+            mime="audio/ogg",
+            title_hint=None,
+            source_uri=primary_mxc,
+        )
+        return await self._publish(
+            source=source, kind="note", sender_mxid=sender_mxid,
+            display_link=primary_mxc or "(voice batch)",
+            actor=sender_mxid,
+            capture_id=capture_id,
+        )
+
     async def capture_binary(
         self, *,
         file_data: bytes,

--- a/stacklets/docs/bot/capture_pipeline.py
+++ b/stacklets/docs/bot/capture_pipeline.py
@@ -41,6 +41,7 @@ from pipeline import (
     LLMUnavailableError,
 )
 from stack import resolve_model
+from stack.ai.client import LLMError
 
 try:
     from pypdf import PdfReader  # type: ignore
@@ -63,6 +64,11 @@ TEXT_MIMES = {
     "text/plain", "text/markdown", "text/x-markdown",
 }
 TEXT_EXTS = {"md", "markdown", "txt"}
+
+# Voice memos: when whisper is wired, the transcript IS the note body.
+# Element and most Matrix clients upload Opus-in-OGG; the other formats
+# show up when people attach a file picker rather than the in-app recorder.
+AUDIO_MIME_PREFIX = "audio/"
 
 
 @dataclass
@@ -96,6 +102,7 @@ class CapturePipeline:
         capture_keep_body: bool,
         capture_tag_prompt_size: int,
         vision_max_pdf_pages: int = DEFAULT_VISION_MAX_PDF_PAGES,
+        transcriber=None,
     ):
         self._url_extractor = url_extractor
         self._text_extractor = text_extractor
@@ -108,6 +115,9 @@ class CapturePipeline:
         self.capture_keep_body = capture_keep_body
         self.capture_tag_prompt_size = capture_tag_prompt_size
         self.vision_max_pdf_pages = vision_max_pdf_pages
+        # Optional: when None, audio uploads soft-skip with extract_failed
+        # so the bot tells the sender it can't transcribe right now.
+        self._transcriber = transcriber
 
     async def capture_url(
         self, *, url: str, sender_mxid: str, notifier: Notifier,
@@ -166,10 +176,16 @@ class CapturePipeline:
         wiki entry links back to the original binary -- we don't
         re-store the bytes; Matrix already has them.
         """
-        source, images, kind = self._source_from_binary(
-            file_data=file_data, mime=mime, filename=filename,
-            source_uri=source_uri,
-        )
+        if mime and mime.startswith(AUDIO_MIME_PREFIX):
+            source, images, kind = await self._source_from_audio(
+                file_data=file_data, mime=mime, filename=filename,
+                source_uri=source_uri,
+            )
+        else:
+            source, images, kind = self._source_from_binary(
+                file_data=file_data, mime=mime, filename=filename,
+                source_uri=source_uri,
+            )
         if source is None:
             return CaptureOutcome(status="extract_failed")
         return await self._publish(
@@ -177,6 +193,48 @@ class CapturePipeline:
             display_link=display_link or source_uri or filename,
             images=images, actor=sender_mxid,
             capture_id=capture_id,
+        )
+
+    async def _source_from_audio(
+        self, *, file_data: bytes, mime: str, filename: str,
+        source_uri: str | None,
+    ) -> tuple[SourceContent | None, list[ImageAttachment], str]:
+        """Transcribe a voice memo into a note-shaped SourceContent.
+
+        The transcript IS the note body: same kind ("note") that md/txt
+        uploads use, so the classifier sees the transcribed text and the
+        mirror writes the words verbatim. Returning ``None`` signals the
+        capture as extract_failed -- the orchestrator already renders a
+        friendly reply for that case, so a missing/down whisper service
+        surfaces uniformly across PDFs and audio.
+        """
+        if self._transcriber is None:
+            logger.info(
+                "[capture] audio dropped: no transcriber configured "
+                "(WHISPER_URL unset?)"
+            )
+            return (None, [], "note")
+        try:
+            transcript = await self._transcriber.transcribe(
+                file_data, filename=filename or "voice.ogg",
+            )
+        except LLMError as e:
+            # Same failure shape the LLM client uses for chat outages;
+            # the orchestrator already maps extract_failed to a user-
+            # visible "I couldn't process that" reply.
+            logger.warning("[capture] transcription failed: {}", e)
+            return (None, [], "note")
+        if not transcript.strip():
+            return (None, [], "note")
+        return (
+            SourceContent(
+                text=transcript,
+                mime=mime,
+                title_hint=filename or None,
+                source_uri=source_uri,
+            ),
+            [],
+            "note",
         )
 
     def _source_from_binary(

--- a/stacklets/docs/bot/messages/archivist.yml
+++ b/stacklets/docs/bot/messages/archivist.yml
@@ -11,7 +11,7 @@ en:
   # File upload
   received_photo: "\U0001F4F7 Received photo from {sender} — analyzing..."
   received_document: "\U0001F4C4 Received document from {sender} — analyzing..."
-  received_voice: "\U0001F3A4 Received voice memo from {sender} — transcribing..."
+  received_voice: "\U0001F3A4 Received voice memo from {sender}. Transcribing..."
   download_failed: "\u274C Failed to download {name}: {error}"
   download_failed_matrix: "\u274C Failed to download {name} from Matrix."
 
@@ -66,7 +66,7 @@ en:
   new_in_paperless: "\U0001F195 New in Paperless: {items}"
 
   # Scan
-  scan_started: "\U0001F4F8 Batch started for {sender} — send pages, photos, or voice memos, then ) or 'fertig' to combine."
+  scan_started: "\U0001F4F8 Batch started for {sender}. Send pages, photos, or voice memos, then ) or 'fertig' to combine."
   page_received: "\U0001F4C4 Page {num} received."
   scan_page_failed: "\u274C Failed to download page: {error}"
   scan_page_failed_matrix: "\u274C Failed to download page from Matrix."
@@ -77,9 +77,9 @@ en:
   scan_voice_received: "\U0001F3A4 Voice memo {num} received."
   scan_voice_failed: "\u274C Failed to download voice memo: {error}"
   scan_voice_failed_matrix: "\u274C Failed to download voice memo from Matrix."
-  scan_voice_no_transcriber: "\U0001F3A4 Voice transcription is not configured — set up AI with 'stack up ai'."
+  scan_voice_no_transcriber: "\U0001F3A4 Voice transcription is not configured. Set up AI with 'stack up ai'."
   scan_voice_empty: "\U0001F3A4 Couldn't hear anything in that voice memo."
-  scan_voice_complete: "\U0001F3A4 Combining {count} voice memos into one note — analyzing..."
+  scan_voice_complete: "\U0001F3A4 Combining {count} voice memos into one note. Analyzing..."
   no_active_scan: "No active scan. Send ( or 'scan' to start one."
 
   # URL archiving
@@ -152,7 +152,7 @@ de:
   # File upload
   received_photo: "\U0001F4F7 Foto von {sender} empfangen — wird analysiert..."
   received_document: "\U0001F4C4 Dokument von {sender} empfangen — wird analysiert..."
-  received_voice: "\U0001F3A4 Sprachnachricht von {sender} empfangen — wird transkribiert..."
+  received_voice: "\U0001F3A4 Sprachnachricht von {sender} empfangen. Wird transkribiert..."
   download_failed: "\u274C Download von {name} fehlgeschlagen: {error}"
   download_failed_matrix: "\u274C Download von {name} aus Matrix fehlgeschlagen."
 
@@ -207,7 +207,7 @@ de:
   new_in_paperless: "\U0001F195 Neu in Paperless: {items}"
 
   # Scan
-  scan_started: "\U0001F4F8 Batch gestartet für {sender} — sende Seiten, Fotos oder Sprachnachrichten, dann ) oder 'fertig' zum Zusammenfassen."
+  scan_started: "\U0001F4F8 Batch gestartet für {sender}. Sende Seiten, Fotos oder Sprachnachrichten, dann ) oder 'fertig' zum Zusammenfassen."
   page_received: "\U0001F4C4 Seite {num} empfangen."
   scan_page_failed: "\u274C Seite konnte nicht heruntergeladen werden: {error}"
   scan_page_failed_matrix: "\u274C Seite konnte nicht aus Matrix heruntergeladen werden."
@@ -218,9 +218,9 @@ de:
   scan_voice_received: "\U0001F3A4 Sprachnachricht {num} empfangen."
   scan_voice_failed: "\u274C Sprachnachricht konnte nicht heruntergeladen werden: {error}"
   scan_voice_failed_matrix: "\u274C Sprachnachricht konnte nicht aus Matrix heruntergeladen werden."
-  scan_voice_no_transcriber: "\U0001F3A4 Sprach-Transkription ist nicht eingerichtet — 'stack up ai' ausführen."
+  scan_voice_no_transcriber: "\U0001F3A4 Sprach-Transkription ist nicht eingerichtet. 'stack up ai' ausführen."
   scan_voice_empty: "\U0001F3A4 Konnte nichts in der Sprachnachricht hören."
-  scan_voice_complete: "\U0001F3A4 Kombiniere {count} Sprachnachrichten zu einer Notiz — wird analysiert..."
+  scan_voice_complete: "\U0001F3A4 Kombiniere {count} Sprachnachrichten zu einer Notiz. Wird analysiert..."
   no_active_scan: "Kein aktiver Scan. Sende ( oder 'scan' um einen zu starten."
 
   # URL archiving

--- a/stacklets/docs/bot/messages/archivist.yml
+++ b/stacklets/docs/bot/messages/archivist.yml
@@ -94,6 +94,8 @@ en:
   # URL capture (knowledge rooms — links become summarized notes, not Paperless docs)
   capture_fetching: "\U0001F50D Reading {url}..."
   capture_failed: "\u274C Couldn't read that link. Either the host is unreachable or there's no article body to extract."
+  capture_failed_transcription: "\U0001F3A4 Couldn't transcribe that voice memo. Whisper may be down or misconfigured."
+  capture_failed_binary: "\u274C Couldn't read that file."
   capture_llm_failed: "\U0001F4DD Captured the page, but classification skipped: {error}"
   capture_no_mirror: "\u274C Captures need the `code` stacklet up so I can write to the memory vault. Run `stack up code`."
   captured: "\u2705 Captured: {title}"
@@ -233,6 +235,8 @@ de:
   # URL-Capture (Wissensräume — Links werden zu zusammengefassten Notizen, nicht zu Paperless-Dokumenten)
   capture_fetching: "\U0001F50D Lese {url}..."
   capture_failed: "\u274C Konnte den Link nicht lesen. Entweder ist die Seite nicht erreichbar, oder es gibt keinen Artikel-Inhalt zum Extrahieren."
+  capture_failed_transcription: "\U0001F3A4 Konnte die Sprachnachricht nicht transkribieren. Whisper ist möglicherweise nicht erreichbar oder falsch konfiguriert."
+  capture_failed_binary: "\u274C Konnte diese Datei nicht lesen."
   capture_llm_failed: "\U0001F4DD Seite gespeichert, aber Klassifizierung übersprungen: {error}"
   capture_no_mirror: "\u274C Captures brauchen das `code`-Stacklet, damit ich in den Memory-Vault schreiben kann. Starte `stack up code`."
   captured: "\u2705 Gespeichert: {title}"

--- a/stacklets/docs/bot/messages/archivist.yml
+++ b/stacklets/docs/bot/messages/archivist.yml
@@ -66,7 +66,7 @@ en:
   new_in_paperless: "\U0001F195 New in Paperless: {items}"
 
   # Scan
-  scan_started: "\U0001F4F8 Scan started for {sender} — upload your pages, then send ) or 'fertig' when done."
+  scan_started: "\U0001F4F8 Batch started for {sender} — send pages, photos, or voice memos, then ) or 'fertig' to combine."
   page_received: "\U0001F4C4 Page {num} received."
   scan_page_failed: "\u274C Failed to download page: {error}"
   scan_page_failed_matrix: "\u274C Failed to download page from Matrix."
@@ -74,6 +74,12 @@ en:
   scan_complete_single: "\U0001F4CB Scan complete (1 page) — analyzing..."
   scan_complete_multi: "\U0001F4CB Scan complete — combining {count} pages into PDF..."
   scan_combine_failed: "\u274C Failed to combine pages into PDF: {error}"
+  scan_voice_received: "\U0001F3A4 Voice memo {num} received."
+  scan_voice_failed: "\u274C Failed to download voice memo: {error}"
+  scan_voice_failed_matrix: "\u274C Failed to download voice memo from Matrix."
+  scan_voice_no_transcriber: "\U0001F3A4 Voice transcription is not configured — set up AI with 'stack up ai'."
+  scan_voice_empty: "\U0001F3A4 Couldn't hear anything in that voice memo."
+  scan_voice_complete: "\U0001F3A4 Combining {count} voice memos into one note — analyzing..."
   no_active_scan: "No active scan. Send ( or 'scan' to start one."
 
   # URL archiving
@@ -199,7 +205,7 @@ de:
   new_in_paperless: "\U0001F195 Neu in Paperless: {items}"
 
   # Scan
-  scan_started: "\U0001F4F8 Scan gestartet für {sender} — lade deine Seiten hoch, dann sende ) oder 'fertig'."
+  scan_started: "\U0001F4F8 Batch gestartet für {sender} — sende Seiten, Fotos oder Sprachnachrichten, dann ) oder 'fertig' zum Zusammenfassen."
   page_received: "\U0001F4C4 Seite {num} empfangen."
   scan_page_failed: "\u274C Seite konnte nicht heruntergeladen werden: {error}"
   scan_page_failed_matrix: "\u274C Seite konnte nicht aus Matrix heruntergeladen werden."
@@ -207,6 +213,12 @@ de:
   scan_complete_single: "\U0001F4CB Scan abgeschlossen (1 Seite) — wird analysiert..."
   scan_complete_multi: "\U0001F4CB Scan abgeschlossen — {count} Seiten werden zu PDF zusammengefasst..."
   scan_combine_failed: "\u274C Seiten konnten nicht zu PDF zusammengefasst werden: {error}"
+  scan_voice_received: "\U0001F3A4 Sprachnachricht {num} empfangen."
+  scan_voice_failed: "\u274C Sprachnachricht konnte nicht heruntergeladen werden: {error}"
+  scan_voice_failed_matrix: "\u274C Sprachnachricht konnte nicht aus Matrix heruntergeladen werden."
+  scan_voice_no_transcriber: "\U0001F3A4 Sprach-Transkription ist nicht eingerichtet — 'stack up ai' ausführen."
+  scan_voice_empty: "\U0001F3A4 Konnte nichts in der Sprachnachricht hören."
+  scan_voice_complete: "\U0001F3A4 Kombiniere {count} Sprachnachrichten zu einer Notiz — wird analysiert..."
   no_active_scan: "Kein aktiver Scan. Sende ( oder 'scan' um einen zu starten."
 
   # URL archiving

--- a/stacklets/docs/bot/messages/archivist.yml
+++ b/stacklets/docs/bot/messages/archivist.yml
@@ -11,6 +11,7 @@ en:
   # File upload
   received_photo: "\U0001F4F7 Received photo from {sender} — analyzing..."
   received_document: "\U0001F4C4 Received document from {sender} — analyzing..."
+  received_voice: "\U0001F3A4 Received voice memo from {sender} — transcribing..."
   download_failed: "\u274C Failed to download {name}: {error}"
   download_failed_matrix: "\u274C Failed to download {name} from Matrix."
 
@@ -143,6 +144,7 @@ de:
   # File upload
   received_photo: "\U0001F4F7 Foto von {sender} empfangen — wird analysiert..."
   received_document: "\U0001F4C4 Dokument von {sender} empfangen — wird analysiert..."
+  received_voice: "\U0001F3A4 Sprachnachricht von {sender} empfangen — wird transkribiert..."
   download_failed: "\u274C Download von {name} fehlgeschlagen: {error}"
   download_failed_matrix: "\u274C Download von {name} aus Matrix fehlgeschlagen."
 

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -475,6 +475,16 @@ class Classifier:
         return cls(llm)
 
     @property
+    def llm(self) -> LLM:
+        """Expose the framework LLM for other components that need it.
+
+        Captures piggyback on this for transcript cleanup -- the LLM is
+        the same one the classifier already built, so we don't open a
+        second HTTP client just to polish a voice memo.
+        """
+        return self._llm
+
+    @property
     def capabilities(self) -> ModelCapabilities:
         """Expose the vision-capability cache for tests + diagnostics."""
         return self._llm.capabilities

--- a/stacklets/docs/bot/pipeline.py
+++ b/stacklets/docs/bot/pipeline.py
@@ -1002,7 +1002,7 @@ Return this exact JSON structure:
   "title": "scannable title under 80 chars. Use the content's language. Capture what this is *about*, not just the source name.",
   "summary": "Markdown summary. Length scales with input — short paste (under ~300 chars): 1-2 sentences. Long content (articles, threads, posts): 200-400 words covering key points, claims, named entities, and conclusions. The user reads this instead of reopening the source.",
   "facts": ["Concrete facts extracted from the content. Each fact MUST anchor on a number, date, named entity, or proper noun — a sentence without one of those is filler and belongs in the summary instead. Count scales with content: 0 for a short note with nothing to extract, 1-3 for a homepage bookmark, 4-8 for a typical article, more for data-heavy content. Don't pad, don't cap."],
-  "tags": ["3-5 topic tags. Format: lowercase, hyphen-separated (kebab-case), e.g. 'open-source', 'digital-sovereignty', 'local-llms'. Tag the stable interest area, not every concept mentioned. One tag per domain — pick 'gov-tech' OR 'government-tools' OR 'ai-in-government', not all three. Reuse existing tags from the list above when a near-fit exists; a new tag is justified only when no existing tag is within two synonyms."],
+  "tags": ["3-5 content-specific tags. Format: lowercase, hyphen-separated (kebab-case). DERIVE tags from concrete nouns, named activities, named items, places, and seasons that appear in the content. PREFER SPECIFIC over generic: 'camping' beats 'travel', 'wäschesack' beats 'haushalt', 'lasagna-recipe' beats 'food', 'local-llms' beats 'ai'. German content → German tags ('campingurlaub', 'bremsen', 'kindergarten'). MINIMUM 3 entries — if a short note has only one obvious specific (e.g. 'camping'), add adjacent ones (the activity, the gear named, the season, the place). Existing-tag reuse: only when an existing tag is content-specific itself; ignore generic categories from the list."],
   "persons": ["which family members this is for or about. Pick from the family members list. Empty list if unclear — the caller will default to the sender."]
 }}
 
@@ -1010,7 +1010,7 @@ Rules:
 - LANGUAGE: use the content's original language for title, summary, facts. German content → German output.
 - summary: write a real digest, not a teaser. Match length to input — terse for short pastes, fuller for long-form. Do NOT include the source URL; it's surfaced separately in the vault entry.
 - facts: each fact carries an anchor (number, date, named entity, proper noun). "X is widely used" is not a fact; "X is used by 600K+ agents" is. Don't pad to hit a count; an empty list beats invented facts.
-- tags: lowercase, hyphen-separated, 1-3 words each. Drop redundancy — never emit two tags about the same domain. Prefer existing tags from the list whenever a near-fit exists.
+- tags: 3-5 entries, no exceptions. Each tag must be content-specific: 'camping' not 'travel', 'wäschesack' not 'haushalt', 'bremsen' not 'auto'. The retrieval test for a good tag: would the user, six months from now, type this word to search for this specific content? If no, replace it with a more specific one. Lowercase, hyphen-separated, 1-3 words. Match the content's language.
 - persons: only if the content explicitly names a family member. Don't guess from sender.
 
 Content:

--- a/stacklets/docs/bot/reply_presenter.py
+++ b/stacklets/docs/bot/reply_presenter.py
@@ -128,6 +128,7 @@ def render_capture_reply(
     source_title_hint: str | None,
     classification: dict,
     link: str,
+    transcript: str | None = None,
 ) -> str:
     """Render the "capture saved" reply.
 
@@ -136,9 +137,25 @@ def render_capture_reply(
     source link / "(pasted text)" placeholder rather than a Paperless
     URL. Title falls back through the classifier title, the extractor's
     hint, then a generic "Capture".
+
+    ``transcript`` is the verbatim text for voice captures; when set it
+    renders as a block-quoted preamble above the title so the sender
+    can verify whisper heard them correctly. None for every other
+    capture shape.
     """
+    lines: list[str] = []
+    if transcript:
+        # Block-quote each line so multi-sentence memos still render as
+        # one quote block in Element / SchildiChat / FluffyChat. The
+        # mic emoji signals "this is the spoken content."
+        lines.append("\U0001F3A4 What I heard:")
+        lines.append("")
+        for line in transcript.splitlines() or [transcript]:
+            lines.append(f"> {line}" if line else ">")
+        lines.append("")
+
     title = classification.get("title") or source_title_hint or "Capture"
-    lines = [t("captured", title=title)]
+    lines.append(t("captured", title=title))
 
     # Captures classify under `tags`; the documents pipeline uses
     # `topics`. Accept either so the same presenter works for both

--- a/stacklets/messages/bot/scribe.py
+++ b/stacklets/messages/bot/scribe.py
@@ -5,15 +5,11 @@ with the transcribed text. Uses whisper.cpp running natively on the host
 for Metal GPU acceleration — a 5-minute voice memo transcribes in ~20
 seconds, vs 10+ minutes CPU-only inside Docker.
 
-The transcription API is OpenAI-compatible (/v1/audio/transcriptions),
-so this bot works with any backend that serves that endpoint.
+The transcription API call is delegated to the shared `Transcriber`
+capability on the AI client; the bot is just the Matrix-side wiring —
+download audio, hand bytes to the Transcriber, post the result.
 """
 
-import os
-import tempfile
-from pathlib import Path
-
-import aiohttp
 from loguru import logger
 from nio import (
     AsyncClient,
@@ -21,40 +17,7 @@ from nio import (
 )
 
 from microbot import MicroBot
-
-# Default — overridden by bots.json config
-DEFAULT_WHISPER_URL = "http://host.docker.internal:42062/v1/audio/transcriptions"
-
-
-async def _transcribe(whisper_url: str, audio_bytes: bytes, filename: str) -> str:
-    """POST audio to whisper-server, return transcribed text."""
-    suffix = Path(filename).suffix or ".ogg"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as f:
-        f.write(audio_bytes)
-        tmp_path = f.name
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            data = aiohttp.FormData()
-            data.add_field(
-                "file",
-                open(tmp_path, "rb"),
-                filename=filename,
-                content_type="application/octet-stream",
-            )
-            data.add_field("response_format", "json")
-
-            async with session.post(
-                whisper_url, data=data, timeout=aiohttp.ClientTimeout(total=120)
-            ) as resp:
-                resp.raise_for_status()
-                result = await resp.json()
-                return result.get("text", "").strip()
-    except Exception as e:
-        logger.error("[scribe] Transcription failed: {}", e)
-        return ""
-    finally:
-        Path(tmp_path).unlink(missing_ok=True)
+from stack.ai.client import LLMError, Transcriber
 
 
 class ScribeBot(MicroBot):
@@ -62,7 +25,10 @@ class ScribeBot(MicroBot):
 
     def __init__(self, homeserver, user_id, password, session_dir, **config):
         super().__init__(homeserver, user_id, password, session_dir, **config)
-        self.whisper_url = os.environ.get("WHISPER_URL", config.get("whisper_url", DEFAULT_WHISPER_URL))
+        # The Transcriber owns the HTTP client; we don't have a clean
+        # shutdown hook in the MicroBot base, so we accept that the
+        # underlying client lives for the lifetime of the bot process.
+        self._transcriber = Transcriber.from_env(namespace=self.name)
 
     def register_callbacks(self, client: AsyncClient) -> None:
         self.add_event_callback(self._on_voice, RoomMessageAudio)
@@ -81,7 +47,14 @@ class ScribeBot(MicroBot):
             return
 
         filename = event.body if event.body else "voice.ogg"
-        text = await _transcribe(self.whisper_url, audio, filename)
+        text = ""
+        try:
+            text = await self._transcriber.transcribe(audio, filename=filename)
+        except LLMError as e:
+            # The Transcriber maps every transport / API failure to an
+            # LLMError; we log and fall through to the empty-text branch
+            # so the family sees a friendly reply instead of silence.
+            logger.error("[scribe] Transcription failed: {}", e)
         await self._set_typing(room.room_id, on=False)
 
         if text:
@@ -94,4 +67,3 @@ class ScribeBot(MicroBot):
             await self._send(
                 room.room_id, "Sorry, I couldn't transcribe that audio.",
             )
-

--- a/stacklets/messages/bot/scribe.py
+++ b/stacklets/messages/bot/scribe.py
@@ -17,7 +17,7 @@ from nio import (
 )
 
 from microbot import MicroBot
-from stack.ai.client import LLMError, LLMUnavailableError, Transcriber
+from stack.ai.client import LLM, LLMError, LLMUnavailableError, Transcriber
 
 
 class ScribeBot(MicroBot):
@@ -43,6 +43,20 @@ class ScribeBot(MicroBot):
             )
             self._transcriber = None
 
+        # The LLM is optional: when present, it polishes raw whisper
+        # output into a punctuated paragraph (the Transcriber owns the
+        # prompt). When absent, scribe still posts the raw transcript --
+        # less readable but never a blocker.
+        try:
+            self._llm = LLM.from_env(namespace=self.name)
+        except LLMUnavailableError as e:
+            logger.warning(
+                "[scribe] transcript cleanup disabled: {} — "
+                "voice messages will post the raw whisper output",
+                e,
+            )
+            self._llm = None
+
     def register_callbacks(self, client: AsyncClient) -> None:
         self.add_event_callback(self._on_voice, RoomMessageAudio)
 
@@ -67,7 +81,9 @@ class ScribeBot(MicroBot):
         filename = event.body if event.body else "voice.ogg"
         text = ""
         try:
-            text = await self._transcriber.transcribe(audio, filename=filename)
+            text = await self._transcriber.transcribe(
+                audio, filename=filename, cleanup_with=self._llm,
+            )
         except LLMError as e:
             # The Transcriber maps every transport / API failure to an
             # LLMError; we log and fall through to the empty-text branch

--- a/stacklets/messages/bot/scribe.py
+++ b/stacklets/messages/bot/scribe.py
@@ -17,7 +17,7 @@ from nio import (
 )
 
 from microbot import MicroBot
-from stack.ai.client import LLMError, Transcriber
+from stack.ai.client import LLMError, LLMUnavailableError, Transcriber
 
 
 class ScribeBot(MicroBot):
@@ -28,13 +28,31 @@ class ScribeBot(MicroBot):
         # The Transcriber owns the HTTP client; we don't have a clean
         # shutdown hook in the MicroBot base, so we accept that the
         # underlying client lives for the lifetime of the bot process.
-        self._transcriber = Transcriber.from_env(namespace=self.name)
+        #
+        # When WHISPER_URL isn't set (e.g. the AI stacklet hasn't been
+        # installed yet) the constructor would otherwise crash here. We
+        # degrade to a no-op bot instead: still in the room, still
+        # joinable, but silent on voice messages until whisper is wired.
+        try:
+            self._transcriber = Transcriber.from_env(namespace=self.name)
+        except LLMUnavailableError as e:
+            logger.warning(
+                "[scribe] transcription disabled: {} — "
+                "voice messages will be ignored until WHISPER_URL is set",
+                e,
+            )
+            self._transcriber = None
 
     def register_callbacks(self, client: AsyncClient) -> None:
         self.add_event_callback(self._on_voice, RoomMessageAudio)
 
     async def _on_voice(self, room, event: RoomMessageAudio) -> None:
         if event.sender == self.user_id:
+            return
+        if self._transcriber is None:
+            # The startup warning already told the admin why; don't
+            # spam a per-message error reply or a typing indicator that
+            # leads nowhere.
             return
 
         logger.info("[scribe] Voice from {} in {}", event.sender, room.room_id)

--- a/tests/framework/test_ai_client.py
+++ b/tests/framework/test_ai_client.py
@@ -531,3 +531,106 @@ class TestTranscriberFromEnv:
         monkeypatch.delenv("WHISPER_KEY", raising=False)
         tr = Transcriber.from_env()
         assert tr._client.api_key == "not-needed"
+
+
+# ── Transcript cleanup ──────────────────────────────────────────────────
+#
+# The cleanup pass turns whisper's raw output into a punctuated paragraph.
+# We test against a stub LLM rather than the framework LLM + httpserver:
+# the contract we care about is "raw whisper text -> LLM.complete -> result",
+# not the inner HTTP shape (already covered by TestComplete above).
+
+
+class _StubLLM:
+    """Minimal LLM-shaped object for Transcriber cleanup tests.
+
+    Records the role and prompt it was called with, returns a configured
+    string or raises a configured error. Matches the signature
+    ``Transcriber._cleanup`` calls: ``complete(role, prompt)``.
+    """
+
+    def __init__(self, result: str = "Cleaned text.",
+                 error: Exception | None = None):
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, str]] = []
+
+    async def complete(self, role: str, prompt: str) -> str:
+        self.calls.append((role, prompt))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class TestTranscriberCleanup:
+    """The cleanup_with kwarg is a best-effort polish: the caller always
+    gets a usable transcript, never a hard failure when the LLM hiccups."""
+
+    async def test_cleanup_applied_when_llm_provided(self, httpserver: HTTPServer):
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "hey i forgot to renew the boiler"})
+
+        llm = _StubLLM(result="Hey, I forgot to renew the boiler.")
+        tr = _make_transcriber(httpserver)
+        result = await tr.transcribe(b"audio", cleanup_with=llm)
+        assert result == "Hey, I forgot to renew the boiler."
+        # The cleanup hit the LLM exactly once, with the raw transcript
+        # interpolated into the strict-rules prompt.
+        assert len(llm.calls) == 1
+        role, prompt = llm.calls[0]
+        assert role == "transcript_cleanup"
+        assert "hey i forgot to renew the boiler" in prompt
+        assert "Do not change, add, remove, or reorder any words." in prompt
+        await tr.aclose()
+
+    async def test_no_cleanup_when_kwarg_omitted(self, httpserver: HTTPServer):
+        """Default path: no LLM passed -> raw STT result returned unchanged.
+        Verifies the kwarg defaults to None and skips cleanup entirely."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "raw words"})
+
+        tr = _make_transcriber(httpserver)
+        assert await tr.transcribe(b"audio") == "raw words"
+        await tr.aclose()
+
+    async def test_empty_raw_skips_cleanup_call(self, httpserver: HTTPServer):
+        """A silent voice memo returns empty -> no point asking the LLM
+        to clean nothing. Verifies we don't waste a call on empties."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "   "})
+
+        llm = _StubLLM(result="should not be reached")
+        tr = _make_transcriber(httpserver)
+        assert await tr.transcribe(b"silence", cleanup_with=llm) == ""
+        assert llm.calls == []
+        await tr.aclose()
+
+    async def test_llm_error_falls_back_to_raw(self, httpserver: HTTPServer):
+        """The LLM is down at cleanup time. The caller still gets the raw
+        transcript -- without punctuation, but usable. Cleanup is polish,
+        not a hard requirement."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "raw uncleaned words"})
+
+        failing = _StubLLM(error=LLMUnavailableError("oMLX offline"))
+        tr = _make_transcriber(httpserver)
+        result = await tr.transcribe(b"audio", cleanup_with=failing)
+        assert result == "raw uncleaned words"
+        assert len(failing.calls) == 1  # we did try once
+        await tr.aclose()
+
+    async def test_empty_cleanup_response_falls_back_to_raw(self, httpserver: HTTPServer):
+        """A model that follows the prompt poorly and returns nothing is
+        no better than the LLM being down. Fall back to raw."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "raw words present"})
+
+        empty_llm = _StubLLM(result="   \n  ")
+        tr = _make_transcriber(httpserver)
+        assert await tr.transcribe(b"audio", cleanup_with=empty_llm) == "raw words present"
+        await tr.aclose()

--- a/tests/framework/test_ai_client.py
+++ b/tests/framework/test_ai_client.py
@@ -32,6 +32,7 @@ from stack.ai.client import (  # noqa: E402
     LLMTimeoutError,
     LLMUnavailableError,
     ModelCapabilities,
+    Transcriber,
 )
 
 
@@ -365,3 +366,168 @@ class TestHasVision:
         llm = _make_llm(httpserver, capabilities=cap)
         assert await llm.has_vision() is True
         await llm.aclose()
+
+
+# ── Transcriber ──────────────────────────────────────────────────────────
+#
+# The Transcriber wraps the same SDK but points at whisper-server, which
+# speaks /v1/audio/transcriptions. We pin transport-level behaviour the
+# same way the LLM tests do: a pytest-httpserver mock for the endpoint,
+# and assert that bytes go in as multipart and text comes back out.
+
+def _make_transcriber(httpserver: HTTPServer, *, timeout: float = 5.0) -> Transcriber:
+    """Build a Transcriber pointed at the local httpserver mock."""
+    client = AsyncOpenAI(
+        base_url=httpserver.url_for("/v1"),
+        api_key="not-needed",
+        max_retries=0,
+        timeout=timeout,
+    )
+    return Transcriber(client, namespace="test-bot")
+
+
+class TestTranscribe:
+    """Happy path + error translation for the Transcriber."""
+
+    async def test_returns_text_from_server(self, httpserver: HTTPServer):
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "hello from whisper"})
+
+        tr = _make_transcriber(httpserver)
+        result = await tr.transcribe(b"fake-audio-bytes", filename="voice.ogg")
+        assert result == "hello from whisper"
+        await tr.aclose()
+
+    async def test_strips_surrounding_whitespace(self, httpserver: HTTPServer):
+        """whisper-server often returns text with a leading space; callers
+        shouldn't have to remember to strip."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_json({"text": "  hello  \n"})
+
+        tr = _make_transcriber(httpserver)
+        assert await tr.transcribe(b"fake-audio") == "hello"
+        await tr.aclose()
+
+    async def test_sends_multipart_with_filename(self, httpserver: HTTPServer):
+        """The filename matters — whisper.cpp sniffs the container by
+        extension, so 'voice.ogg' vs 'voice.wav' picks a different decoder.
+        Pin that the SDK actually puts our filename on the wire."""
+        captured: dict = {}
+
+        def handler(request):
+            captured["content_type"] = request.headers.get("Content-Type", "")
+            captured["body"] = request.get_data()
+            from werkzeug.wrappers import Response
+            return Response(
+                json.dumps({"text": "ok"}),
+                content_type="application/json",
+            )
+
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_handler(handler)
+
+        tr = _make_transcriber(httpserver)
+        await tr.transcribe(b"PAYLOAD-BYTES", filename="memo.wav")
+
+        assert captured["content_type"].startswith("multipart/form-data")
+        assert b"memo.wav" in captured["body"]
+        assert b"PAYLOAD-BYTES" in captured["body"]
+        await tr.aclose()
+
+    async def test_404_raises_unavailable(self, httpserver: HTTPServer):
+        """Whisper has one model, so a 404 isn't 'model not found' — it's
+        the endpoint being misconfigured. Surface as Unavailable, not the
+        ModelNotFound the LLM uses."""
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_data("not found", status=404)
+
+        tr = _make_transcriber(httpserver)
+        with pytest.raises(LLMUnavailableError):
+            await tr.transcribe(b"audio")
+        await tr.aclose()
+
+    async def test_500_raises_unavailable(self, httpserver: HTTPServer):
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_data("boom", status=500)
+
+        tr = _make_transcriber(httpserver)
+        with pytest.raises(LLMUnavailableError):
+            await tr.transcribe(b"audio")
+        await tr.aclose()
+
+    async def test_connection_refused_raises_unavailable(self):
+        """Whisper-server isn't running — APIConnectionError -> Unavailable."""
+        client = AsyncOpenAI(
+            base_url="http://127.0.0.1:1/v1",
+            api_key="not-needed",
+            max_retries=0,
+            timeout=2.0,
+        )
+        tr = Transcriber(client, namespace="test-bot")
+        with pytest.raises(LLMUnavailableError):
+            await tr.transcribe(b"audio")
+        await tr.aclose()
+
+    async def test_timeout_raises_timeout(self, httpserver: HTTPServer):
+        """A long voice memo can stall past the SDK's timeout; map to the
+        same LLMTimeoutError so callers handle it uniformly with the LLM."""
+        import time
+
+        def slow_handler(request):
+            time.sleep(0.5)
+            from werkzeug.wrappers import Response
+            return Response("{}", content_type="application/json")
+
+        httpserver.expect_request(
+            "/v1/audio/transcriptions", method="POST",
+        ).respond_with_handler(slow_handler)
+
+        client = AsyncOpenAI(
+            base_url=httpserver.url_for("/v1"),
+            api_key="not-needed",
+            max_retries=0,
+            timeout=httpx.Timeout(0.1),
+        )
+        tr = Transcriber(client, namespace="test-bot")
+        with pytest.raises(LLMTimeoutError):
+            await tr.transcribe(b"audio")
+        await tr.aclose()
+
+
+class TestTranscriberFromEnv:
+    def test_strips_trailing_endpoint(self, monkeypatch):
+        """The bot-runner env renders WHISPER_URL with the full endpoint;
+        the SDK appends /audio/transcriptions itself, so we strip it."""
+        monkeypatch.setenv(
+            "WHISPER_URL", "http://host.docker.internal:42062/v1/audio/transcriptions"
+        )
+        tr = Transcriber.from_env(namespace="x")
+        assert str(tr._client.base_url).rstrip("/") == "http://host.docker.internal:42062/v1"
+
+    def test_accepts_v1_base(self, monkeypatch):
+        """Setting just the /v1 root must also work — the SDK appends the
+        endpoint either way."""
+        monkeypatch.setenv("WHISPER_URL", "http://whisper.local/v1")
+        tr = Transcriber.from_env()
+        assert str(tr._client.base_url).rstrip("/") == "http://whisper.local/v1"
+
+    def test_empty_url_raises_unavailable(self, monkeypatch):
+        """Privacy guard mirrors LLM.from_env: an unset WHISPER_URL must
+        not silently fall through to api.openai.com (the SDK's default)."""
+        monkeypatch.delenv("WHISPER_URL", raising=False)
+        monkeypatch.delenv("WHISPER_KEY", raising=False)
+        with pytest.raises(LLMUnavailableError):
+            Transcriber.from_env()
+
+    def test_empty_key_falls_back(self, monkeypatch):
+        """Native whisper-server is unauthenticated; the SDK insists on
+        *some* key so the constructor substitutes a placeholder."""
+        monkeypatch.setenv("WHISPER_URL", "http://whisper.local/v1")
+        monkeypatch.delenv("WHISPER_KEY", raising=False)
+        tr = Transcriber.from_env()
+        assert tr._client.api_key == "not-needed"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -348,11 +348,20 @@ def memory_repo(code) -> None:
     from stack.forgejo import ForgejoClient
     import lib as memory_lib
 
-    client = ForgejoClient(
+    admin_client = ForgejoClient(
         url=code.url, admin_user=code.admin_user, admin_password=code.admin_password,
     )
-    memory_lib.ensure_memory_repo(client)
-    memory_lib.install_seeds(client)
+    memory_lib.ensure_memory_repo(admin_client)
+    # install_seeds writes through the contents API which requires a
+    # token-authed client (basic admin auth isn't enough). Mirror
+    # `install_memory_to_forgejo_admin`'s production shape: issue an
+    # admin token, then use it for the seed push.
+    admin_token = admin_client.issue_token(
+        code.admin_user, code.admin_password,
+        "memory-install-tests", memory_lib.TOKEN_SCOPES,
+    )
+    token_client = ForgejoClient(url=code.url, token=admin_token)
+    memory_lib.install_seeds(token_client)
 
 
 @pytest.fixture

--- a/tests/integration/test_capture_binary_e2e.py
+++ b/tests/integration/test_capture_binary_e2e.py
@@ -1,0 +1,631 @@
+"""End-to-end coverage for the capture-binary path.
+
+Captures used to be URL-only and text-only. Recent work added:
+
+  - PDFs and images in non-documents rooms become visual bookmarks,
+    with the binary staying on the homeserver (`source_uri: mxc://...`)
+    instead of duplicating into Paperless.
+  - `.md` / `.txt` uploads land as `kind: note` with the bytes
+    preserved verbatim in the mirror.
+  - Replying (without `@`-mention) to a `capture.filed` confirmation
+    re-runs the classifier and rewrites the entry in place, emitting
+    a `capture.reclassified` envelope so further corrections can chain.
+  - `@`-mention in a capture room is conversational: the mention
+    bypasses the reply-to-correct router so search queries reach the
+    search handler.
+
+These four scenarios exercise the framework end-to-end against the
+real container rig (Synapse, Forgejo, bot-runner) with OpenAI stubbed
+deterministically via pytest-httpserver.
+
+Run with `-s` to stream the BDD narration:
+
+    uv run --extra test pytest -s tests/integration/test_capture_binary_e2e.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+
+from nio.api import RoomVisibility
+from nio.responses import RoomInviteResponse, UploadResponse
+
+from tests.integration.forgejo import ForgejoError
+from tests.integration.openai_stub import stub_classify
+
+
+MEMORY_OWNER = "family"
+MEMORY_REPO = "memory"
+ARCHIVIST_MXID = "@archivist-bot:test.local"
+FAMSTACK_EVENT_KEY = "dev.famstack.event"
+
+
+# ── Shared helpers ──────────────────────────────────────────────────────
+
+
+async def _wait_for_bot_membership(client, room_id: str, bot_mxid: str,
+                                   timeout: int = 30) -> None:
+    """Poll until the archivist has accepted its invite and joined."""
+    from nio.responses import JoinedMembersResponse
+    for _ in range(timeout):
+        resp = await client.joined_members(room_id)
+        if isinstance(resp, JoinedMembersResponse):
+            if any(m.user_id == bot_mxid for m in resp.members):
+                return
+        await asyncio.sleep(1)
+    raise AssertionError(f"{bot_mxid} did not join {room_id} within {timeout}s")
+
+
+async def _wait_for_capture_by_title(code, title: str,
+                                     timeout: int = 60) -> str | None:
+    """Find a mirror file whose frontmatter title matches `title`."""
+    for _ in range(timeout):
+        try:
+            tree = code.list_tree(MEMORY_OWNER, MEMORY_REPO)
+        except ForgejoError:
+            await asyncio.sleep(1)
+            continue
+        for entry in tree:
+            path = entry.get("path", "")
+            if entry.get("type") != "blob" or not path.endswith(".md"):
+                continue
+            if path == "README.md":
+                continue
+            try:
+                fm, _ = code.load_frontmatter(MEMORY_OWNER, MEMORY_REPO, path)
+            except Exception:
+                continue
+            if isinstance(fm, dict) and fm.get("title") == title:
+                return path
+        await asyncio.sleep(1)
+    return None
+
+
+async def _wait_for_bot_reply(
+    client, room_id: str, *, after_ts_ms: int,
+    envelope_type: str | None = None,
+    body_substring: str | None = None,
+    timeout: int = 60,
+):
+    """Sync until the archivist posts a message matching the predicate.
+
+    Each round consumes one sync long-poll (~5s); bounded by ``timeout``
+    seconds. Returns the matching event, or None on timeout.
+    """
+    from nio import SyncResponse, RoomMessageText
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        resp = await client.sync(timeout=4000)
+        if not isinstance(resp, SyncResponse):
+            continue
+        room = resp.rooms.join.get(room_id)
+        if room is None:
+            continue
+        for ev in room.timeline.events:
+            if not isinstance(ev, RoomMessageText):
+                continue
+            if ev.sender != ARCHIVIST_MXID:
+                continue
+            if ev.server_timestamp < after_ts_ms:
+                continue
+            if body_substring and body_substring not in ev.body:
+                continue
+            if envelope_type:
+                env = ev.source.get("content", {}).get(FAMSTACK_EVENT_KEY) or {}
+                if env.get("type") != envelope_type:
+                    continue
+            return ev
+    return None
+
+
+def _tiny_pdf(text_lines: list[str]) -> bytes:
+    """Hand-rolled single-page PDF with each line at its own y-offset.
+
+    Just real enough for Paperless OCR + pypdf text-layer extraction
+    to recover the content. Avoids pulling reportlab into the test
+    dependency surface for one test scenario.
+    """
+    def _esc(s: str) -> str:
+        return s.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    parts = ["BT", "/F1 14 Tf", "72 760 Td"]
+    for i, line in enumerate(text_lines):
+        if i > 0:
+            parts.append("0 -18 Td")
+        parts.append(f"({_esc(line)}) Tj")
+    parts.append("ET")
+    stream = "\n".join(parts).encode("latin-1")
+    obj1 = b"<< /Type /Catalog /Pages 2 0 R >>"
+    obj2 = b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"
+    obj3 = (
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+    )
+    obj4 = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"
+    obj5 = (
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n"
+        + stream + b"\nendstream"
+    )
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for i, body in enumerate((obj1, obj2, obj3, obj4, obj5), start=1):
+        offsets.append(len(out))
+        out += f"{i} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref_pos = len(out)
+    out += b"xref\n0 6\n0000000000 65535 f \n"
+    for off in offsets[1:]:
+        out += f"{off:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+async def _matrix_upload(client, data: bytes, filename: str, mime: str) -> str:
+    """Upload bytes to the homeserver media repo; return the mxc URL."""
+    upload, _ = await client.upload(
+        data_provider=lambda *_: io.BytesIO(data),
+        content_type=mime,
+        filename=filename,
+        filesize=len(data),
+    )
+    if not isinstance(upload, UploadResponse):
+        raise AssertionError(f"matrix upload failed: {upload}")
+    return upload.content_uri
+
+
+async def _create_notes_room(homer, name: str) -> str:
+    """Create a private notes room, invite the archivist, wait for join."""
+    create = await homer.room_create(
+        name=name, visibility=RoomVisibility.private,
+    )
+    room_id = getattr(create, "room_id", None)
+    assert room_id, f"room_create returned no room_id: {create}"
+    invite = await homer.room_invite(room_id, ARCHIVIST_MXID)
+    assert isinstance(invite, RoomInviteResponse), f"invite failed: {invite}"
+    await _wait_for_bot_membership(homer, room_id, ARCHIVIST_MXID)
+    return room_id
+
+
+def _now_ms() -> int:
+    import time
+    return int(time.time() * 1000)
+
+
+# ── Scenario 1: PDF in capture room → kind=bookmark ────────────────────
+
+
+async def test_pdf_in_capture_room_becomes_a_bookmark(
+    bdd, openai, paperless, mirror_scope, code, homer,
+):
+    """Homer drops a small text-layer PDF in a notes room → bookmark.
+
+    Scenario
+    --------
+    Given  a notes room with the archivist invited
+    And    the OpenAI mock will classify the upload as a bookmark
+    When   Homer uploads a small PDF
+    Then   family/memory has the entry under `homer/bookmarks/`
+    And    the frontmatter carries `kind: bookmark`, the mxc source_uri,
+           and the capture_id matching the upload event_id
+    """
+    scope = mirror_scope
+    bdd.scenario("PDF in notes room becomes a kind=bookmark mirror entry")
+
+    expected_title = scope.tag("Springfield travel notes")
+    expected_tag = scope.tag("Travel")
+
+    bdd.given(f"Homer creates a notes room and invites {ARCHIVIST_MXID}")
+    room_id = await _create_notes_room(homer, f"Homer Bookmarks {scope.uid}")
+    bdd.detail(f"room_id = {room_id}")
+
+    bdd.given("the OpenAI mock returns a bookmark-shape classification")
+    stub_classify(openai, {
+        "title": expected_title,
+        "persons": ["Homer"],
+        "tags": [expected_tag],
+        "summary": "Notes about a planned trip to Springfield's annual chili cook-off.",
+        "facts": ["Annual cook-off in spring", "Family of four attending"],
+    })
+
+    bdd.when("Homer uploads a small PDF to the notes room")
+    pdf = _tiny_pdf([
+        "Springfield Travel Notes",
+        f"Marker: {scope.uid}",
+        "Plan a trip in May for the annual chili cook-off.",
+    ])
+    filename = f"travel-{scope.uid}.pdf"
+    mxc = await _matrix_upload(homer, pdf, filename, "application/pdf")
+    before = _now_ms()
+    send = await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.file",
+            "body": filename,
+            "url": mxc,
+            "info": {"mimetype": "application/pdf", "size": len(pdf)},
+        },
+    )
+    upload_event_id = send.event_id
+    bdd.detail(f"upload event_id = {upload_event_id}")
+
+    bdd.then(f"family/memory has a capture entry titled '{expected_title}'")
+    path = await _wait_for_capture_by_title(code, expected_title)
+    assert path, (
+        f"No capture file titled {expected_title!r} appeared in "
+        f"{MEMORY_OWNER}/{MEMORY_REPO} within 60s. Check bot-runner logs."
+    )
+    bdd.ok(f"mirror path = {path}")
+
+    bdd.and_("the path lives under homer/bookmarks/")
+    assert path.startswith("homer/bookmarks/"), \
+        f"expected homer/bookmarks/ prefix, got {path}"
+
+    bdd.then("frontmatter carries kind=bookmark, mxc source_uri, capture_id")
+    fm, _body = code.load_frontmatter(MEMORY_OWNER, MEMORY_REPO, path)
+    assert fm.get("kind") == "bookmark", f"expected kind=bookmark, got {fm.get('kind')!r}"
+    assert fm.get("title") == expected_title
+    assert fm.get("source_uri") == mxc, \
+        f"expected source_uri={mxc}, got {fm.get('source_uri')!r}"
+    assert fm.get("capture_id") == upload_event_id, (
+        f"expected capture_id={upload_event_id!r}, got {fm.get('capture_id')!r} "
+        "-- Matrix event_id MUST persist as the stable correlation key"
+    )
+    bdd.ok(f"kind={fm['kind']} capture_id={fm['capture_id'][:24]}...")
+
+    bdd.and_("a capture.filed envelope was emitted on the bot's reply")
+    reply = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before,
+        envelope_type="capture.filed",
+        body_substring=expected_title,
+    )
+    assert reply is not None, "no capture.filed envelope on the bot's reply"
+    env = reply.source["content"][FAMSTACK_EVENT_KEY]
+    assert env["data"]["vault_path"] == path, \
+        f"envelope vault_path={env['data']['vault_path']} != mirror path={path}"
+    assert env["data"]["capture_id"] == upload_event_id
+
+
+# ── Scenario 2: .md upload → kind=note, body preserved ─────────────────
+
+
+async def test_markdown_upload_in_capture_room_becomes_a_note(
+    bdd, openai, paperless, mirror_scope, code, homer,
+):
+    """An .md file is content-bearing, not a pointer → kind=note.
+
+    Scenario
+    --------
+    Given  a notes room with the archivist invited
+    And    the OpenAI mock classifies the upload as a note
+    When   Homer uploads a Markdown file
+    Then   the mirror entry is `kind: note`, lives under `homer/notes/`,
+           and the original bytes are preserved verbatim in the body
+    """
+    scope = mirror_scope
+    bdd.scenario("Markdown upload becomes kind=note with body preserved")
+
+    expected_title = scope.tag("Quick LLM notes")
+
+    bdd.given(f"Homer creates a notes room and invites {ARCHIVIST_MXID}")
+    room_id = await _create_notes_room(homer, f"Homer Md {scope.uid}")
+
+    bdd.given("the OpenAI mock returns a note classification")
+    stub_classify(openai, {
+        "title": expected_title,
+        "persons": ["Homer"],
+        "tags": [scope.tag("LLMs")],
+        "summary": "A few quick notes on running quantised models locally.",
+        "facts": [],
+    })
+
+    bdd.when("Homer uploads a Markdown file")
+    body_text = (
+        "# Quick LLM notes\n\n"
+        "Random observations about MLX-LM running on Apple Silicon.\n\n"
+        f"- Marker: {scope.uid}\n"
+        "- Quantised models keep the memory footprint reasonable.\n"
+        "- `mlx_lm.server` exposes an OpenAI-compatible API.\n"
+    )
+    data = body_text.encode("utf-8")
+    filename = f"notes-{scope.uid}.md"
+    mxc = await _matrix_upload(homer, data, filename, "text/markdown")
+    send = await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.file",
+            "body": filename,
+            "url": mxc,
+            "info": {"mimetype": "text/markdown", "size": len(data)},
+        },
+    )
+    bdd.detail(f"upload event_id = {send.event_id}")
+
+    bdd.then(f"family/memory has a note titled '{expected_title}'")
+    path = await _wait_for_capture_by_title(code, expected_title)
+    assert path, f"no note titled {expected_title!r} appeared within 60s"
+    bdd.ok(f"mirror path = {path}")
+
+    bdd.and_("the path lives under homer/notes/")
+    assert path.startswith("homer/notes/"), \
+        f"expected homer/notes/ prefix, got {path}"
+
+    bdd.then("kind=note and the original bytes are preserved in the body")
+    fm, body = code.load_frontmatter(MEMORY_OWNER, MEMORY_REPO, path)
+    assert fm.get("kind") == "note", f"expected kind=note, got {fm.get('kind')!r}"
+    assert fm.get("source_uri") == mxc
+    # The mirror renders the original under a collapsible callout; each
+    # line is `> `-prefixed. Check the marker landed there verbatim.
+    assert f"> - Marker: {scope.uid}" in body, (
+        f"original paste missing from body. First 600 chars: {body[:600]!r}"
+    )
+
+
+# ── Scenario 3: reply-to-correct rewrites the capture in place ─────────
+
+
+async def test_capture_reply_to_correct_rewrites_mirror_and_emits_reclassified(
+    bdd, openai, paperless, mirror_scope, code, homer,
+):
+    """Homer files a capture, then replies with a correction.
+
+    Scenario
+    --------
+    Given  the archivist filed a capture (envelope captured)
+    When   Homer replies to the Gespeichert message with a correction
+    Then   the archivist re-classifies the entry, rewrites the mirror
+           in place (new title + tags), and emits a capture.reclassified
+           envelope so further corrections can chain
+    """
+    scope = mirror_scope
+    bdd.scenario("Reply-to-correct rewrites the capture entry in place")
+
+    initial_title = scope.tag("Initial title")
+    corrected_title = scope.tag("Corrected title")
+    initial_tag = scope.tag("Misclassified")
+    corrected_tag = scope.tag("Correct")
+
+    bdd.given(f"Homer creates a notes room and invites {ARCHIVIST_MXID}")
+    room_id = await _create_notes_room(homer, f"Homer Correct {scope.uid}")
+
+    bdd.given("the OpenAI mock will classify twice -- initial, then reprocess")
+    stub_classify(openai, {
+        "title": initial_title,
+        "persons": ["Homer"],
+        "tags": [initial_tag],
+        "summary": "Initial classification of a captured PDF.",
+        "facts": [],
+    })
+    # Reprocess pass. The bot reads the prior summary + tags from the
+    # mirror, classifier sees them in the source text and the chain
+    # walker's hint; we stub a fresh payload that the rewrite uses.
+    stub_classify(openai, {
+        "title": corrected_title,
+        "persons": ["Homer"],
+        "tags": [corrected_tag],
+        "summary": "Corrected classification reflecting Homer's hint.",
+        "facts": [],
+    })
+
+    bdd.when("Homer uploads a small PDF to the notes room")
+    pdf = _tiny_pdf([
+        "Capture under test",
+        f"Marker: {scope.uid}",
+        "Some captured content for the bot to summarise.",
+    ])
+    filename = f"capture-{scope.uid}.pdf"
+    mxc = await _matrix_upload(homer, pdf, filename, "application/pdf")
+    before_initial = _now_ms()
+    await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.file",
+            "body": filename,
+            "url": mxc,
+            "info": {"mimetype": "application/pdf", "size": len(pdf)},
+        },
+    )
+
+    bdd.then(f"the initial capture is filed as '{initial_title}'")
+    initial_path = await _wait_for_capture_by_title(code, initial_title)
+    assert initial_path, "initial capture not found within 60s"
+    bdd.ok(f"initial path = {initial_path}")
+
+    bdd.and_("the bot's filing reply carries a capture.filed envelope")
+    filed_reply = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before_initial,
+        envelope_type="capture.filed",
+        body_substring=initial_title,
+    )
+    assert filed_reply is not None, "missing capture.filed envelope"
+
+    bdd.when("Homer replies to the Gespeichert message with a correction")
+    correction = "Actually the title should reflect a Correct classification."
+    before_reprocess = _now_ms()
+    await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.text",
+            "body": correction,
+            "m.relates_to": {
+                "m.in_reply_to": {"event_id": filed_reply.event_id},
+            },
+            "format": "org.matrix.custom.html",
+            "formatted_body": (
+                f'<mx-reply><blockquote>'
+                f'<a href="https://matrix.to/#/{room_id}/{filed_reply.event_id}">'
+                f'In reply to</a> '
+                f'<a href="https://matrix.to/#/{ARCHIVIST_MXID}">{ARCHIVIST_MXID}</a>'
+                f'<br>{filed_reply.body[:80]}'
+                f'</blockquote></mx-reply>{correction}'
+            ),
+        },
+    )
+
+    bdd.then(f"the mirror is rewritten with the new title '{corrected_title}'")
+    new_path = await _wait_for_capture_by_title(code, corrected_title)
+    assert new_path, "rewritten capture not found within 60s"
+    bdd.ok(f"new path = {new_path}")
+
+    bdd.and_("the old entry is removed (rename, not duplicate)")
+    if new_path != initial_path:
+        # Title-slug renames remove the prior file. When the new title
+        # happens to slug-equal the old one (unlikely with our scoped
+        # tags) the same path survives -- skip the assertion in that case.
+        try:
+            still_there = await _wait_for_capture_by_title(
+                code, initial_title, timeout=5,
+            )
+        except Exception:
+            still_there = None
+        assert still_there is None, (
+            f"old entry {initial_path} still present after rename to {new_path}"
+        )
+
+    bdd.then("frontmatter shows the corrected tags and persists capture_id")
+    fm, _ = code.load_frontmatter(MEMORY_OWNER, MEMORY_REPO, new_path)
+    tags = fm.get("tags") or []
+    assert corrected_tag in tags, f"expected {corrected_tag!r} in {tags}"
+    assert initial_tag not in tags, (
+        f"stale {initial_tag!r} survived in {tags} -- delta semantics broken"
+    )
+    assert isinstance(fm.get("capture_id"), str), \
+        f"capture_id missing from rewritten entry: {fm}"
+
+    bdd.and_("the bot replied with a capture.reclassified envelope")
+    reclassed = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before_reprocess,
+        envelope_type="capture.reclassified",
+        body_substring=corrected_title,
+    )
+    assert reclassed is not None, (
+        "no capture.reclassified envelope -- chained corrections will not work"
+    )
+    env = reclassed.source["content"][FAMSTACK_EVENT_KEY]
+    assert env["data"]["vault_path"] == new_path
+
+
+# ── Scenario 4: @-mention with a search query hits search, not reprocess ─
+
+
+async def test_mention_in_capture_room_routes_to_search_not_reprocess(
+    bdd, openai, paperless, mirror_scope, code, homer,
+):
+    """`@`-mention overrides the reply-to-correct router.
+
+    Element X attaches `m.in_reply_to` to mentioned messages even when
+    they're conversational. Without the mention-guard the search query
+    would be eaten by capture-reprocess and never reach
+    `_handle_search`. We verify the routing here by sending a mention-
+    shaped reply to a `capture.filed` confirmation and asserting the
+    bot's response is a search-shaped reply (not a reclassified one).
+
+    Scenario
+    --------
+    Given  the archivist filed a capture
+    When   Homer @-mentions the bot with a search query, threaded as a
+           reply to the Gespeichert message
+    Then   the bot's reply is a search result (search emoji, not the
+           reclassify emoji) AND no capture.reclassified envelope was
+           emitted
+    """
+    scope = mirror_scope
+    bdd.scenario("Mention with search query bypasses reprocess")
+
+    filed_title = scope.tag("Indexable capture")
+
+    bdd.given(f"Homer creates a notes room and invites {ARCHIVIST_MXID}")
+    room_id = await _create_notes_room(homer, f"Homer Search {scope.uid}")
+
+    bdd.given("the OpenAI mock will classify once and rewrite a query once")
+    stub_classify(openai, {
+        "title": filed_title,
+        "persons": ["Homer"],
+        "tags": [scope.tag("Searchable")],
+        "summary": "A captured doc Homer will later search for.",
+        "facts": [],
+    })
+    # Search runs a rewrite_query LLM call -- stub that too. Whatever
+    # tokens come back, the search itself returns deterministic
+    # results from the test vault state.
+    openai.expect_ordered_request(
+        "/v1/chat/completions", method="POST",
+    ).respond_with_json({
+        "id": "cmpl-test", "object": "chat.completion", "model": "test",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": json.dumps({"keywords": ["searchable"]}),
+            },
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    })
+
+    bdd.when("Homer uploads a small PDF and waits for the filing reply")
+    pdf = _tiny_pdf([
+        "Indexable capture", f"Marker: {scope.uid}", "Content to be searched later.",
+    ])
+    filename = f"index-{scope.uid}.pdf"
+    mxc = await _matrix_upload(homer, pdf, filename, "application/pdf")
+    before_initial = _now_ms()
+    await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.file", "body": filename, "url": mxc,
+            "info": {"mimetype": "application/pdf", "size": len(pdf)},
+        },
+    )
+    filed = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before_initial,
+        envelope_type="capture.filed", body_substring=filed_title,
+    )
+    assert filed is not None
+
+    bdd.when("Homer @-mentions the bot with a search query as a reply")
+    before_search = _now_ms()
+    await homer.room_send(
+        room_id=room_id, message_type="m.room.message",
+        content={
+            "msgtype": "m.text",
+            "body": "Archivist: searchable",
+            "format": "org.matrix.custom.html",
+            "formatted_body": (
+                f'<a href="https://matrix.to/#/{ARCHIVIST_MXID}">Archivist</a>'
+                ': searchable'
+            ),
+            "m.mentions": {"user_ids": [ARCHIVIST_MXID]},
+            "m.relates_to": {
+                "m.in_reply_to": {"event_id": filed.event_id},
+            },
+        },
+    )
+
+    bdd.then("the bot replies with a search-shaped message")
+    # Search replies start with the search emoji (`\U0001F50D` 🔍) per
+    # `messages/archivist.yml`. A reclassified reply would start with
+    # the loop emoji (`\U0001F501` 🔁). Asserting on the emoji is the
+    # cheapest unambiguous shape check.
+    reply = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before_search,
+        body_substring="\U0001F50D",
+    )
+    assert reply is not None, (
+        "no search-shaped reply -- the mention guard regressed and search "
+        "got swallowed by reprocess"
+    )
+    assert "\U0001F501" not in reply.body[:4], (
+        f"reply looks like a reclassification, not a search: {reply.body[:80]!r}"
+    )
+
+    bdd.and_("no capture.reclassified envelope was emitted")
+    reclassed = await _wait_for_bot_reply(
+        homer, room_id, after_ts_ms=before_search,
+        envelope_type="capture.reclassified", timeout=10,
+    )
+    assert reclassed is None, (
+        "capture.reclassified envelope appeared -- the mention-guard let "
+        "the search query slip into reprocess"
+    )

--- a/tests/stacklets/test_capture_pipeline.py
+++ b/tests/stacklets/test_capture_pipeline.py
@@ -94,7 +94,8 @@ class FakeNotifier:
         self.statuses.append((key, kwargs))
 
 
-def _pipeline(*, mirror, classifier=None, capture_keep_body=False):
+def _pipeline(*, mirror, classifier=None, capture_keep_body=False,
+              transcriber=None):
     return CapturePipeline(
         url_extractor=FakeExtractor(_source(source_uri="http://src")),
         text_extractor=FakeExtractor(_source(source_uri="http://embedded")),
@@ -106,7 +107,26 @@ def _pipeline(*, mirror, classifier=None, capture_keep_body=False):
         classify_max_chars=10000,
         capture_keep_body=capture_keep_body,
         capture_tag_prompt_size=50,
+        transcriber=transcriber,
     )
+
+
+class FakeTranscriber:
+    """Stand-in for stack.ai.client.Transcriber — records calls and
+    returns a configured transcript or raises a configured error."""
+
+    def __init__(self, transcript: str = "I forgot to renew the boiler service",
+                 error: Exception | None = None):
+        self.transcript = transcript
+        self.error = error
+        self.calls: list[tuple[bytes, str]] = []
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
+                         model: str | None = None) -> str:
+        self.calls.append((audio, filename))
+        if self.error is not None:
+            raise self.error
+        return self.transcript
 
 
 class TestCaptureUrl:
@@ -250,12 +270,14 @@ class TestSourceFromBinary:
         assert kind == "bookmark"
 
     def test_unsupported_mime_returns_none(self):
-        # Audio, video, archives: out of scope for v1 captures.
+        # _source_from_binary itself doesn't handle audio; capture_binary
+        # routes audio through _source_from_audio upstream. Video and
+        # archives still land here and fall through to None.
         pipe = self._pipe()
         source, images, _kind = pipe._source_from_binary(
             file_data=b"riff-wave",
-            mime="audio/wav",
-            filename="voice.wav",
+            mime="video/mp4",
+            filename="clip.mp4",
             source_uri="mxc://server/xyz",
         )
         assert source is None
@@ -293,5 +315,124 @@ class TestSourceFromBinary:
         assert source.text == body
         assert kind == "note"
         assert images == []
+
+
+# ── Audio capture (voice memos) ────────────────────────────────────────
+
+
+class TestSourceFromAudio:
+    """The audio branch: transcribe via the injected Transcriber, return
+    a note-shaped SourceContent. When no transcriber is wired, soft-skip
+    with None so the orchestrator surfaces a friendly extract_failed."""
+
+    @pytest.mark.asyncio
+    async def test_transcribes_audio_into_note(self):
+        tr = FakeTranscriber(transcript="Reminder: book the boiler service")
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=tr)
+        source, images, kind = await pipe._source_from_audio(
+            file_data=b"opus-bytes", mime="audio/ogg",
+            filename="voice-2026-06-09.ogg",
+            source_uri="mxc://server/abc",
+        )
+        assert tr.calls == [(b"opus-bytes", "voice-2026-06-09.ogg")]
+        assert source is not None
+        assert source.text == "Reminder: book the boiler service"
+        assert source.mime == "audio/ogg"
+        assert source.title_hint == "voice-2026-06-09.ogg"
+        assert source.source_uri == "mxc://server/abc"
+        assert images == []
+        assert kind == "note"
+
+    @pytest.mark.asyncio
+    async def test_no_transcriber_soft_skips(self):
+        # WHISPER_URL unset at bootstrap -> the pipeline drops audio
+        # rather than raising. Bot replies with extract_failed.
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=None)
+        source, images, _kind = await pipe._source_from_audio(
+            file_data=b"opus-bytes", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+        )
+        assert source is None
+        assert images == []
+
+    @pytest.mark.asyncio
+    async def test_transcriber_error_soft_skips(self):
+        # Whisper is misconfigured or down -> log + drop, same shape as
+        # the no-transcriber case so the user-facing reply is uniform.
+        from stack.ai.client import LLMUnavailableError
+        tr = FakeTranscriber(error=LLMUnavailableError("whisper down"))
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=tr)
+        source, images, _kind = await pipe._source_from_audio(
+            file_data=b"opus-bytes", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+        )
+        assert source is None
+        assert images == []
+
+    @pytest.mark.asyncio
+    async def test_empty_transcript_soft_skips(self):
+        # whisper.cpp sometimes returns "" for a silent clip; treat it
+        # like an unreadable scan -- no point classifying empty bytes.
+        tr = FakeTranscriber(transcript="   \n  ")
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=tr)
+        source, images, _kind = await pipe._source_from_audio(
+            file_data=b"silence", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+        )
+        assert source is None
+        assert images == []
+
+
+class TestCaptureBinaryAudioRouting:
+    """capture_binary peeks at the mime: audio/* -> _source_from_audio,
+    everything else -> _source_from_binary. The classify + mirror tail
+    runs identically afterwards, so a transcribed voice memo lands in
+    the mirror as a fully classified note."""
+
+    @pytest.mark.asyncio
+    async def test_audio_mime_routes_through_transcriber(self):
+        mirror = FakeMirror()
+        tr = FakeTranscriber(transcript="Pick up Bart's prescription Friday")
+        pipe = _pipeline(mirror=mirror, transcriber=tr)
+        out = await pipe.capture_binary(
+            file_data=b"opus-data", mime="audio/ogg",
+            filename="voice-2026-06-09.ogg",
+            source_uri="mxc://server/abc",
+            sender_mxid="@homer:s",
+        )
+        # The transcript reached the mirror via the classify tail.
+        assert tr.calls == [(b"opus-data", "voice-2026-06-09.ogg")]
+        assert out.status == "captured"
+        assert mirror.captures, "expected the transcript to be mirrored as a note"
+        published = mirror.captures[0]
+        # The body the mirror writes IS the transcript -- voice memo as a
+        # searchable note in the sender's bucket.
+        assert "Pick up Bart's prescription Friday" in published["body_text"]
+        assert published["kind"] == "note"
+
+    @pytest.mark.asyncio
+    async def test_audio_without_transcriber_returns_extract_failed(self):
+        # Mirrors a bot booted before `stack up ai` -- the rest of the
+        # bot is alive, but voice messages can't be processed yet.
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=None)
+        out = await pipe.capture_binary(
+            file_data=b"opus-data", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+            sender_mxid="@homer:s",
+        )
+        assert out.status == "extract_failed"
+
+    @pytest.mark.asyncio
+    async def test_non_audio_mime_bypasses_transcriber(self):
+        # An image upload must not get sent to whisper -- the transcriber
+        # is for audio only, so non-audio mimes never touch it.
+        tr = FakeTranscriber()
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=tr)
+        await pipe.capture_binary(
+            file_data=b"\xff\xd8jpg", mime="image/jpeg",
+            filename="recipe.jpg", source_uri="mxc://server/abc",
+            sender_mxid="@homer:s",
+        )
+        assert tr.calls == []
 
 

--- a/tests/stacklets/test_capture_pipeline.py
+++ b/tests/stacklets/test_capture_pipeline.py
@@ -169,6 +169,9 @@ class TestCaptureUrl:
         notifier = FakeNotifier()
         out = await pipe.capture_url(url="http://x", sender_mxid="@homer:s", notifier=notifier)
         assert out.status == "extract_failed"
+        # URL-shaped failure -> the reply layer renders the link error
+        # message (`Couldn't read that link...`).
+        assert out.failure_reason == "url"
         # Fetching was still announced before the failed extract.
         assert notifier.statuses[0][0] == "capture_fetching"
 
@@ -534,6 +537,24 @@ class TestCaptureBinaryAudioRouting:
             sender_mxid="@homer:s",
         )
         assert out.status == "extract_failed"
+        # The reason qualifies the failure so the reply layer can render
+        # a voice-shaped message ('Couldn't transcribe...') rather than
+        # the URL-shaped message ('Couldn't read that link...').
+        assert out.failure_reason == "transcription"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_binary_returns_binary_failure_reason(self):
+        """A non-audio mime that the binary path can't extract (e.g.
+        an unsupported video format) returns failure_reason='binary' so
+        the user gets the file-shaped error message, not the link one."""
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=FakeTranscriber())
+        out = await pipe.capture_binary(
+            file_data=b"random-bytes", mime="video/mp4",
+            filename="clip.mp4", source_uri="mxc://server/v",
+            sender_mxid="@homer:s",
+        )
+        assert out.status == "extract_failed"
+        assert out.failure_reason == "binary"
 
     @pytest.mark.asyncio
     async def test_non_audio_mime_bypasses_transcriber(self):

--- a/tests/stacklets/test_capture_pipeline.py
+++ b/tests/stacklets/test_capture_pipeline.py
@@ -206,6 +206,88 @@ class TestCaptureText:
         assert out.status == "empty"
 
 
+class TestCaptureVoiceBatch:
+    """The ( ... ) batch flow: N voice memos arrive, each gets transcribed
+    on its way in (with LLM cleanup if available), then `)` combines them
+    into one note via capture_voice_batch."""
+
+    @pytest.mark.asyncio
+    async def test_concatenates_transcripts_with_paragraph_breaks(self):
+        mirror = FakeMirror()
+        pipe = _pipeline(mirror=mirror)
+        out = await pipe.capture_voice_batch(
+            transcripts=[
+                "First memo about the boiler.",
+                "Second memo about Bart's prescription.",
+                "Third memo with shopping list.",
+            ],
+            primary_mxc="mxc://server/first",
+            sender_mxid="@homer:s",
+        )
+        assert out.status == "captured"
+        body = mirror.captures[0]["body_text"]
+        assert "First memo about the boiler." in body
+        assert "Second memo about Bart's prescription." in body
+        assert "Third memo with shopping list." in body
+        # Paragraph breaks between memos so the LLM and the human reader
+        # both see them as distinct thoughts.
+        assert "boiler.\n\nSecond" in body
+
+    @pytest.mark.asyncio
+    async def test_empty_transcripts_returns_empty_status(self):
+        """A `(` ... `)` with no voice memos (or all silent ones) drops
+        out as empty -- the orchestrator silently no-ops, matching the
+        existing scan_cancelled semantics for empty PDF batches."""
+        pipe = _pipeline(mirror=FakeMirror())
+        out = await pipe.capture_voice_batch(
+            transcripts=[], primary_mxc=None, sender_mxid="@homer:s",
+        )
+        assert out.status == "empty"
+
+    @pytest.mark.asyncio
+    async def test_blank_transcripts_filtered(self):
+        """Empty / whitespace-only transcripts are dropped silently so
+        one silent memo in the middle of a batch doesn't add a hole
+        of blank lines to the combined body."""
+        mirror = FakeMirror()
+        pipe = _pipeline(mirror=mirror)
+        out = await pipe.capture_voice_batch(
+            transcripts=["real one", "   ", "", "another real one"],
+            primary_mxc="mxc://server/first",
+            sender_mxid="@homer:s",
+        )
+        assert out.status == "captured"
+        body = mirror.captures[0]["body_text"]
+        assert body == "real one\n\nanother real one"
+
+    @pytest.mark.asyncio
+    async def test_primary_mxc_threads_through_as_source_uri(self):
+        """The first memo's mxc becomes the vault note's link -- the
+        wiki entry points back to the start of the conversation."""
+        mirror = FakeMirror()
+        pipe = _pipeline(mirror=mirror)
+        out = await pipe.capture_voice_batch(
+            transcripts=["just one"],
+            primary_mxc="mxc://server/start-of-batch",
+            sender_mxid="@homer:s",
+        )
+        assert mirror.captures[0]["source_uri"] == "mxc://server/start-of-batch"
+        assert out.display_link == "mxc://server/start-of-batch"
+
+    @pytest.mark.asyncio
+    async def test_outcome_carries_transcript_for_reply_echo(self):
+        """The mime=audio/ogg on the synthetic SourceContent triggers
+        the same transcript-in-reply behaviour single-memo captures
+        get -- so the sender sees the combined text quoted back."""
+        pipe = _pipeline(mirror=FakeMirror())
+        out = await pipe.capture_voice_batch(
+            transcripts=["one", "two"],
+            primary_mxc="mxc://server/x",
+            sender_mxid="@homer:s",
+        )
+        assert out.transcript == "one\n\ntwo"
+
+
 class TestTagList:
     """`_tag_list` mixes the classifier's free-form tags with a `Person: X`
     tag per attributed person, normalising types and whitespace."""

--- a/tests/stacklets/test_capture_pipeline.py
+++ b/tests/stacklets/test_capture_pipeline.py
@@ -95,7 +95,7 @@ class FakeNotifier:
 
 
 def _pipeline(*, mirror, classifier=None, capture_keep_body=False,
-              transcriber=None):
+              transcriber=None, llm=None):
     return CapturePipeline(
         url_extractor=FakeExtractor(_source(source_uri="http://src")),
         text_extractor=FakeExtractor(_source(source_uri="http://embedded")),
@@ -108,22 +108,31 @@ def _pipeline(*, mirror, classifier=None, capture_keep_body=False,
         capture_keep_body=capture_keep_body,
         capture_tag_prompt_size=50,
         transcriber=transcriber,
+        llm=llm,
     )
 
 
 class FakeTranscriber:
     """Stand-in for stack.ai.client.Transcriber — records calls and
-    returns a configured transcript or raises a configured error."""
+    returns a configured transcript or raises a configured error.
+
+    Mirrors the real signature including ``cleanup_with`` so the capture
+    pipeline can pass an LLM through and we can assert the routing.
+    """
 
     def __init__(self, transcript: str = "I forgot to renew the boiler service",
                  error: Exception | None = None):
         self.transcript = transcript
         self.error = error
-        self.calls: list[tuple[bytes, str]] = []
+        self.calls: list[dict] = []
 
     async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
-                         model: str | None = None) -> str:
-        self.calls.append((audio, filename))
+                         model: str | None = None,
+                         cleanup_with=None) -> str:
+        self.calls.append({
+            "audio": audio, "filename": filename,
+            "cleanup_with": cleanup_with,
+        })
         if self.error is not None:
             raise self.error
         return self.transcript
@@ -334,7 +343,9 @@ class TestSourceFromAudio:
             filename="voice-2026-06-09.ogg",
             source_uri="mxc://server/abc",
         )
-        assert tr.calls == [(b"opus-bytes", "voice-2026-06-09.ogg")]
+        assert len(tr.calls) == 1
+        assert tr.calls[0]["audio"] == b"opus-bytes"
+        assert tr.calls[0]["filename"] == "voice-2026-06-09.ogg"
         assert source is not None
         assert source.text == "Reminder: book the boiler service"
         assert source.mime == "audio/ogg"
@@ -401,7 +412,9 @@ class TestCaptureBinaryAudioRouting:
             sender_mxid="@homer:s",
         )
         # The transcript reached the mirror via the classify tail.
-        assert tr.calls == [(b"opus-data", "voice-2026-06-09.ogg")]
+        assert len(tr.calls) == 1
+        assert tr.calls[0]["audio"] == b"opus-data"
+        assert tr.calls[0]["filename"] == "voice-2026-06-09.ogg"
         assert out.status == "captured"
         assert mirror.captures, "expected the transcript to be mirrored as a note"
         published = mirror.captures[0]
@@ -452,5 +465,39 @@ class TestCaptureBinaryAudioRouting:
             sender_mxid="@homer:s",
         )
         assert tr.calls == []
+
+    @pytest.mark.asyncio
+    async def test_llm_passed_to_transcriber_as_cleanup_with(self):
+        """The CapturePipeline.llm kwarg threads through to the Transcriber's
+        cleanup_with on every audio capture. This is the wiring contract
+        that powers transcript cleanup -- the Transcriber owns the prompt;
+        the pipeline only has to hand it the LLM."""
+        # Sentinel object: not actually called by FakeTranscriber, but we
+        # assert it shows up in the recorded call.
+        sentinel_llm = object()
+        tr = FakeTranscriber(transcript="raw words")
+        pipe = _pipeline(
+            mirror=FakeMirror(), transcriber=tr, llm=sentinel_llm,
+        )
+        await pipe.capture_binary(
+            file_data=b"opus-data", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+            sender_mxid="@homer:s",
+        )
+        assert tr.calls[0]["cleanup_with"] is sentinel_llm
+
+    @pytest.mark.asyncio
+    async def test_no_llm_means_no_cleanup(self):
+        """When the LLM isn't wired (e.g. archivist boots before
+        OPENAI_URL is set), cleanup_with is None and the Transcriber
+        returns the raw transcript verbatim."""
+        tr = FakeTranscriber(transcript="raw words")
+        pipe = _pipeline(mirror=FakeMirror(), transcriber=tr, llm=None)
+        await pipe.capture_binary(
+            file_data=b"opus-data", mime="audio/ogg",
+            filename="voice.ogg", source_uri="mxc://server/abc",
+            sender_mxid="@homer:s",
+        )
+        assert tr.calls[0]["cleanup_with"] is None
 
 

--- a/tests/stacklets/test_capture_pipeline.py
+++ b/tests/stacklets/test_capture_pipeline.py
@@ -409,6 +409,24 @@ class TestCaptureBinaryAudioRouting:
         # searchable note in the sender's bucket.
         assert "Pick up Bart's prescription Friday" in published["body_text"]
         assert published["kind"] == "note"
+        # The outcome carries the transcript so the reply renderer can
+        # echo it back to the sender; PDF/URL/note captures get None.
+        assert out.transcript == "Pick up Bart's prescription Friday"
+
+    @pytest.mark.asyncio
+    async def test_non_audio_capture_outcome_has_no_transcript(self):
+        """A markdown note capture must not surface a transcript field --
+        only audio captures get one, so the reply layer can branch on
+        presence rather than mime-sniffing again."""
+        mirror = FakeMirror()
+        pipe = _pipeline(mirror=mirror, transcriber=FakeTranscriber())
+        out = await pipe.capture_binary(
+            file_data=b"# Hello\n\nbody",
+            mime="text/markdown", filename="note.md",
+            source_uri="mxc://server/md1", sender_mxid="@homer:s",
+        )
+        assert out.status == "captured"
+        assert out.transcript is None
 
     @pytest.mark.asyncio
     async def test_audio_without_transcriber_returns_extract_failed(self):

--- a/tests/stacklets/test_capture_prompt.py
+++ b/tests/stacklets/test_capture_prompt.py
@@ -128,3 +128,46 @@ class TestExistingTags:
         # Cold start — no existing vocabulary. The prompt still works;
         # the LLM gets to invent the seed tags.
         assert "tags" in prompt
+
+
+# ── Tag-quality bias ─────────────────────────────────────────────────────
+
+
+class TestTagQualityBias:
+    """The capture classifier defaults to generic categories ('Travel')
+    when nothing pushes it. These pins keep the prompt biased toward
+    content-specific tags so 'find my camping notes next year' works."""
+
+    def test_enforces_minimum_three_tags(self):
+        """A single generic tag ('Travel') is the failure mode we hit
+        in practice. Pin the minimum so the rule survives future edits."""
+        prompt = _build_capture_prompt(**COMMON)
+        # The exact phrasing varies; what must NOT slip is the floor.
+        # We pin the literal "MINIMUM 3" since that's the strongest form.
+        assert "MINIMUM 3" in prompt
+
+    def test_advertises_specific_over_generic_bias(self):
+        """A short rule isn't enough; concrete contrast examples push
+        the model harder than abstract instructions. The camping vs
+        travel pair is the canonical demo for this rule."""
+        prompt = _build_capture_prompt(**COMMON)
+        # Two contrast pairs is the bar -- one feels like an example,
+        # multiple feels like a pattern.
+        assert "'camping' beats 'travel'" in prompt
+        assert "PREFER SPECIFIC" in prompt or "Prefer specific" in prompt
+
+    def test_includes_german_tag_examples(self):
+        """The family is bilingual; tags follow the content's language.
+        Without German examples, the model defaults to English tags on
+        German voice memos -- which then fail to match German search."""
+        prompt = _build_capture_prompt(**COMMON)
+        # At least one German content-specific tag in the examples
+        # (rotates between voice-memo and document scenarios in real use).
+        assert "wäschesack" in prompt or "campingurlaub" in prompt
+
+    def test_retrieval_test_framing_in_rules(self):
+        """The rules block frames 'is this a good tag' as the retrieval
+        test: would the user type this six months from now? Keeping
+        that framing anchors the model to user intent over tidiness."""
+        prompt = _build_capture_prompt(**COMMON)
+        assert "six months from now" in prompt

--- a/tests/stacklets/test_reply_presenter.py
+++ b/tests/stacklets/test_reply_presenter.py
@@ -194,3 +194,48 @@ class TestRenderCaptureReply:
             _en, source_title_hint="x", classification={}, link="(pasted text)",
         )
         assert out.rstrip().endswith("(pasted text)")
+
+    def test_transcript_renders_block_quoted_above_title(self):
+        """Voice captures echo the transcript so the sender can spot a
+        mistranscription without opening the vault. It goes above the
+        title so it's the first thing they read."""
+        transcript = "Reminder: book Bart's prescription before Friday"
+        out = render_capture_reply(
+            _en, source_title_hint=None,
+            classification={"title": "Bart prescription pickup"},
+            link="mxc://server/abc",
+            transcript=transcript,
+        )
+        # The "What I heard" header signals these are the spoken words.
+        assert "What I heard" in out
+        # Block-quoted (single line memo -> one '> ' line).
+        assert f"> {transcript}" in out
+        # Transcript appears BEFORE the title line.
+        assert out.index(transcript) < out.index("Captured")
+
+    def test_transcript_multiline_keeps_each_line_quoted(self):
+        """Element renders consecutive '> ' lines as one quote block;
+        each transcript line gets its own '> ' prefix so a 3-sentence
+        memo stays visually a single quote."""
+        transcript = "First sentence.\nSecond sentence.\nThird sentence."
+        out = render_capture_reply(
+            _en, source_title_hint=None,
+            classification={"title": "Multi-sentence memo"},
+            link="mxc://server/abc",
+            transcript=transcript,
+        )
+        assert "> First sentence." in out
+        assert "> Second sentence." in out
+        assert "> Third sentence." in out
+
+    def test_no_transcript_omits_header(self):
+        """The transcript block is gated on the kwarg -- a URL/PDF capture
+        doesn't get a spurious 'What I heard' header."""
+        out = render_capture_reply(
+            _en, source_title_hint="Reddit thread",
+            classification={"title": "x"},
+            link="https://reddit.com/x",
+            transcript=None,
+        )
+        assert "What I heard" not in out
+        assert "> " not in out

--- a/tests/stacklets/test_scribe.py
+++ b/tests/stacklets/test_scribe.py
@@ -153,6 +153,57 @@ async def test_failed_download_sends_nothing(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_no_whisper_url_does_not_crash_construction(tmp_path, monkeypatch):
+    """WHISPER_URL missing -> the bot still constructs, sets transcriber=None,
+    and logs a warning. The family server should boot scribe even when AI
+    hasn't been installed yet."""
+    monkeypatch.delenv("WHISPER_URL", raising=False)
+    bot = ScribeBot(
+        homeserver="http://x", user_id="@scribe-bot:server",
+        password="x", session_dir=str(tmp_path),
+    )
+    assert bot._transcriber is None
+
+
+@pytest.mark.asyncio
+async def test_voice_no_op_when_transcriber_disabled(tmp_path, monkeypatch):
+    """Without a transcriber the bot silently ignores audio: no typing
+    indicator, no apology reply, no download. The warning at startup is
+    the one and only signal."""
+    monkeypatch.delenv("WHISPER_URL", raising=False)
+    bot = ScribeBot(
+        homeserver="http://x", user_id="@scribe-bot:server",
+        password="x", session_dir=str(tmp_path),
+    )
+    bot._client = _FakeClient()
+    assert bot._transcriber is None
+
+    calls = {"download": [], "send": [], "typing": []}
+
+    async def fake_download(mxc):
+        calls["download"].append(mxc)
+        return b"audio-bytes"
+
+    async def fake_send(room_id, text, reply_to=None, *, metadata=None):
+        calls["send"].append(text)
+
+    async def fake_typing(room_id, on=True):
+        calls["typing"].append((room_id, on))
+
+    bot._download_media = fake_download
+    bot._send = fake_send
+    bot._set_typing = fake_typing
+
+    event = SimpleNamespace(
+        sender="@homer:server", url="mxc://server/abc",
+        event_id="$v:server", body="voice.ogg",
+    )
+    await bot._on_voice(SimpleNamespace(room_id="!r:server"), event)
+
+    assert calls == {"download": [], "send": [], "typing": []}
+
+
+@pytest.mark.asyncio
 async def test_transcriber_error_falls_back_to_apology(tmp_path, monkeypatch):
     """If whisper is down (Transcriber raises LLMError) the bot tells the
     sender it couldn't do it — silent failure leaves people wondering."""

--- a/tests/stacklets/test_scribe.py
+++ b/tests/stacklets/test_scribe.py
@@ -5,6 +5,10 @@ built `room_send` directly. After the transport consolidation it goes
 through the framework: `_download_media` (authenticated endpoint),
 `_set_typing`, and `_send` (formatted, threaded). These pin that the
 handler drives the framework methods rather than the raw client.
+
+The transcription HTTP call is delegated to the shared `Transcriber`
+capability on the AI client; these tests inject a stub Transcriber so
+the bot's wiring is exercised without a whisper server.
 """
 
 from __future__ import annotations
@@ -18,8 +22,11 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "core" / "bot-runner"))
 sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "messages" / "bot"))
+# `lib/` hosts `stack.ai.client`, which the bot now imports at module load.
+sys.path.insert(0, str(_REPO_ROOT / "lib"))
 
 from scribe import ScribeBot  # noqa: E402
+from stack.ai.client import LLMUnavailableError  # noqa: E402
 
 
 class _FakeClient:
@@ -44,12 +51,34 @@ class _FakeClient:
         return SimpleNamespace(body=b"")
 
 
-def _build(tmp_path):
+class _StubTranscriber:
+    """Stand-in for `stack.ai.client.Transcriber` — records calls and
+    returns a configured transcript (or raises a configured error)."""
+
+    def __init__(self, result: str = "hello world", error: Exception | None = None):
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[bytes, str]] = []
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
+                         model: str | None = None) -> str:
+        self.calls.append((audio, filename))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _build(tmp_path, monkeypatch, *, transcriber: _StubTranscriber | None = None):
+    # Transcriber.from_env reads WHISPER_URL at construction; we don't
+    # care what URL the stub is "pointed at", but the constructor refuses
+    # an empty value, so pin a benign placeholder.
+    monkeypatch.setenv("WHISPER_URL", "http://test.local/v1")
     bot = ScribeBot(
         homeserver="http://x", user_id="@scribe-bot:server",
         password="x", session_dir=str(tmp_path),
     )
     bot._client = _FakeClient()
+    bot._transcriber = transcriber or _StubTranscriber()
     return bot
 
 
@@ -58,7 +87,7 @@ async def test_voice_routes_through_framework(tmp_path, monkeypatch):
     """A voice message is downloaded via `_download_media`, transcribed,
     and posted via `_send` threaded to the voice event; typing toggles
     via `_set_typing`."""
-    bot = _build(tmp_path)
+    bot = _build(tmp_path, monkeypatch)
 
     calls = {"download": [], "send": [], "typing": []}
 
@@ -76,11 +105,6 @@ async def test_voice_routes_through_framework(tmp_path, monkeypatch):
     bot._send = fake_send
     bot._set_typing = fake_typing
 
-    import scribe
-    async def fake_transcribe(url, audio, filename):
-        return "hello world"
-    monkeypatch.setattr(scribe, "_transcribe", fake_transcribe)
-
     event = SimpleNamespace(
         sender="@homer:server", url="mxc://server/abc123",
         event_id="$v:server", body="voice.ogg",
@@ -88,6 +112,8 @@ async def test_voice_routes_through_framework(tmp_path, monkeypatch):
     await bot._on_voice(SimpleNamespace(room_id="!r:server"), event)
 
     assert calls["download"] == ["mxc://server/abc123"]
+    # The Transcriber got the downloaded bytes and the caption filename.
+    assert bot._transcriber.calls == [(b"audio-bytes", "voice.ogg")]
     assert len(calls["send"]) == 1
     room_id, text, reply_to = calls["send"][0]
     assert room_id == "!r:server"
@@ -98,9 +124,9 @@ async def test_voice_routes_through_framework(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_failed_download_sends_nothing(tmp_path):
+async def test_failed_download_sends_nothing(tmp_path, monkeypatch):
     """When media can't be downloaded, scribe bails without posting."""
-    bot = _build(tmp_path)
+    bot = _build(tmp_path, monkeypatch)
     sent = []
 
     async def fake_download(mxc):
@@ -122,3 +148,36 @@ async def test_failed_download_sends_nothing(tmp_path):
     )
     await bot._on_voice(SimpleNamespace(room_id="!r:server"), event)
     assert sent == []
+    # The Transcriber must not be called when there's nothing to transcribe.
+    assert bot._transcriber.calls == []
+
+
+@pytest.mark.asyncio
+async def test_transcriber_error_falls_back_to_apology(tmp_path, monkeypatch):
+    """If whisper is down (Transcriber raises LLMError) the bot tells the
+    sender it couldn't do it — silent failure leaves people wondering."""
+    failing = _StubTranscriber(error=LLMUnavailableError("whisper offline"))
+    bot = _build(tmp_path, monkeypatch, transcriber=failing)
+    sent: list[str] = []
+
+    async def fake_download(mxc):
+        return b"audio-bytes"
+
+    async def fake_send(room_id, text, reply_to=None, *, metadata=None):
+        sent.append(text)
+
+    async def fake_typing(room_id, on=True):
+        pass
+
+    bot._download_media = fake_download
+    bot._send = fake_send
+    bot._set_typing = fake_typing
+
+    event = SimpleNamespace(
+        sender="@homer:server", url="mxc://server/abc",
+        event_id="$v:server", body="voice.ogg",
+    )
+    await bot._on_voice(SimpleNamespace(room_id="!r:server"), event)
+
+    assert len(sent) == 1
+    assert "couldn't transcribe" in sent[0].lower()

--- a/tests/stacklets/test_scribe.py
+++ b/tests/stacklets/test_scribe.py
@@ -61,8 +61,12 @@ class _StubTranscriber:
         self.calls: list[tuple[bytes, str]] = []
 
     async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg",
-                         model: str | None = None) -> str:
-        self.calls.append((audio, filename))
+                         model: str | None = None,
+                         cleanup_with=None) -> str:
+        self.calls.append({
+            "audio": audio, "filename": filename,
+            "cleanup_with": cleanup_with,
+        })
         if self.error is not None:
             raise self.error
         return self.result
@@ -113,7 +117,12 @@ async def test_voice_routes_through_framework(tmp_path, monkeypatch):
 
     assert calls["download"] == ["mxc://server/abc123"]
     # The Transcriber got the downloaded bytes and the caption filename.
-    assert bot._transcriber.calls == [(b"audio-bytes", "voice.ogg")]
+    assert len(bot._transcriber.calls) == 1
+    assert bot._transcriber.calls[0]["audio"] == b"audio-bytes"
+    assert bot._transcriber.calls[0]["filename"] == "voice.ogg"
+    # The bot built no LLM (no OPENAI_URL in the test env), so cleanup
+    # is skipped: cleanup_with comes through as None.
+    assert bot._transcriber.calls[0]["cleanup_with"] is None
     assert len(calls["send"]) == 1
     room_id, text, reply_to = calls["send"][0]
     assert room_id == "!r:server"
@@ -150,6 +159,48 @@ async def test_failed_download_sends_nothing(tmp_path, monkeypatch):
     assert sent == []
     # The Transcriber must not be called when there's nothing to transcribe.
     assert bot._transcriber.calls == []
+
+
+@pytest.mark.asyncio
+async def test_llm_threaded_into_transcribe_when_configured(tmp_path, monkeypatch):
+    """When OPENAI_URL is set, scribe builds an LLM and passes it as
+    cleanup_with so whisper's raw output gets polished. The LLM itself
+    isn't called in this test -- we use a stub transcriber that just
+    records what kwarg it received."""
+    monkeypatch.setenv("WHISPER_URL", "http://test.local/v1")
+    monkeypatch.setenv("OPENAI_URL", "http://test.local/v1")
+    bot = ScribeBot(
+        homeserver="http://x", user_id="@scribe-bot:server",
+        password="x", session_dir=str(tmp_path),
+    )
+    bot._client = _FakeClient()
+    assert bot._llm is not None, "scribe should construct an LLM when OPENAI_URL is set"
+
+    stub = _StubTranscriber(result="Cleaned text.")
+    bot._transcriber = stub
+
+    async def fake_download(mxc):
+        return b"audio-bytes"
+
+    async def fake_send(room_id, text, reply_to=None, *, metadata=None):
+        pass
+
+    async def fake_typing(room_id, on=True):
+        pass
+
+    bot._download_media = fake_download
+    bot._send = fake_send
+    bot._set_typing = fake_typing
+
+    event = SimpleNamespace(
+        sender="@homer:server", url="mxc://server/abc",
+        event_id="$v:server", body="voice.ogg",
+    )
+    await bot._on_voice(SimpleNamespace(room_id="!r:server"), event)
+
+    # The bot's own LLM instance came through as cleanup_with -- not a
+    # different one, not None.
+    assert stub.calls[0]["cleanup_with"] is bot._llm
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
 - The archivist now files voice memos. Send a voice message to its room and the transcript lands in the sender's vault as a searchable note, classified and tagged like any other
      capture.
      - The reply quotes the transcript back to the sender in a block quote so a bad transcription is visible from the chat without opening the vault.
      - An LLM cleanup pass polishes raw whisper output: punctuation, capitalization, sentence breaks. The prompt forbids content changes; on any LLM hiccup the bot ships the raw
      transcript instead of failing.
      - Scribe was refactored onto the same Transcriber capability the archivist now uses. Both bots degrade gracefully: missing WHISPER_URL silently disables voice handling, missing
      OPENAI_URL disables only the cleanup polish.