### PR TITLE
fix(photos): add network alias so Immich server can reach ML

### DIFF
--- a/stacklets/photos/docker-compose.yml
+++ b/stacklets/photos/docker-compose.yml
@@ -42,7 +42,9 @@ services:
     # Metal is not yet supported in the Docker image. Still fast enough for
     # face recognition and CLIP search on M-series chips.
     networks:
-      - stack
+      stack:
+        aliases:
+          - immich-machine-learning
     volumes:
       - model-cache:/cache
     env_file:


### PR DESCRIPTION
Immich defaults to http://immich-machine-learning:3003 but the container is named stack-photos-ml. Without the alias, all ML jobs (CLIP, OCR, face detection) fail silently.