### PR TITLE
chore: v0.3.0-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The reference implementation runs on a Mac Studio M1 in our living room at Lake 
 <br>
 
 > [!NOTE]
-> [**v0.3.0-beta.2**](https://github.com/famstack-dev/famstack/releases/tag/v0.3.0-beta.2) is the current Beta.
+> [**v0.3.0-beta.3**](https://github.com/famstack-dev/famstack/releases/tag/v0.3.0-beta.3) is the current Beta.
 >
 > The state of this project is: **It works on my machine.™**
 > I gave my best it works on yours too. If it doesn't, come back and report it

--- a/lib/stack/cli.py
+++ b/lib/stack/cli.py
@@ -194,7 +194,7 @@ def _notify_up(stck, result):
             lines.append(f"- {hint}")
         _notify(stck, "\n".join(lines))
 
-VERSION = "0.3.0-beta.2"
+VERSION = "0.3.0-beta.3"
 
 
 # ── Stack + Docker orchestration ──────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "famstack"
-version = "0.3.0b2"
+version = "0.3.0b3"
 description = "Self-hosted family server stack for Apple Silicon"
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "famstack"
-version = "0.3.0b2"
+version = "0.3.0b3"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Version bump across the three files the release check now covers.

What the release carries: documents that timed out mid-filing now finish,
the AI stacklet installs on current Homebrew again, and starting it says
what it is doing instead of failing quietly.