### PR TITLE
fix(archivist): finish a document whose filing was interrupted

### DIFF
--- a/stacklets/docs/bot/document_pipeline.py
+++ b/stacklets/docs/bot/document_pipeline.py
@@ -35,6 +35,7 @@ from pipeline import (
     ImageAttachment,
     PaperlessDuplicateError,
     enrich_document,
+    extract_bot_summary,
     reformat_document,
 )
 from stack import resolve_model
@@ -208,8 +209,14 @@ class DocumentPipeline:
         try:
             doc_id = await self._paperless.wait_task(task_id)
         except PaperlessDuplicateError as e:
-            return FilingOutcome(
-                status="duplicate", display_name=display_name, duplicate=e,
+            doc_id = await self._unfinished_twin(e)
+            if doc_id is None:
+                return FilingOutcome(
+                    status="duplicate", display_name=display_name, duplicate=e,
+                )
+            logger.info(
+                "[archivist] Resuming unfinished doc #{} from re-upload of {}",
+                doc_id, display_name,
             )
         if not doc_id:
             return FilingOutcome(status="ocr_failed", display_name=display_name)
@@ -301,6 +308,31 @@ class DocumentPipeline:
             llm_error=result.llm_error,
             envelope=envelope,
         )
+
+    async def _unfinished_twin(self, dup: PaperlessDuplicateError) -> int | None:
+        """The existing document a re-upload should finish, if any.
+
+        Paperless rejects a re-upload on content hash, which used to end
+        the story. That made the most common real failure unrecoverable:
+        the upload lands, enrichment dies, and the document sits with no
+        tags, no correspondent and no vault entry. Every retry hit the
+        duplicate wall before reaching enrichment, so the answer was
+        always "already filed" and the document stayed invisible to
+        search forever.
+
+        An archivist summary is the mark of a finished filing (the same
+        marker the note sweep keys on), so a twin without one is work
+        that was interrupted: return its id and let the caller resume on
+        it. A twin that has one is a genuine re-drop of something already
+        filed, and re-running the LLM there would cost minutes on the
+        small machines this stack is built for.
+        """
+        if dup.doc_id is None:
+            return None
+        doc = await self._paperless.get_doc(dup.doc_id)
+        if not doc or extract_bot_summary(doc):
+            return None
+        return dup.doc_id
 
     async def _enrich(
         self, doc, ext, is_image, is_pdf_with_text, is_pdf_ocr_layer,

--- a/tests/stacklets/test_document_pipeline.py
+++ b/tests/stacklets/test_document_pipeline.py
@@ -125,6 +125,76 @@ class TestEarlyExits:
         assert mirror.published[0]["fallback_title"] == "note.txt"
 
 
+class TestResumingAnUnfinishedFiling:
+    """A re-upload finishes a document whose classification never ran.
+
+    Paperless rejects a re-upload on content hash, and that used to end
+    the story. It made the most common real failure unrecoverable: the
+    upload succeeds, enrichment dies (a timeout, a model still loading),
+    and the document sits in Paperless with no tags, no correspondent
+    and no vault entry. Every retry hit the duplicate wall before
+    reaching enrichment, so the answer was always "already filed" and
+    the document stayed unreadable to search forever.
+
+    Re-uploading is how a family member asks for that job to be
+    finished. The pipeline reads the twin: no archivist summary means
+    the work never completed, so it resumes on the existing document
+    rather than stopping.
+    """
+
+    @staticmethod
+    def _summarised(doc_id=42):
+        """A twin the archivist has already finished with."""
+        return {
+            "id": doc_id,
+            "content": "a fully readable document body here",
+            "notes": [{"id": 1, "note": "## Summary\nA gas bill.\n\n<!-- archivist-bot -->"}],
+        }
+
+    @staticmethod
+    def _naked(doc_id=42):
+        """A twin that was filed but never enriched."""
+        return {"id": doc_id, "content": "a fully readable document body here"}
+
+    @pytest.mark.asyncio
+    async def test_reupload_of_an_unenriched_document_resumes_it(self):
+        dup = PaperlessDuplicateError(doc_id=42, title="Existing")
+        mirror = FakeMirror()
+        out = await _process(_pipeline(
+            FakePaperless(duplicate=dup, doc=self._naked()),
+            mirror=mirror, classify_enabled=False,
+        ))
+
+        assert out.status != "duplicate", "a naked twin must not dead-end"
+        assert out.doc_id == 42, "resumes the existing document, no second copy"
+        assert len(mirror.published) == 1, "the missing vault entry now exists"
+
+    @pytest.mark.asyncio
+    async def test_reupload_of_a_finished_document_is_still_a_duplicate(self):
+        # An accidental re-drop of something already filed. Reporting the
+        # twin is the whole job; re-running the LLM would cost minutes on
+        # the small machines this stack is built for.
+        dup = PaperlessDuplicateError(doc_id=42, title="Existing")
+        mirror = FakeMirror()
+        out = await _process(_pipeline(
+            FakePaperless(duplicate=dup, doc=self._summarised()), mirror=mirror,
+        ))
+
+        assert out.status == "duplicate"
+        assert out.duplicate is dup
+        assert mirror.published == [], "no work redone for a finished document"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_of_a_deleted_twin_is_still_a_duplicate(self):
+        # Paperless named a twin that is no longer there. Nothing to
+        # resume, so the honest answer remains the duplicate report.
+        dup = PaperlessDuplicateError(doc_id=42, title="Existing")
+        out = await _process(_pipeline(
+            FakePaperless(duplicate=dup, doc=None), mirror=FakeMirror(),
+        ))
+        assert out.status == "duplicate"
+
+
 class TestReprocess:
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Re-uploading a document whose classification timed out answered "already
filed" and stopped, leaving it in Paperless with no tags, no summary and
nothing in the wiki. Search could tell you it existed but knew nothing
about it, and chat offered no way to fix that.

A re-upload now resumes the unfinished document instead of bouncing off
Paperless duplicate detection. One that was already filed properly still
reports as a duplicate, so nothing is redone.