### PR TITLE
fix(agent): stop the agent looping on tools forever

### DIFF
--- a/stacklets/agent/config.json
+++ b/stacklets/agent/config.json
@@ -13,7 +13,8 @@
   },
   "agents": {
     "defaults": {
-      "model_preset": "primary"
+      "model_preset": "primary",
+      "max_tool_iterations": 12
     }
   },
   "tools": {


### PR DESCRIPTION
Nothing bounded how many tool calls the agent could make answering one
question, so a bad question could keep it working indefinitely while the
family waited. Caps it at 12.

Salvaged from `fix/agent-turn-limits`, which is otherwise already on main
via #70. That branch also set `"streaming": true` for the long-silence
half of the same problem, and a later WIP removed it again, so that half
is deliberately not here.