### PR TITLE
fix(ai): install the local AI engine on current Homebrew

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -406,13 +406,21 @@ Local AI engine. Powers document classification, voice transcription, and text-t
 First-run setup takes 10 to 20 minutes:
 
 1. Asks managed oMLX (default, recommended) or external OpenAI-compatible endpoint.
-2. Installs oMLX via Homebrew.
+2. Taps and trusts the `jundot/omlx` Homebrew tap, then installs oMLX (see below).
 3. Installs `cmake` and `ffmpeg` if missing.
 4. Clones and builds whisper.cpp with Metal support (1 to 2 minutes of compilation).
 5. Downloads the Whisper large-v3-turbo model (1.5 GB).
 6. Downloads the LLM picked for your RAM tier (2.5 to 25 GB).
 7. Starts oMLX as a Homebrew service, Whisper as a launchd service.
 8. Brings up the Piper TTS container.
+
+**About the Homebrew tap.** oMLX is not in Homebrew's own repositories, it is published through the `jundot/omlx` tap. Homebrew 6 refuses to run formulas from outside taps until you trust them, so `stack up ai` trusts this one for you and says so while it does it. That is a real widening of what Homebrew will execute on your Mac, which is why it is called out rather than buried in the install log. To take it back:
+
+```bash
+brew untrust jundot/omlx
+```
+
+Trusted taps are recorded in `~/.homebrew/trust.json` (or under `$XDG_CONFIG_HOME/homebrew/` if you set it). On Homebrew 5 and older there is no trust gate and the step is skipped.
 
 Why native instead of Docker? Metal GPU acceleration does not pass through Docker on macOS cleanly. Roughly 10x performance difference. Docker for orchestrated services, native for the GPU work.
 

--- a/stacklets/ai/hooks/on_install.py
+++ b/stacklets/ai/hooks/on_install.py
@@ -16,10 +16,16 @@ import shutil
 import time
 from pathlib import Path
 
-from stack.prompt import section, dim, done, warn
+from stack.prompt import section, dim, done, out, warn
 
 
 OMLX_PORT = 42060
+# Where oMLX is published. Homebrew 6 refuses to load a formula from a
+# third-party tap until that tap is trusted, so the trust step in
+# `_install_omlx_formula` is what stands between a working `stack up ai`
+# and an install that dies at the first brew command.
+OMLX_TAP = "jundot/omlx"
+OMLX_TAP_URL = "https://github.com/jundot/omlx"
 WHISPER_MODEL = "ggml-large-v3-turbo.bin"
 WHISPER_MODEL_URL = f"https://huggingface.co/ggerganov/whisper.cpp/resolve/main/{WHISPER_MODEL}"
 WHISPER_PORT = 42062
@@ -51,6 +57,41 @@ def run(ctx):
     section("Setup complete")
 
 
+def _install_omlx_formula(ctx) -> None:
+    """Tap, trust, and install oMLX, saying out loud what is being trusted.
+
+    Homebrew 6 will not load a formula from a tap outside its own
+    repositories until that tap has been trusted, and the refusal is
+    fatal: `brew install` exits non-zero, `on_install` fails, and the AI
+    stacklet cannot be set up at all. So the trust is not an optimisation,
+    it is the install. That makes it exactly the kind of thing to say out
+    loud rather than slip past the user inside a compound shell command:
+    we are widening what Homebrew will execute on their machine, and they
+    should be able to see it happen and undo it.
+
+    Split into three steps for the same reason the one-liner was a
+    problem: chained with `&&`, a failure anywhere reported the whole
+    string, so the trust refusal looked like a tap failure.
+
+    `brew trust` arrived in Homebrew 6. On older versions there is no gate
+    to clear, so a missing subcommand means the job is already done.
+    """
+    ctx.step("Installing oMLX via Homebrew...")
+    ctx.shell_live(f"brew tap {OMLX_TAP} {OMLX_TAP_URL}")
+
+    out(f"Trusting the {OMLX_TAP} Homebrew tap")
+    dim("  Homebrew asks before running formulas from outside its own")
+    dim("  repositories. This one publishes oMLX, the engine that runs")
+    dim("  language models on your Mac's GPU.")
+    dim(f"  To undo later: brew untrust {OMLX_TAP}")
+    try:
+        ctx.shell(f"brew trust {OMLX_TAP}")
+    except RuntimeError:
+        dim("  (this Homebrew has no trust gate — nothing to do)")
+
+    ctx.shell_live("brew install omlx --with-grammar")
+
+
 def _install_omlx(ctx, state_dir: Path):
     section("oMLX", "MLX inference (Metal GPU)")
 
@@ -72,8 +113,7 @@ def _install_omlx(ctx, state_dir: Path):
         ctx.shell("brew list omlx")
         done("oMLX already installed")
     except RuntimeError:
-        ctx.step("Installing oMLX via Homebrew...")
-        ctx.shell_live("brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx --with-grammar")
+        _install_omlx_formula(ctx)
         done("oMLX installed")
 
     # Configure: port 42060, shared models directory

--- a/tests/stacklets/test_ai_omlx_install.py
+++ b/tests/stacklets/test_ai_omlx_install.py
@@ -12,14 +12,25 @@ an older Homebrew with no trust gate still reaches the install.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "lib"))
-sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "ai" / "hooks"))
 
-from on_install import OMLX_TAP, _install_omlx_formula  # noqa: E402
+# Every stacklet has a hook module named `on_install`, so a plain
+# `import on_install` after a sys.path insert resolves to whichever test
+# ran first and cached it in sys.modules -- the ai hook would shadow the
+# backup one for the rest of the session. Load this one from its path
+# under its own name so the tests stay order-independent.
+_HOOK_PATH = _REPO_ROOT / "stacklets" / "ai" / "hooks" / "on_install.py"
+_spec = importlib.util.spec_from_file_location("ai_hooks_on_install", _HOOK_PATH)
+_ai_on_install = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ai_on_install)
+
+OMLX_TAP = _ai_on_install.OMLX_TAP
+_install_omlx_formula = _ai_on_install._install_omlx_formula
 
 
 class FakeCtx:

--- a/tests/stacklets/test_ai_omlx_install.py
+++ b/tests/stacklets/test_ai_omlx_install.py
@@ -1,0 +1,97 @@
+"""Installing oMLX: the Homebrew steps `stack up ai` runs on first boot.
+
+Homebrew 6 refuses to load a formula from a tap outside its own
+repositories until that tap is trusted. famstack publishes oMLX through
+one, so without an explicit trust step `brew install` exits non-zero,
+`on_install` fails, and the AI stacklet cannot be set up at all -- on
+any machine with a current Homebrew, for every new user.
+
+These pin the shape of that install: what runs, in what order, and that
+an older Homebrew with no trust gate still reaches the install.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "lib"))
+sys.path.insert(0, str(_REPO_ROOT / "stacklets" / "ai" / "hooks"))
+
+from on_install import OMLX_TAP, _install_omlx_formula  # noqa: E402
+
+
+class FakeCtx:
+    """Records the shell commands a hook issues.
+
+    `no_trust_subcommand` reproduces a pre-6 Homebrew, where `brew trust`
+    does not exist and ctx.shell raises.
+    """
+
+    def __init__(self, *, no_trust_subcommand: bool = False):
+        self.commands: list[str] = []
+        self.steps: list[str] = []
+        self._no_trust = no_trust_subcommand
+
+    def step(self, msg):
+        self.steps.append(msg)
+
+    def shell(self, cmd):
+        self.commands.append(cmd)
+        if self._no_trust and cmd.startswith("brew trust"):
+            raise RuntimeError("Unknown command: trust")
+        return ""
+
+    def shell_live(self, cmd):
+        self.commands.append(cmd)
+        return ""
+
+
+class TestOmlxInstallSteps:
+
+    def test_the_tap_is_trusted_before_the_install_runs(self):
+        """The whole point: an untrusted tap makes `brew install` fail."""
+        ctx = FakeCtx()
+        _install_omlx_formula(ctx)
+
+        joined = " | ".join(ctx.commands)
+        assert f"brew trust {OMLX_TAP}" in joined, "the trust step must run"
+
+        trust_at = next(i for i, c in enumerate(ctx.commands)
+                        if c.startswith("brew trust"))
+        install_at = next(i for i, c in enumerate(ctx.commands)
+                          if c.startswith("brew install omlx"))
+        assert trust_at < install_at, "trusting after installing is too late"
+
+    def test_the_tap_is_added_before_it_is_trusted(self):
+        ctx = FakeCtx()
+        _install_omlx_formula(ctx)
+
+        tap_at = next(i for i, c in enumerate(ctx.commands)
+                      if c.startswith("brew tap"))
+        trust_at = next(i for i, c in enumerate(ctx.commands)
+                        if c.startswith("brew trust"))
+        assert tap_at < trust_at
+
+    def test_grammar_is_requested_so_json_mode_works(self):
+        # Structured classification needs xgrammar; without the flag the
+        # formula installs a build whose JSON mode is broken.
+        ctx = FakeCtx()
+        _install_omlx_formula(ctx)
+        assert any(c == "brew install omlx --with-grammar" for c in ctx.commands)
+
+    def test_steps_are_separate_commands_not_one_chained_string(self):
+        """Chained with `&&`, any failure reported the whole string, so a
+        trust refusal read as a tap failure. Separate commands make the
+        failing step the one that gets named."""
+        ctx = FakeCtx()
+        _install_omlx_formula(ctx)
+        assert not any("&&" in c for c in ctx.commands)
+
+    def test_a_homebrew_without_a_trust_gate_still_installs(self):
+        """`brew trust` arrived in Homebrew 6. On older versions there is
+        nothing to clear, so its absence is success, not a failed install."""
+        ctx = FakeCtx(no_trust_subcommand=True)
+        _install_omlx_formula(ctx)  # must not raise
+        assert any(c.startswith("brew install omlx") for c in ctx.commands)


### PR DESCRIPTION
Homebrew 6 refuses to run formulas from taps outside its own repositories
until they are trusted. oMLX ships through one, so `stack up ai` died at
its first brew command and the AI stacklet could not be installed at all
on an up-to-date Mac.

Setup now taps, trusts and installs as separate steps, and says what it is
trusting and how to undo it.